### PR TITLE
Use `compio-macros` in tests

### DIFF
--- a/compio/Cargo.toml
+++ b/compio/Cargo.toml
@@ -40,11 +40,13 @@ compio-dispatcher = { workspace = true, optional = true }
 
 # Shared dev dependencies for all platforms
 [dev-dependencies]
+compio-buf = { workspace = true, features = ["arrayvec"] }
+compio-macros = { workspace = true }
+
 bumpalo = "3"
 criterion = { version = "0.5", features = ["async_tokio"] }
 futures-util = "0.3"
 futures-channel = "0.3"
-compio-buf = { workspace = true, features = ["arrayvec"] }
 tempfile = "3"
 tokio = { version = "1", features = ["fs", "io-util", "macros", "net", "rt"] }
 

--- a/compio/tests/dispatcher.rs
+++ b/compio/tests/dispatcher.rs
@@ -9,7 +9,7 @@ use compio::{
 };
 use futures_util::{stream::FuturesUnordered, StreamExt};
 
-#[compio::test]
+#[compio_macros::test]
 async fn listener_dispatch() {
     const THREAD_NUM: usize = 5;
     const CLIENT_NUM: usize = 10;

--- a/compio/tests/event.rs
+++ b/compio/tests/event.rs
@@ -1,6 +1,6 @@
 use compio::event::Event;
 
-#[compio::test]
+#[compio_macros::test]
 async fn event_handle() {
     let event = Event::new().unwrap();
     let handle = event.handle().unwrap();

--- a/compio/tests/file.rs
+++ b/compio/tests/file.rs
@@ -13,7 +13,7 @@ async fn read_hello(file: &File) {
     assert_eq!(&buf, HELLO);
 }
 
-#[compio::test]
+#[compio_macros::test]
 async fn basic_read() {
     let mut tempfile = tempfile();
     tempfile.write_all(HELLO).unwrap();
@@ -22,7 +22,7 @@ async fn basic_read() {
     read_hello(&file).await;
 }
 
-#[compio::test]
+#[compio_macros::test]
 async fn basic_write() {
     let tempfile = tempfile();
 
@@ -35,7 +35,7 @@ async fn basic_write() {
     assert_eq!(file, HELLO);
 }
 
-#[compio::test]
+#[compio_macros::test]
 async fn cancel_read() {
     let mut tempfile = tempfile();
     tempfile.write_all(HELLO).unwrap();
@@ -48,7 +48,7 @@ async fn cancel_read() {
     read_hello(&file).await;
 }
 
-#[compio::test]
+#[compio_macros::test]
 async fn drop_open() {
     let tempfile = tempfile();
     let _ = File::create(tempfile.path());

--- a/compio/tests/runtime.rs
+++ b/compio/tests/runtime.rs
@@ -10,7 +10,7 @@ use compio::{
 use compio_runtime::Unattached;
 use tempfile::NamedTempFile;
 
-#[compio::test]
+#[compio_macros::test]
 async fn multi_threading() {
     const DATA: &str = "Hello world!";
 
@@ -38,7 +38,7 @@ async fn multi_threading() {
     }
 }
 
-#[compio::test]
+#[compio_macros::test]
 async fn try_clone() {
     const DATA: &str = "Hello world!";
 
@@ -67,7 +67,7 @@ async fn try_clone() {
     }
 }
 
-#[compio::test]
+#[compio_macros::test]
 async fn drop_on_complete() {
     use std::sync::Arc;
 
@@ -131,7 +131,7 @@ async fn drop_on_complete() {
     drop(file);
 }
 
-#[compio::test]
+#[compio_macros::test]
 async fn too_many_submissions() {
     let tempfile = tempfile();
 
@@ -145,7 +145,7 @@ async fn too_many_submissions() {
 }
 
 #[cfg(feature = "allocator_api")]
-#[compio::test]
+#[compio_macros::test]
 async fn arena() {
     use std::{
         alloc::{AllocError, Allocator, Layout},

--- a/compio/tests/tcp_accept.rs
+++ b/compio/tests/tcp_accept.rs
@@ -17,7 +17,7 @@ async fn test_impl(addr: impl ToSockAddrs) {
 macro_rules! test_accept {
     ($(($ident:ident, $target:expr),)*) => {
         $(
-            #[compio::test]
+            #[compio_macros::test]
             async fn $ident() {
                 println!("Testing {}...", stringify!($ident));
                 test_impl($target).await;

--- a/compio/tests/tcp_connect.rs
+++ b/compio/tests/tcp_connect.rs
@@ -29,7 +29,7 @@ async fn test_connect_ip_impl(
 macro_rules! test_connect_ip {
     ($(($ident:ident, $target:expr, $addr_f:path),)*) => {
         $(
-            #[compio::test]
+            #[compio_macros::test]
             async fn $ident() {
                 test_connect_ip_impl($target, $addr_f).await;
             }
@@ -62,7 +62,7 @@ async fn test_connect_impl<A: ToSockAddrs>(mapping: impl FnOnce(&TcpListener) ->
 macro_rules! test_connect {
     ($(($ident:ident, $mapping:tt),)*) => {
         $(
-            #[compio::test]
+            #[compio_macros::test]
             async fn $ident() {
                 #[allow(unused_parens)]
                 test_connect_impl($mapping).await;
@@ -95,7 +95,7 @@ test_connect! {
     })),
 }
 
-#[compio::test]
+#[compio_macros::test]
 async fn connect_invalid_dst() {
     assert!(TcpStream::connect("127.0.0.0:0").await.is_err());
 }

--- a/compio/tests/udp.rs
+++ b/compio/tests/udp.rs
@@ -1,6 +1,6 @@
 use compio::net::UdpSocket;
 
-#[compio::test]
+#[compio_macros::test]
 async fn connect() {
     const MSG: &str = "foo bar baz";
 
@@ -19,7 +19,7 @@ async fn connect() {
     assert_eq!(active.peer_addr().unwrap(), passive_addr);
 }
 
-#[compio::test]
+#[compio_macros::test]
 async fn send_to() {
     const MSG: &str = "foo bar baz";
 

--- a/compio/tests/unix_stream.rs
+++ b/compio/tests/unix_stream.rs
@@ -2,7 +2,7 @@ use std::net::Shutdown;
 
 use compio::net::{UnixListener, UnixStream};
 
-#[compio::test]
+#[compio_macros::test]
 async fn accept_read_write() -> std::io::Result<()> {
     let dir = tempfile::Builder::new()
         .prefix("compio-uds-tests")
@@ -28,7 +28,7 @@ async fn accept_read_write() -> std::io::Result<()> {
     Ok(())
 }
 
-#[compio::test]
+#[compio_macros::test]
 async fn shutdown() -> std::io::Result<()> {
     let dir = tempfile::Builder::new()
         .prefix("compio-uds-tests")


### PR DESCRIPTION
This PR change `compio::test` in tests to `compio_macros::test`, and make it a mandatory dev dependency. `macros` feature of `compio` is optional, meaning tests have to be runned with feature flag. This also makes RA happy (instead of yelling macro not exist).
