### PR TITLE
Get use of `attach` for polling driver.

### DIFF
--- a/compio/src/attacher.rs
+++ b/compio/src/attacher.rs
@@ -32,4 +32,20 @@ impl Attacher {
         self.once.get_or_try_init(|| attach(source.as_raw_fd()))?;
         Ok(())
     }
+
+    pub fn is_attached(&self) -> bool {
+        self.once.get().is_some()
+    }
+
+    pub fn try_clone(&self, source: &impl AsRawFd) -> io::Result<Self> {
+        if cfg!(target_os = "windows") {
+            Ok(self.clone())
+        } else {
+            let new_self = Self::new();
+            if self.is_attached() {
+                new_self.attach(source)?;
+            }
+            Ok(new_self)
+        }
+    }
 }

--- a/compio/src/driver/mod.rs
+++ b/compio/src/driver/mod.rs
@@ -114,13 +114,13 @@ impl Proactor {
         })
     }
 
-    /// Attach an fd to the driver.
+    /// Attach an fd to the driver. It will cause unexpected result to attach
+    /// the handle with one driver and push an op to another driver.
     ///
     /// ## Platform specific
     /// * IOCP: it will be attached to the completion port. An fd could only be
     ///   attached to one driver, and could only be attached once, even if you
-    ///   `try_clone` it. It will cause unexpected result to attach the handle
-    ///   with one driver and push an op to another driver.
+    ///   `try_clone` it.
     /// * io-uring: it will do nothing and return `Ok(())`.
     /// * polling: it will initialize inner queue and register to the driver. On
     ///   Linux and Android, if the fd is a normal file or a directory, this

--- a/compio/src/driver/mod.rs
+++ b/compio/src/driver/mod.rs
@@ -122,7 +122,9 @@ impl Proactor {
     ///   `try_clone` it. It will cause unexpected result to attach the handle
     ///   with one driver and push an op to another driver.
     /// * io-uring: it will do nothing and return `Ok(())`.
-    /// * polling: it will initialize inner queue and register to the driver.
+    /// * polling: it will initialize inner queue and register to the driver. On
+    ///   Linux and Android, if the fd is a normal file or a directory, this
+    ///   method will do nothing.
     pub fn attach(&mut self, fd: RawFd) -> io::Result<()> {
         self.driver.attach(fd)
     }

--- a/compio/src/driver/mod.rs
+++ b/compio/src/driver/mod.rs
@@ -121,7 +121,8 @@ impl Proactor {
     ///   attached to one driver, and could only be attached once, even if you
     ///   `try_clone` it. It will cause unexpected result to attach the handle
     ///   with one driver and push an op to another driver.
-    /// * io-uring/polling: it will do nothing and return `Ok(())`.
+    /// * io-uring: it will do nothing and return `Ok(())`.
+    /// * polling: it will initialize inner queue and register to the driver.
     pub fn attach(&mut self, fd: RawFd) -> io::Result<()> {
         self.driver.attach(fd)
     }

--- a/compio/src/driver/poll/mod.rs
+++ b/compio/src/driver/poll/mod.rs
@@ -112,7 +112,7 @@ impl FdQueue {
                 return (user_data, Interest::Writable);
             }
         }
-        unreachable!("should receive event when no interest")
+        unreachable!("should not receive event when no interest")
     }
 }
 
@@ -145,18 +145,16 @@ impl Driver {
         if self.cancelled.remove(&user_data) {
             Ok(false)
         } else {
-            let need_add = !self.registry.contains_key(&arg.fd);
-            let queue = self.registry.entry(arg.fd).or_default();
+            let queue = self
+                .registry
+                .get_mut(&arg.fd)
+                .expect("the fd should be attached");
             queue.push_back_interest(user_data, arg.interest);
             // We use fd as the key.
             let event = queue.event(arg.fd as usize);
             unsafe {
-                if need_add {
-                    self.poll.add(arg.fd, event)?;
-                } else {
-                    let fd = BorrowedFd::borrow_raw(arg.fd);
-                    self.poll.modify(fd, event)?;
-                }
+                let fd = BorrowedFd::borrow_raw(arg.fd);
+                self.poll.modify(fd, event)?;
             }
             Ok(true)
         }
@@ -239,7 +237,11 @@ impl Driver {
         Ok(())
     }
 
-    pub fn attach(&mut self, _fd: RawFd) -> io::Result<()> {
+    pub fn attach(&mut self, fd: RawFd) -> io::Result<()> {
+        self.registry.entry(fd).or_default();
+        unsafe {
+            self.poll.add(fd, Event::none(0))?;
+        }
         Ok(())
     }
 

--- a/compio/src/driver/poll/op.rs
+++ b/compio/src/driver/poll/op.rs
@@ -18,11 +18,7 @@ use crate::{
 
 impl<T: IoBufMut> OpCode for ReadAt<T> {
     fn pre_submit(mut self: Pin<&mut Self>) -> io::Result<Decision> {
-        if cfg!(any(
-            target_os = "linux",
-            target_os = "android",
-            target_os = "illumos"
-        )) {
+        if cfg!(any(target_os = "linux", target_os = "android")) {
             let fd = self.fd;
             let slice = self.buffer.as_uninit_slice();
             Ok(Decision::Completed(syscall!(pread(
@@ -55,11 +51,7 @@ impl<T: IoBufMut> OpCode for ReadAt<T> {
 
 impl<T: IoBuf> OpCode for WriteAt<T> {
     fn pre_submit(self: Pin<&mut Self>) -> io::Result<Decision> {
-        if cfg!(any(
-            target_os = "linux",
-            target_os = "android",
-            target_os = "illumos"
-        )) {
+        if cfg!(any(target_os = "linux", target_os = "android")) {
             let slice = self.buffer.as_slice();
             Ok(Decision::Completed(syscall!(pwrite(
                 self.fd,

--- a/compio/src/event/eventfd.rs
+++ b/compio/src/event/eventfd.rs
@@ -20,7 +20,10 @@ impl Event {
     pub fn new() -> io::Result<Self> {
         let fd = syscall!(eventfd(0, 0))?;
         let fd = unsafe { OwnedFd::from_raw_fd(fd) };
-        Ok(Self { fd })
+        Ok(Self {
+            fd,
+            attacher: Attacher::new(),
+        })
     }
 
     /// Get a notify handle.

--- a/compio/src/fs/file.rs
+++ b/compio/src/fs/file.rs
@@ -47,11 +47,7 @@ fn file_with_options(
     use std::os::unix::prelude::OpenOptionsExt;
 
     // Don't set nonblocking with epoll.
-    if cfg!(not(any(
-        target_os = "linux",
-        target_os = "android",
-        target_os = "illumos"
-    ))) {
+    if cfg!(not(any(target_os = "linux", target_os = "android"))) {
         options.custom_flags(libc::O_NONBLOCK);
     }
     options.open(path)
@@ -265,11 +261,10 @@ impl File {
         let mut total_written = 0;
         let mut written;
         while total_written < buf_len {
-            (written, buffer) = buf_try!(
-                self.write_at(buffer.slice(total_written..), pos + total_written)
-                    .await
-                    .into_inner()
-            );
+            (written, buffer) = buf_try!(self
+                .write_at(buffer.slice(total_written..), pos + total_written)
+                .await
+                .into_inner());
             total_written += written;
         }
         (Ok(total_written), buffer)

--- a/compio/src/fs/file.rs
+++ b/compio/src/fs/file.rs
@@ -98,10 +98,11 @@ impl File {
     ///
     /// It does not clear the attach state.
     pub fn try_clone(&self) -> io::Result<Self> {
+        let inner = self.inner.try_clone()?;
         Ok(Self {
-            inner: self.inner.try_clone()?,
             #[cfg(feature = "runtime")]
-            attacher: self.attacher.clone(),
+            attacher: self.attacher.try_clone(&inner)?,
+            inner,
         })
     }
 

--- a/compio/src/net/socket.rs
+++ b/compio/src/net/socket.rs
@@ -37,10 +37,11 @@ impl Socket {
     }
 
     pub fn try_clone(&self) -> io::Result<Self> {
+        let socket = self.socket.try_clone()?;
         Ok(Self {
-            socket: self.socket.try_clone()?,
             #[cfg(feature = "runtime")]
-            attacher: self.attacher.clone(),
+            attacher: self.attacher.try_clone(&socket)?,
+            socket,
         })
     }
 


### PR DESCRIPTION
Also unify the behavior of the `try_clone` method.