### PR TITLE
feat: add entry flags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /Cargo.lock
 /.vscode
 /.cargo
+/.idea

--- a/compio-driver/src/iocp/mod.rs
+++ b/compio-driver/src/iocp/mod.rs
@@ -179,7 +179,7 @@ impl Driver {
             } else {
                 Ok(0)
             };
-            Some(Entry::new(user_data, result))
+            Some(Entry::new(user_data, result, 0))
         } else {
             let transferred = iocp_entry.dwNumberOfBytesTransferred;
             // Any thin pointer is OK because we don't use the type of opcode.
@@ -197,7 +197,7 @@ impl Driver {
                     _ => Err(io::Error::from_raw_os_error(error as _)),
                 }
             };
-            Some(Entry::new(overlapped.user_data, res))
+            Some(Entry::new(overlapped.user_data, res, 0))
         }
     }
 

--- a/compio-driver/src/iour/mod.rs
+++ b/compio-driver/src/iour/mod.rs
@@ -165,7 +165,7 @@ fn create_entry(entry: cqueue::Entry) -> Entry {
     } else {
         Ok(result as _)
     };
-    Entry::new(entry.user_data() as _, result)
+    Entry::new(entry.user_data() as _, result, entry.flags())
 }
 
 fn timespec(duration: std::time::Duration) -> Timespec {

--- a/compio-driver/src/lib.rs
+++ b/compio-driver/src/lib.rs
@@ -276,16 +276,26 @@ impl Operation {
 pub struct Entry {
     user_data: usize,
     result: io::Result<usize>,
+    flags: u32,
 }
 
 impl Entry {
-    pub(crate) fn new(user_data: usize, result: io::Result<usize>) -> Self {
-        Self { user_data, result }
+    pub(crate) fn new(user_data: usize, result: io::Result<usize>, flags: u32) -> Self {
+        Self {
+            user_data,
+            result,
+            flags,
+        }
     }
 
     /// The user-defined data returned by [`Proactor::push`].
     pub fn user_data(&self) -> usize {
         self.user_data
+    }
+
+    /// The entry flags
+    pub fn flags(&self) -> u32 {
+        self.flags
     }
 
     /// The result of the operation.

--- a/compio-driver/src/poll/mod.rs
+++ b/compio-driver/src/poll/mod.rs
@@ -234,7 +234,7 @@ impl Driver {
                     Poll::Ready(res) => Some(res),
                 };
                 if let Some(res) = res {
-                    let entry = Entry::new(user_data, res);
+                    let entry = Entry::new(user_data, res, 0);
                     entries.extend(Some(entry));
                 }
             }
@@ -267,5 +267,6 @@ fn entry_cancelled(user_data: usize) -> Entry {
     Entry::new(
         user_data,
         Err(io::Error::from_raw_os_error(libc::ETIMEDOUT)),
+        0,
     )
 }


### PR DESCRIPTION
add `flags` field for `Entry`

in io-uring, the [cqe flags](https://docs.rs/io-uring/0.6.2/io_uring/cqueue/struct.Entry.html#method.flags) is meaningful, add this field can let driver use the flags

in IOCP or epoll, this flags can be simply set to 0