### PR TITLE
Use SetFileCompletionNotificationModes when attaching.

### DIFF
--- a/compio-driver/Cargo.toml
+++ b/compio-driver/Cargo.toml
@@ -48,6 +48,7 @@ windows-sys = { version = "0.48", features = [
     "Win32_System_IO",
     "Win32_System_Pipes",
     "Win32_System_Threading",
+    "Win32_System_WindowsProgramming",
 ] }
 
 # Linux specific dependencies

--- a/compio-driver/src/iocp/mod.rs
+++ b/compio-driver/src/iocp/mod.rs
@@ -19,8 +19,10 @@ use windows_sys::Win32::{
         RtlNtStatusToDosError, ERROR_HANDLE_EOF, ERROR_IO_INCOMPLETE, ERROR_NO_DATA,
         ERROR_OPERATION_ABORTED, INVALID_HANDLE_VALUE, NTSTATUS, STATUS_PENDING, STATUS_SUCCESS,
     },
+    Storage::FileSystem::SetFileCompletionNotificationModes,
     System::{
         Threading::INFINITE,
+        WindowsProgramming::{FILE_SKIP_COMPLETION_PORT_ON_SUCCESS, FILE_SKIP_SET_EVENT_ON_HANDLE},
         IO::{CreateIoCompletionPort, GetQueuedCompletionStatusEx, OVERLAPPED, OVERLAPPED_ENTRY},
     },
 };
@@ -203,6 +205,13 @@ impl Driver {
         syscall!(
             BOOL,
             CreateIoCompletionPort(fd as _, self.port.as_raw_handle() as _, 0, 0)
+        )?;
+        syscall!(
+            BOOL,
+            SetFileCompletionNotificationModes(
+                fd as _,
+                (FILE_SKIP_COMPLETION_PORT_ON_SUCCESS | FILE_SKIP_SET_EVENT_ON_HANDLE) as _
+            )
         )?;
         Ok(())
     }

--- a/compio/tests/file.rs
+++ b/compio/tests/file.rs
@@ -72,7 +72,7 @@ async fn poll_once(future: impl std::future::Future) {
     let mut future = pin!(future);
 
     poll_fn(|cx| {
-        assert!(future.as_mut().poll(cx).is_pending());
+        let _ = future.as_mut().poll(cx);
         Poll::Ready(())
     })
     .await;

--- a/compio/tests/runtime.rs
+++ b/compio/tests/runtime.rs
@@ -183,7 +183,7 @@ async fn poll_once(future: impl std::future::Future) {
     let mut future = pin!(future);
 
     poll_fn(|cx| {
-        assert!(future.as_mut().poll(cx).is_pending());
+        let _ = future.as_mut().poll(cx);
         Poll::Ready(())
     })
     .await;


### PR DESCRIPTION
Some IO methods may success immediately. However, it will also issue a packet to IOCP. Now in #82 we've allowed success immediately in `push`, so it is possible to handle these methods, and disable the packet issue.

We can disable the inner event handle of file object as well. It may improve the performance a little.

## Reference

https://learn.microsoft.com/en-US/troubleshoot/windows/win32/asynchronous-disk-io-synchronous

https://devblogs.microsoft.com/oldnewthing/20190719-00/?p=102722

https://devblogs.microsoft.com/oldnewthing/20200221-00/?p=103466

https://github.com/dotnet/corefx/pull/15141