### PR TITLE
Pop the op later.

### DIFF
--- a/compio-driver/src/iocp/mod.rs
+++ b/compio-driver/src/iocp/mod.rs
@@ -293,8 +293,7 @@ impl<T> Overlapped<T> {
     }
 }
 
-#[doc(hidden)]
-pub struct RawOp(NonNull<Overlapped<dyn OpCode>>);
+pub(crate) struct RawOp(NonNull<Overlapped<dyn OpCode>>);
 
 impl RawOp {
     pub(crate) fn new(user_data: usize, op: impl OpCode + 'static) -> Self {

--- a/compio-driver/src/iour/mod.rs
+++ b/compio-driver/src/iour/mod.rs
@@ -15,8 +15,7 @@ use slab::Slab;
 use crate::Entry;
 
 pub(crate) mod op;
-#[doc(hidden)]
-pub use crate::unix::RawOp;
+pub(crate) use crate::unix::RawOp;
 
 /// Abstraction of io-uring operations.
 pub trait OpCode {

--- a/compio-driver/src/lib.rs
+++ b/compio-driver/src/lib.rs
@@ -253,18 +253,13 @@ impl Operation {
         Self { op, user_data }
     }
 
-    #[doc(hidden)]
-    pub fn into_inner(self) -> RawOp {
-        self.op
-    }
-
     /// Restore the original operation.
     ///
     /// # Safety
     ///
     /// The caller should guarantee that the type is right.
     pub unsafe fn into_op<T: OpCode>(self) -> T {
-        self.into_inner().into_inner()
+        self.op.into_inner()
     }
 
     /// The same user_data when the operation is pushed into the driver.

--- a/compio-driver/src/poll/mod.rs
+++ b/compio-driver/src/poll/mod.rs
@@ -17,8 +17,7 @@ use slab::Slab;
 use crate::{syscall, Entry};
 
 pub(crate) mod op;
-#[doc(hidden)]
-pub use crate::unix::RawOp;
+pub(crate) use crate::unix::RawOp;
 
 /// Abstraction of operations.
 pub trait OpCode {

--- a/compio-driver/src/unix/mod.rs
+++ b/compio-driver/src/unix/mod.rs
@@ -7,8 +7,7 @@ use std::{mem::ManuallyDrop, pin::Pin, ptr::NonNull};
 
 use crate::OpCode;
 
-#[doc(hidden)]
-pub struct RawOp(NonNull<dyn OpCode>);
+pub(crate) struct RawOp(NonNull<dyn OpCode>);
 
 impl RawOp {
     pub(crate) fn new(_user_data: usize, op: impl OpCode + 'static) -> Self {


### PR DESCRIPTION
There could be such case:
```
Proactor::push      0
Proactor::poll      0
Proactor::pop       0
Proactor::push      0 // Because the previous op is popped.
Proactor::poll      0
Proactor::pop       0
Runtime::poll_task  0 // Boom because the second op replaces the first op.
```

This PR fixes this problem, making `poll_task` call `pop`. Therefore the behavior will be:
```
Proactor::push      0
Proactor::poll      0
Proactor::push      1 // Because the previous op is *not* popped.
Proactor::poll      1
Runtime::poll_task  0
Proactor::pop       0
```

This PR also makes `RawOp` totally hidden because the runtime doesn't need to know it.