### PR TITLE
Fix: unable to resolve `compio-runtime` in macros

### DIFF
--- a/compio-macros/src/lib.rs
+++ b/compio-macros/src/lib.rs
@@ -33,7 +33,7 @@ fn retrieve_runtime_mod() -> proc_macro2::TokenStream {
             let ident = Ident::new(&name, Span::call_site());
             quote!(::#ident::runtime)
         }
-        Err(_) => match crate_name("compio_runtime") {
+        Err(_) => match crate_name("compio-runtime") {
             Ok(FoundCrate::Itself) => quote!(crate),
             Ok(FoundCrate::Name(name)) => {
                 let ident = Ident::new(&name, Span::call_site());


### PR DESCRIPTION
`proc_macro_crate::crate_name` takes crate name specified in `Cargo.toml`, which is `compio-runtime` in this case.