### PR TITLE
Add custom `IoSlice`

### DIFF
--- a/compio-buf/Cargo.toml
+++ b/compio-buf/Cargo.toml
@@ -21,7 +21,6 @@ bytes = { version = "1", optional = true }
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
 
-
 [features]
 # Dependencies
 arrayvec = ["dep:arrayvec"]

--- a/compio-buf/Cargo.toml
+++ b/compio-buf/Cargo.toml
@@ -18,6 +18,10 @@ bumpalo = { version = "3", optional = true }
 arrayvec = { version = "0.7", optional = true }
 bytes = { version = "1", optional = true }
 
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"
+
+
 [features]
 # Dependencies
 arrayvec = ["dep:arrayvec"]

--- a/compio-buf/src/io_slice.rs
+++ b/compio-buf/src/io_slice.rs
@@ -53,6 +53,9 @@ mod sys {
     }
 }
 
+#[cfg(not(any(unix, windows)))]
+compile_error!("`IoSlice` only available on unix and windows");
+
 /// An unsafe `'static` slice of bytes to interact with os api.
 ///
 /// Like [`IoSliceMut`] in `std`, `IoSlice` guarantees the ABI compatability

--- a/compio-buf/src/io_slice.rs
+++ b/compio-buf/src/io_slice.rs
@@ -1,0 +1,126 @@
+use std::mem::MaybeUninit;
+
+#[cfg(unix)]
+mod sys {
+    #[repr(transparent)]
+    pub struct Inner(libc::iovec);
+
+    impl Inner {
+        pub fn new(ptr: *mut u8, len: usize) -> Self {
+            Self(libc::iovec {
+                iov_base: ptr as *mut libc::c_void,
+                iov_len: len,
+            })
+        }
+
+        pub fn len(&self) -> usize {
+            self.0.iov_len
+        }
+
+        pub fn as_ptr(&self) -> *mut u8 {
+            self.0.iov_base as *mut u8
+        }
+    }
+}
+
+#[cfg(windows)]
+mod sys {
+    // Copied from std
+    #[repr(C)]
+    struct WSABUF {
+        pub len: u32,
+        pub buf: *mut u8,
+    }
+
+    #[repr(transparent)]
+    pub struct Inner(WSABUF);
+
+    impl Inner {
+        pub fn new(ptr: *mut u8, len: usize) -> Self {
+            Self(WSABUF {
+                len: len as u32,
+                buf: ptr,
+            })
+        }
+
+        pub fn len(&self) -> usize {
+            self.0.len as _
+        }
+
+        pub fn as_ptr(&self) -> *mut u8 {
+            self.0.buf
+        }
+    }
+}
+
+/// An unsafe `'static` slice of bytes to interact with os api.
+///
+/// Like [`IoSliceMut`] in `std`, `IoSlice` guarantees the ABI compatability
+/// on unix and windows, but without the lifetime, makes it easier to use with
+/// compio driver as they need to take ownership (`'static`) of the
+/// buffer. However, this does makes the type unsafe to construct, and should
+/// only be used with compio driver.
+///
+/// [`IoSliceMut`]: std::io::IoSliceMut
+#[repr(transparent)]
+pub struct IoSlice(sys::Inner);
+
+impl IoSlice {
+    /// Create a new `IoSlice` from a raw pointer and a length.
+    ///
+    /// # Safety
+    /// The caller must ensure that:
+    /// - the pointer is valid for the lifetime of the `IoSlice`
+    /// - the length is correct (the content can be uninitialized, but must be
+    ///   accessible)
+    /// - the pointer is not used for anything else while the `IoSlice` is in
+    ///   use
+    pub unsafe fn new(ptr: *mut u8, len: usize) -> Self {
+        Self(sys::Inner::new(ptr, len))
+    }
+
+    /// Create a new `IoSlice` from an initialized slice.
+    ///
+    /// # Safety
+    /// The caller must ensure that:
+    /// - the slice is valid for the lifetime of the `IoSlice`
+    /// - the slice is not used for anything else while the `IoSlice` is in use
+    pub unsafe fn from_slice(slice: &mut [u8]) -> Self {
+        Self::new(slice.as_mut_ptr(), slice.len())
+    }
+
+    /// Create a new `IoSlice` from a uninitialized slice.
+    ///
+    /// # Safety
+    /// The caller must ensure that:
+    /// - the slice is valid for the lifetime of the `IoSlice`
+    /// - the slice is not used for anything else while the `IoSlice` is in use
+    pub unsafe fn from_uninit(slice: &mut [MaybeUninit<u8>]) -> Self {
+        Self::new(slice.as_mut_ptr() as *mut u8, slice.len())
+    }
+
+    /// Break the `IoSlice` into a raw pointer and a length.
+    pub fn into_parts(self) -> (*mut u8, usize) {
+        (self.0.as_ptr(), self.0.len())
+    }
+
+    /// Get the mutable pointer to the buffer.
+    pub fn as_mut_ptr(&self) -> *mut u8 {
+        self.0.as_ptr()
+    }
+
+    /// Get the pointer to the buffer.
+    pub fn as_ptr(&self) -> *const u8 {
+        self.0.as_ptr()
+    }
+
+    /// Get the length of the buffer.
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    /// Check if the buffer is empty.
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}

--- a/compio-buf/src/io_slice.rs
+++ b/compio-buf/src/io_slice.rs
@@ -2,11 +2,13 @@ use std::mem::MaybeUninit;
 
 #[cfg(unix)]
 mod sys {
+    use std::mem::MaybeUninit;
+
     #[repr(transparent)]
     pub struct Inner(libc::iovec);
 
     impl Inner {
-        pub fn new(ptr: *mut u8, len: usize) -> Self {
+        pub fn new(ptr: *mut MaybeUninit<u8>, len: usize) -> Self {
             Self(libc::iovec {
                 iov_base: ptr as *mut libc::c_void,
                 iov_len: len,
@@ -17,26 +19,28 @@ mod sys {
             self.0.iov_len
         }
 
-        pub fn as_ptr(&self) -> *mut u8 {
-            self.0.iov_base as *mut u8
+        pub fn as_ptr(&self) -> *mut MaybeUninit<u8> {
+            self.0.iov_base as *mut MaybeUninit<u8>
         }
     }
 }
 
 #[cfg(windows)]
 mod sys {
+    use std::mem::MaybeUninit;
+
     // Copied from std
     #[repr(C)]
     struct WSABUF {
         pub len: u32,
-        pub buf: *mut u8,
+        pub buf: *mut MaybeUninit<u8>,
     }
 
     #[repr(transparent)]
     pub struct Inner(WSABUF);
 
     impl Inner {
-        pub fn new(ptr: *mut u8, len: usize) -> Self {
+        pub fn new(ptr: *mut MaybeUninit<u8>, len: usize) -> Self {
             Self(WSABUF {
                 len: len as u32,
                 buf: ptr,
@@ -47,7 +51,7 @@ mod sys {
             self.0.len as _
         }
 
-        pub fn as_ptr(&self) -> *mut u8 {
+        pub fn as_ptr(&self) -> *mut MaybeUninit<u8> {
             self.0.buf
         }
     }
@@ -56,15 +60,15 @@ mod sys {
 #[cfg(not(any(unix, windows)))]
 compile_error!("`IoSlice` only available on unix and windows");
 
-/// An unsafe `'static` slice of bytes to interact with os api.
+/// An unsafe, `'static`, initialized, and immutable slice of bytes to interact
+/// with system API.
 ///
-/// Like [`IoSliceMut`] in `std`, `IoSlice` guarantees the ABI compatability
+/// Like [`IoSlice`] in `std`, `IoSlice` guarantees the ABI compatability
 /// on unix and windows, but without the lifetime, makes it easier to use with
-/// compio driver as they need to take ownership (`'static`) of the
-/// buffer. However, this does makes the type unsafe to construct, and should
-/// only be used with compio driver.
+/// compio driver at the cost of unsafe to construct. `IoSlice` should only be
+/// used with compio driver.
 ///
-/// [`IoSliceMut`]: std::io::IoSliceMut
+/// [`IoSlice`]: std::io::IoSlice
 #[repr(transparent)]
 pub struct IoSlice(sys::Inner);
 
@@ -74,46 +78,84 @@ impl IoSlice {
     /// # Safety
     /// The caller must ensure that:
     /// - the pointer is valid for the lifetime of the `IoSlice`
-    /// - the length is correct (the content can be uninitialized, but must be
-    ///   accessible)
-    /// - the pointer is not used for anything else while the `IoSlice` is in
-    ///   use
-    pub unsafe fn new(ptr: *mut u8, len: usize) -> Self {
-        Self(sys::Inner::new(ptr, len))
+    /// - the length is correct
+    /// - the content of the buffer is initialized
+    /// - the pointer is not used for mutating while the `IoSlice` is in use
+    pub unsafe fn new(ptr: *const u8, len: usize) -> Self {
+        Self(sys::Inner::new(ptr as _, len))
     }
 
     /// Create a new `IoSlice` from an initialized slice.
     ///
     /// # Safety
-    /// The caller must ensure that:
-    /// - the slice is valid for the lifetime of the `IoSlice`
-    /// - the slice is not used for anything else while the `IoSlice` is in use
-    pub unsafe fn from_slice(slice: &mut [u8]) -> Self {
-        Self::new(slice.as_mut_ptr(), slice.len())
-    }
-
-    /// Create a new `IoSlice` from a uninitialized slice.
-    ///
-    /// # Safety
-    /// The caller must ensure that:
-    /// - the slice is valid for the lifetime of the `IoSlice`
-    /// - the slice is not used for anything else while the `IoSlice` is in use
-    pub unsafe fn from_uninit(slice: &mut [MaybeUninit<u8>]) -> Self {
-        Self::new(slice.as_mut_ptr() as *mut u8, slice.len())
-    }
-
-    /// Break the `IoSlice` into a raw pointer and a length.
-    pub fn into_parts(self) -> (*mut u8, usize) {
-        (self.0.as_ptr(), self.0.len())
-    }
-
-    /// Get the mutable pointer to the buffer.
-    pub fn as_mut_ptr(&self) -> *mut u8 {
-        self.0.as_ptr()
+    /// The caller must ensure that, during the lifetime of the `IoSlice`, the
+    /// slice is valid the and is not used for mutating.
+    pub unsafe fn from_slice(slice: &[u8]) -> Self {
+        Self::new(slice.as_ptr() as _, slice.len())
     }
 
     /// Get the pointer to the buffer.
-    pub fn as_ptr(&self) -> *const u8 {
+    pub fn as_ptr(&self) -> *const MaybeUninit<u8> {
+        self.0.as_ptr()
+    }
+
+    /// Get the length of the buffer.
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    /// Check if the buffer is empty.
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
+
+/// An unsafe, `'static`, maybe uninitialized, and mutable slice of bytes to
+/// interact with system API.
+///
+/// Like [`IoSliceMut`] in `std`, `IoSliceMut` guarantees the ABI compatability
+/// on unix and windows, but without the lifetime and accepts
+/// [`MaybeUninit<u8>`], makes it easier to use with compio driver at the cost
+/// of unsafe to construct. `IoSliceMut` should only be used with compio driver.
+///
+/// [`IoSliceMut`]: std::io::IoSliceMut
+#[repr(transparent)]
+pub struct IoSliceMut(sys::Inner);
+
+impl IoSliceMut {
+    /// Create a new `IoSliceMut` from a raw pointer and a length.
+    ///
+    /// # Safety
+    /// The caller must ensure that:
+    /// - the pointer is valid for the lifetime of the `IoSliceMut`
+    /// - the length is correct (the content can be uninitialized, but must be
+    ///   accessible)
+    /// - the pointer is not used for anything else while the `IoSliceMut` is in
+    ///   use
+    pub unsafe fn new(ptr: *mut MaybeUninit<u8>, len: usize) -> Self {
+        Self(sys::Inner::new(ptr, len))
+    }
+
+    /// Create a new `IoSliceMut` from an initialized slice.
+    ///
+    /// # Safety
+    /// The caller must ensure that, during the lifetime of the `IoSliceMut`,
+    /// the slice is valid the and is not used for anything else.
+    pub unsafe fn from_slice(slice: &mut [u8]) -> Self {
+        Self::new(slice.as_mut_ptr() as _, slice.len())
+    }
+
+    /// Create a new `IoSliceMut` from a uninitialized slice.
+    ///
+    /// # Safety
+    /// The caller must ensure that, during the lifetime of the `IoSliceMut`,
+    /// the slice is valid the and is not used for anything else.
+    pub unsafe fn from_uninit(slice: &mut [MaybeUninit<u8>]) -> Self {
+        Self::new(slice.as_mut_ptr(), slice.len())
+    }
+
+    /// Get the pointer to the buffer.
+    pub fn as_ptr(&self) -> *const MaybeUninit<u8> {
         self.0.as_ptr()
     }
 

--- a/compio-buf/src/io_slice.rs
+++ b/compio-buf/src/io_slice.rs
@@ -95,8 +95,8 @@ impl IoSlice {
     }
 
     /// Get the pointer to the buffer.
-    pub fn as_ptr(&self) -> *const MaybeUninit<u8> {
-        self.0.as_ptr()
+    pub fn as_ptr(&self) -> *const u8 {
+        self.0.as_ptr() as _
     }
 
     /// Get the length of the buffer.
@@ -155,7 +155,7 @@ impl IoSliceMut {
     }
 
     /// Get the pointer to the buffer.
-    pub fn as_ptr(&self) -> *const MaybeUninit<u8> {
+    pub fn as_ptr(&self) -> *mut MaybeUninit<u8> {
         self.0.as_ptr()
     }
 

--- a/compio-buf/src/lib.rs
+++ b/compio-buf/src/lib.rs
@@ -16,6 +16,9 @@ pub use bumpalo;
 #[cfg(feature = "bytes")]
 pub use bytes;
 
+mod io_slice;
+pub use io_slice::*;
+
 mod buf_result;
 pub use buf_result::*;
 

--- a/compio-driver/src/poll/op.rs
+++ b/compio-driver/src/poll/op.rs
@@ -1,6 +1,8 @@
 use std::{io, pin::Pin, task::Poll};
 
-use compio_buf::{IntoInner, IoBuf, IoBufMut, IoVectoredBuf, IoVectoredBufMut};
+use compio_buf::{
+    IntoInner, IoBuf, IoBufMut, IoSlice, IoSliceMut, IoVectoredBuf, IoVectoredBufMut,
+};
 use polling::Event;
 use socket2::SockAddr;
 

--- a/compio-driver/src/poll/op.rs
+++ b/compio-driver/src/poll/op.rs
@@ -1,8 +1,4 @@
-use std::{
-    io::{self, IoSlice, IoSliceMut},
-    pin::Pin,
-    task::Poll,
-};
+use std::{io, pin::Pin, task::Poll};
 
 use compio_buf::{IntoInner, IoBuf, IoBufMut, IoVectoredBuf, IoVectoredBufMut};
 use polling::Event;
@@ -258,7 +254,7 @@ impl<T: IoBufMut> IntoInner for RecvFrom<T> {
 pub struct RecvFromVectored<T: IoVectoredBufMut> {
     pub(crate) fd: RawFd,
     pub(crate) buffer: T,
-    pub(crate) slices: Vec<IoSliceMut<'static>>,
+    pub(crate) slices: Vec<IoSliceMut>,
     pub(crate) addr: sockaddr_storage,
     pub(crate) msg: libc::msghdr,
 }
@@ -369,7 +365,7 @@ pub struct SendToVectored<T: IoVectoredBuf> {
     pub(crate) fd: RawFd,
     pub(crate) buffer: T,
     pub(crate) addr: SockAddr,
-    pub(crate) slices: Vec<IoSlice<'static>>,
+    pub(crate) slices: Vec<IoSlice>,
     pub(crate) msg: libc::msghdr,
 }
 

--- a/compio-driver/src/unix/op.rs
+++ b/compio-driver/src/unix/op.rs
@@ -1,6 +1,6 @@
-use std::io::{IoSlice, IoSliceMut};
-
-use compio_buf::{IntoInner, IoBuf, IoBufMut, IoVectoredBuf, IoVectoredBufMut};
+use compio_buf::{
+    IntoInner, IoBuf, IoBufMut, IoSlice, IoSliceMut, IoVectoredBuf, IoVectoredBufMut,
+};
 use libc::{sockaddr_storage, socklen_t};
 use socket2::SockAddr;
 
@@ -56,7 +56,7 @@ impl<T: IoBufMut> IntoInner for Recv<T> {
 pub struct RecvVectored<T: IoVectoredBufMut> {
     pub(crate) fd: RawFd,
     pub(crate) buffer: T,
-    pub(crate) slices: Vec<IoSliceMut<'static>>,
+    pub(crate) slices: Vec<IoSliceMut>,
 }
 
 impl<T: IoVectoredBufMut> RecvVectored<T> {
@@ -103,7 +103,7 @@ impl<T: IoBuf> IntoInner for Send<T> {
 pub struct SendVectored<T: IoVectoredBuf> {
     pub(crate) fd: RawFd,
     pub(crate) buffer: T,
-    pub(crate) slices: Vec<IoSlice<'static>>,
+    pub(crate) slices: Vec<IoSlice>,
 }
 
 impl<T: IoVectoredBuf> SendVectored<T> {


### PR DESCRIPTION
This PR adds `IoSlice` and `IoSliceMut` to `compio-buf` to provide a more flexible api compare to the std one. 