### PR TITLE
Use IO traits in net & fs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ compio = { version = "0.8.0", features = ["macros"] }
 Then we can use high level APIs to perform filesystem & net IO.
 
 ```rust
-use compio::fs::File;
+use compio::{fs::File, io::AsyncReadAtExt};
 
 #[compio::main]
 async fn main() {

--- a/compio-driver/src/iocp/op.rs
+++ b/compio-driver/src/iocp/op.rs
@@ -105,10 +105,7 @@ impl<T: IoBufMut> OpCode for ReadAt<T> {
     unsafe fn operate(mut self: Pin<&mut Self>, optr: *mut OVERLAPPED) -> Poll<io::Result<usize>> {
         if let Some(overlapped) = optr.as_mut() {
             overlapped.Anonymous.Anonymous.Offset = (self.offset & 0xFFFFFFFF) as _;
-            #[cfg(target_pointer_width = "64")]
-            {
-                overlapped.Anonymous.Anonymous.OffsetHigh = (self.offset >> 32) as _;
-            }
+            overlapped.Anonymous.Anonymous.OffsetHigh = (self.offset >> 32) as _;
         }
         let fd = self.fd as _;
         let slice = self.buffer.as_uninit_slice();
@@ -132,10 +129,7 @@ impl<T: IoBuf> OpCode for WriteAt<T> {
     unsafe fn operate(self: Pin<&mut Self>, optr: *mut OVERLAPPED) -> Poll<io::Result<usize>> {
         if let Some(overlapped) = optr.as_mut() {
             overlapped.Anonymous.Anonymous.Offset = (self.offset & 0xFFFFFFFF) as _;
-            #[cfg(target_pointer_width = "64")]
-            {
-                overlapped.Anonymous.Anonymous.OffsetHigh = (self.offset >> 32) as _;
-            }
+            overlapped.Anonymous.Anonymous.OffsetHigh = (self.offset >> 32) as _;
         }
         let slice = self.buffer.as_slice();
         let mut transferred = 0;

--- a/compio-driver/src/iour/op.rs
+++ b/compio-driver/src/iour/op.rs
@@ -19,7 +19,7 @@ impl<T: IoBufMut> OpCode for ReadAt<T> {
         let fd = Fd(self.fd);
         let slice = self.buffer.as_uninit_slice();
         opcode::Read::new(fd, slice.as_mut_ptr() as _, slice.len() as _)
-            .offset(self.offset as _)
+            .offset(self.offset)
             .build()
     }
 }
@@ -28,7 +28,7 @@ impl<T: IoBuf> OpCode for WriteAt<T> {
     fn create_entry(self: Pin<&mut Self>) -> Entry {
         let slice = self.buffer.as_slice();
         opcode::Write::new(Fd(self.fd), slice.as_ptr(), slice.len() as _)
-            .offset(self.offset as _)
+            .offset(self.offset)
             .build()
     }
 }

--- a/compio-driver/src/op.rs
+++ b/compio-driver/src/op.rs
@@ -66,13 +66,13 @@ impl<T> RecvResultExt for BufResult<usize, (T, sockaddr_storage, socklen_t)> {
 #[derive(Debug)]
 pub struct ReadAt<T: IoBufMut> {
     pub(crate) fd: RawFd,
-    pub(crate) offset: usize,
+    pub(crate) offset: u64,
     pub(crate) buffer: T,
 }
 
 impl<T: IoBufMut> ReadAt<T> {
     /// Create [`ReadAt`].
-    pub fn new(fd: RawFd, offset: usize, buffer: T) -> Self {
+    pub fn new(fd: RawFd, offset: u64, buffer: T) -> Self {
         Self { fd, offset, buffer }
     }
 }
@@ -89,13 +89,13 @@ impl<T: IoBufMut> IntoInner for ReadAt<T> {
 #[derive(Debug)]
 pub struct WriteAt<T: IoBuf> {
     pub(crate) fd: RawFd,
-    pub(crate) offset: usize,
+    pub(crate) offset: u64,
     pub(crate) buffer: T,
 }
 
 impl<T: IoBuf> WriteAt<T> {
     /// Create [`WriteAt`].
-    pub fn new(fd: RawFd, offset: usize, buffer: T) -> Self {
+    pub fn new(fd: RawFd, offset: u64, buffer: T) -> Self {
         Self { fd, offset, buffer }
     }
 }

--- a/compio-fs/Cargo.toml
+++ b/compio-fs/Cargo.toml
@@ -18,6 +18,7 @@ rustdoc-args = ["--cfg docsrs"]
 # Workspace dependencies
 compio-buf = { workspace = true, optional = true }
 compio-driver = { workspace = true }
+compio-io = { workspace = true, optional = true }
 compio-runtime = { workspace = true, optional = true }
 
 # Windows specific dependencies
@@ -45,8 +46,4 @@ compio-runtime = { workspace = true, features = ["time"] }
 futures-util = "0.3"
 
 [features]
-runtime = ["dep:compio-buf", "dep:compio-runtime"]
-
-# Nightly features
-allocator_api = []
-nightly = ["allocator_api", "compio-buf?/allocator_api"]
+runtime = ["dep:compio-buf", "dep:compio-io", "dep:compio-runtime"]

--- a/compio-fs/src/file.rs
+++ b/compio-fs/src/file.rs
@@ -1,12 +1,11 @@
-#[cfg(feature = "allocator_api")]
-use std::alloc::Allocator;
 use std::{fs::Metadata, io, path::Path};
 
 use compio_driver::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
 #[cfg(feature = "runtime")]
 use {
-    compio_buf::{buf_try, vec_alloc, BufResult, IntoInner, IoBuf, IoBufMut},
+    compio_buf::{buf_try, BufResult, IntoInner, IoBuf, IoBufMut},
     compio_driver::op::{BufResultExt, ReadAt, Sync, WriteAt},
+    compio_io::{AsyncReadAt, AsyncWriteAt},
     compio_runtime::{submit, Attachable, Attacher},
 };
 
@@ -101,172 +100,8 @@ impl File {
         self.inner.metadata()
     }
 
-    /// Read some bytes at the specified offset from the file into the specified
-    /// buffer, returning how many bytes were read.
-    ///
-    /// # Return
-    ///
-    /// The method returns the operation result and the same buffer value passed
-    /// as an argument.
-    ///
-    /// If the method returns [`Ok(n)`], then the read was successful. A nonzero
-    /// `n` value indicates that the buffer has been filled with `n` bytes of
-    /// data from the file. If `n` is `0`, then one of the following happened:
-    ///
-    /// 1. The specified offset is the end of the file.
-    /// 2. The buffer specified was 0 bytes in capacity.
-    ///
-    /// It is not an error if the returned value `n` is smaller than the buffer
-    /// size, even when the file contains enough data to fill the buffer.
-    ///
-    /// # Errors
-    ///
-    /// If this function encounters any form of I/O or other error, an error
-    /// variant will be returned. The buffer is returned on error.
     #[cfg(feature = "runtime")]
-    pub async fn read_at<T: IoBufMut>(&self, buffer: T, pos: usize) -> BufResult<usize, T> {
-        let ((), buffer) = buf_try!(self.attach(), buffer);
-        let op = ReadAt::new(self.as_raw_fd(), pos, buffer);
-        submit(op).await.into_inner().map_advanced()
-    }
-
-    /// Read the exact number of bytes required to fill `buffer`.
-    ///
-    /// This function reads as many bytes as necessary to completely fill the
-    /// uninitialized space of specified `buffer`.
-    ///
-    /// # Errors
-    ///
-    /// If this function encounters an "end of file" before completely filling
-    /// the buffer, it returns an error of the kind
-    /// [`ErrorKind::UnexpectedEof`]. The contents of `buffer` are unspecified
-    /// in this case.
-    ///
-    /// If any other read error is encountered then this function immediately
-    /// returns. The contents of `buffer` are unspecified in this case.
-    ///
-    /// If this function returns an error, it is unspecified how many bytes it
-    /// has read, but it will never read more than would be necessary to
-    /// completely fill the buffer.
-    ///
-    /// [`ErrorKind::UnexpectedEof`]: io::ErrorKind::UnexpectedEof
-    #[cfg(feature = "runtime")]
-    pub async fn read_exact_at<T: IoBufMut>(
-        &self,
-        mut buffer: T,
-        pos: usize,
-    ) -> BufResult<usize, T> {
-        let need = buffer.as_uninit_slice().len();
-        let mut total_read = 0;
-        let mut read;
-        while total_read < need {
-            (read, buffer) = buf_try!(self.read_at(buffer, pos + total_read).await);
-            if read == 0 {
-                break;
-            } else {
-                total_read += read;
-            }
-        }
-        let res = if total_read < need {
-            Err(io::Error::new(
-                io::ErrorKind::UnexpectedEof,
-                "failed to fill whole buffer",
-            ))
-        } else {
-            Ok(total_read)
-        };
-        BufResult(res, buffer)
-    }
-
-    /// Read all bytes until EOF in this source, placing them into `buffer`.
-    ///
-    /// All bytes read from this source will be appended to the specified buffer
-    /// `buffer`. This function will continuously call [`read_at()`] to append
-    /// more data to `buffer` until [`read_at()`] returns [`Ok(0)`].
-    ///
-    /// If successful, this function will return the total number of bytes read.
-    ///
-    /// [`read_at()`]: File::read_at
-    #[cfg(feature = "runtime")]
-    pub async fn read_to_end_at<
-        #[cfg(feature = "allocator_api")] A: Allocator + Unpin + 'static,
-    >(
-        &self,
-        mut buffer: vec_alloc!(u8, A),
-        pos: usize,
-    ) -> BufResult<usize, vec_alloc!(u8, A)> {
-        let mut total_read = 0;
-        let mut read;
-        loop {
-            (read, buffer) = buf_try!(self.read_at(buffer, pos + total_read).await);
-            if read == 0 {
-                break;
-            } else {
-                total_read += read;
-                if buffer.len() == buffer.capacity() {
-                    buffer.reserve(32);
-                }
-            }
-        }
-        BufResult(Ok(total_read), buffer)
-    }
-
-    /// Write a buffer into this file at the specified offset, returning how
-    /// many bytes were written.
-    ///
-    /// This function will attempt to write the entire contents of `buf`, but
-    /// the entire write may not succeed, or the write may also generate an
-    /// error. The bytes will be written starting at the specified offset.
-    ///
-    /// # Return
-    ///
-    /// The method returns the operation result and the same buffer value passed
-    /// in as an argument. A return value of `0` typically means that the
-    /// underlying file is no longer able to accept bytes and will likely not be
-    /// able to in the future as well, or that the buffer provided is empty.
-    ///
-    /// # Errors
-    ///
-    /// Each call to `write_at` may generate an I/O error indicating that the
-    /// operation could not be completed. If an error is returned then no bytes
-    /// in the buffer were written to this writer.
-    ///
-    /// It is **not** considered an error if the entire buffer could not be
-    /// written to this writer.
-    #[cfg(feature = "runtime")]
-    pub async fn write_at<T: IoBuf>(&self, buffer: T, pos: usize) -> BufResult<usize, T> {
-        let ((), buffer) = buf_try!(self.attach(), buffer);
-        let op = WriteAt::new(self.as_raw_fd(), pos, buffer);
-        submit(op).await.into_inner()
-    }
-
-    /// Attempts to write an entire buffer into this writer.
-    ///
-    /// This method will continuously call [`write_at`] until there is no more
-    /// data to be written. This method will not return until the entire
-    /// buffer has been successfully written or such an error occurs.
-    ///
-    /// If the buffer contains no data, this will never call [`write_at`].
-    ///
-    /// [`write_at`]: File::write_at
-    #[cfg(feature = "runtime")]
-    pub async fn write_all_at<T: IoBuf>(&self, mut buffer: T, pos: usize) -> BufResult<usize, T> {
-        let buf_len = buffer.buf_len();
-        let mut total_written = 0;
-        let mut written;
-        while total_written < buf_len {
-            (written, buffer) = buf_try!(
-                self.write_at(buffer.slice(total_written..), pos + total_written)
-                    .await
-                    .into_inner()
-            );
-            total_written += written;
-        }
-        BufResult(Ok(total_written), buffer)
-    }
-
-    #[cfg(feature = "runtime")]
-    async fn sync_impl(&self, datasync: bool) -> io::Result<()> {
+    async fn sync_impl(&mut self, datasync: bool) -> io::Result<()> {
         self.attach()?;
         let op = Sync::new(self.as_raw_fd(), datasync);
         submit(op).await.0?;
@@ -278,7 +113,7 @@ impl File {
     /// This function will attempt to ensure that all in-memory data reaches the
     /// filesystem before returning.
     #[cfg(feature = "runtime")]
-    pub async fn sync_all(&self) -> io::Result<()> {
+    pub async fn sync_all(&mut self) -> io::Result<()> {
         self.sync_impl(false).await
     }
 
@@ -294,8 +129,26 @@ impl File {
     ///
     /// [`sync_all`]: File::sync_all
     #[cfg(feature = "runtime")]
-    pub async fn sync_data(&self) -> io::Result<()> {
+    pub async fn sync_data(&mut self) -> io::Result<()> {
         self.sync_impl(true).await
+    }
+}
+
+#[cfg(feature = "runtime")]
+impl AsyncReadAt for File {
+    async fn read_at<T: IoBufMut>(&self, buffer: T, pos: u64) -> BufResult<usize, T> {
+        let ((), buffer) = buf_try!(self.attach(), buffer);
+        let op = ReadAt::new(self.as_raw_fd(), pos, buffer);
+        submit(op).await.into_inner().map_advanced()
+    }
+}
+
+#[cfg(feature = "runtime")]
+impl AsyncWriteAt for File {
+    async fn write_at<T: IoBuf>(&mut self, buffer: T, pos: u64) -> BufResult<usize, T> {
+        let ((), buffer) = buf_try!(self.attach(), buffer);
+        let op = WriteAt::new(self.as_raw_fd(), pos, buffer);
+        submit(op).await.into_inner()
     }
 }
 

--- a/compio-fs/src/lib.rs
+++ b/compio-fs/src/lib.rs
@@ -1,7 +1,6 @@
 //! Filesystem manipulation operations.
 
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
-#![cfg_attr(feature = "allocator_api", feature(allocator_api))]
 #![warn(missing_docs)]
 
 mod file;

--- a/compio-io/Cargo.toml
+++ b/compio-io/Cargo.toml
@@ -17,3 +17,8 @@ paste = "1.0.14"
 compio-runtime = { workspace = true }
 compio-macros = { workspace = true }
 compio-driver = { workspace = true, features = ["io-uring"] }
+
+[features]
+# Nightly features
+allocator_api = []
+nightly = ["allocator_api", "compio-buf/allocator_api"]

--- a/compio-io/src/lib.rs
+++ b/compio-io/src/lib.rs
@@ -86,6 +86,7 @@
 #![warn(missing_docs)]
 // This is OK as we're thread-per-core and don't need `Send` or other auto trait on anonymous future
 #![allow(async_fn_in_trait)]
+#![cfg_attr(feature = "allocator_api", feature(allocator_api))]
 
 mod buffer;
 mod read;

--- a/compio-io/src/read/ext.rs
+++ b/compio-io/src/read/ext.rs
@@ -1,4 +1,7 @@
-use compio_buf::{buf_try, BufResult, IntoInner, IoBufMut, IoVectoredBufMut};
+#[cfg(feature = "allocator_api")]
+use std::alloc::Allocator;
+
+use compio_buf::{buf_try, vec_alloc, BufResult, IntoInner, IoBufMut, IoVectoredBufMut};
 
 use crate::{util::Take, AsyncRead, AsyncReadAt, IoResult};
 
@@ -180,6 +183,36 @@ pub trait AsyncReadAtExt: AsyncReadAt {
             read,
             loop self.read_at(buf, pos + read as u64)
         );
+    }
+
+    /// Read all bytes until EOF in this source, placing them into `buffer`.
+    ///
+    /// All bytes read from this source will be appended to the specified buffer
+    /// `buffer`. This function will continuously call [`read_at()`] to append
+    /// more data to `buffer` until [`read_at()`] returns [`Ok(0)`].
+    ///
+    /// If successful, this function will return the total number of bytes read.
+    ///
+    /// [`read_at()`]: AsyncReadAt::read_at
+    async fn read_to_end_at<#[cfg(feature = "allocator_api")] A: Allocator + Unpin + 'static>(
+        &self,
+        mut buffer: vec_alloc!(u8, A),
+        pos: u64,
+    ) -> BufResult<usize, vec_alloc!(u8, A)> {
+        let mut total_read = 0;
+        let mut read;
+        loop {
+            (read, buffer) = buf_try!(self.read_at(buffer, pos + total_read).await);
+            if read == 0 {
+                break;
+            } else {
+                total_read += read as u64;
+                if buffer.len() == buffer.capacity() {
+                    buffer.reserve(32);
+                }
+            }
+        }
+        BufResult(Ok(total_read as usize), buffer)
     }
 }
 

--- a/compio-io/src/read/ext.rs
+++ b/compio-io/src/read/ext.rs
@@ -173,12 +173,12 @@ pub trait AsyncReadAtExt: AsyncReadAt {
     /// completely fill the buffer.
     ///
     /// [`ErrorKind::UnexpectedEof`]: std::io::ErrorKind::UnexpectedEof
-    async fn read_exact_at<T: IoBufMut>(&self, mut buf: T, pos: usize) -> BufResult<usize, T> {
+    async fn read_exact_at<T: IoBufMut>(&self, mut buf: T, pos: u64) -> BufResult<usize, T> {
         loop_read_exact!(
             buf,
             buf.buf_capacity() - buf.buf_len(),
             read,
-            loop self.read_at(buf, pos + read)
+            loop self.read_at(buf, pos + read as u64)
         );
     }
 }

--- a/compio-io/src/read/mod.rs
+++ b/compio-io/src/read/mod.rs
@@ -184,14 +184,14 @@ impl AsyncRead for &[u8] {
 /// Async read with a ownership of a buffer and a position
 pub trait AsyncReadAt {
     /// Like `read`, except that it reads at a specified position.
-    async fn read_at<T: IoBufMut>(&self, buf: T, pos: usize) -> BufResult<usize, T>;
+    async fn read_at<T: IoBufMut>(&self, buf: T, pos: u64) -> BufResult<usize, T>;
 }
 
 macro_rules! impl_read_at {
     (@ptr $($ty:ty),*) => {
         $(
             impl<A: AsyncReadAt + ?Sized> AsyncReadAt for $ty {
-                async fn read_at<T: IoBufMut>(&self, buf: T, pos: usize) -> BufResult<usize, T> {
+                async fn read_at<T: IoBufMut>(&self, buf: T, pos: u64) -> BufResult<usize, T> {
                     (**self).read_at(buf, pos).await
                 }
             }
@@ -201,8 +201,8 @@ macro_rules! impl_read_at {
     (@slice $($(const $len:ident =>)? $ty:ty), *) => {
         $(
             impl<$(const $len: usize)?> AsyncReadAt for $ty {
-                async fn read_at<T: IoBufMut>(&self, mut buf: T, pos: usize) -> BufResult<usize, T> {
-                    let len = slice_to_buf(&self[pos..], &mut buf);
+                async fn read_at<T: IoBufMut>(&self, mut buf: T, pos: u64) -> BufResult<usize, T> {
+                    let len = slice_to_buf(&self[pos as usize..], &mut buf);
                     BufResult(Ok(len), buf)
                 }
             }

--- a/compio-io/src/write/ext.rs
+++ b/compio-io/src/write/ext.rs
@@ -134,12 +134,12 @@ impl<A: AsyncWrite + ?Sized> AsyncWriteExt for A {}
 pub trait AsyncWriteAtExt: AsyncWriteAt {
     /// Like `write_at`, except that it tries to write the entire contents of
     /// the buffer into this writer.
-    async fn write_all_at<T: IoBuf>(&mut self, mut buf: T, pos: usize) -> BufResult<usize, T> {
+    async fn write_all_at<T: IoBuf>(&mut self, mut buf: T, pos: u64) -> BufResult<usize, T> {
         loop_write_all!(
             buf,
             buf.buf_len(),
             needle,
-            loop self.write_at(buf.slice(needle..), pos + needle)
+            loop self.write_at(buf.slice(needle..), pos + needle as u64)
         );
     }
 }

--- a/compio-net/Cargo.toml
+++ b/compio-net/Cargo.toml
@@ -18,6 +18,7 @@ rustdoc-args = ["--cfg docsrs"]
 # Workspace dependencies
 compio-buf = { workspace = true }
 compio-driver = { workspace = true }
+compio-io = { workspace = true, optional = true }
 compio-runtime = { workspace = true, optional = true }
 
 socket2 = { version = "0.5", features = ["all"] }
@@ -28,4 +29,4 @@ futures-util = "0.3"
 tempfile = "3"
 
 [features]
-runtime = ["dep:compio-runtime"]
+runtime = ["dep:compio-io", "dep:compio-runtime"]

--- a/compio-net/src/socket.rs
+++ b/compio-net/src/socket.rs
@@ -1,4 +1,4 @@
-use std::{io, net::Shutdown};
+use std::io;
 
 use compio_driver::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
 use socket2::{Domain, Protocol, SockAddr, Socket as Socket2, Type};
@@ -70,10 +70,6 @@ impl Socket {
 
     pub fn listen(&self, backlog: i32) -> io::Result<()> {
         self.socket.listen(backlog)
-    }
-
-    pub fn shutdown_std(&self, how: Shutdown) -> io::Result<()> {
-        self.socket.shutdown(how)
     }
 
     pub fn connect(&self, addr: &SockAddr) -> io::Result<()> {
@@ -204,7 +200,7 @@ impl AsyncWrite for Socket {
     }
 
     async fn shutdown(&mut self) -> io::Result<()> {
-        self.shutdown_std(Shutdown::Write)
+        self.socket.shutdown(std::net::Shutdown::Write)
     }
 }
 

--- a/compio-net/src/tcp.rs
+++ b/compio-net/src/tcp.rs
@@ -1,10 +1,11 @@
-use std::{io, net::Shutdown};
+use std::io;
 
 use compio_driver::impl_raw_fd;
 use socket2::{Protocol, SockAddr, Type};
 #[cfg(feature = "runtime")]
 use {
     compio_buf::{BufResult, IoBuf, IoBufMut, IoVectoredBuf, IoVectoredBufMut},
+    compio_io::{AsyncRead, AsyncWrite},
     compio_runtime::impl_attachable,
 };
 
@@ -20,6 +21,7 @@ use crate::{Socket, ToSockAddrs};
 /// ```
 /// use std::net::SocketAddr;
 ///
+/// use compio_io::{AsyncReadExt, AsyncWriteExt};
 /// use compio_net::{TcpListener, TcpStream};
 /// use socket2::SockAddr;
 ///
@@ -32,11 +34,11 @@ use crate::{Socket, ToSockAddrs};
 ///
 ///     let rx_fut = listener.accept();
 ///
-///     let (tx, (rx, _)) = futures_util::try_join!(tx_fut, rx_fut).unwrap();
+///     let (mut tx, (mut rx, _)) = futures_util::try_join!(tx_fut, rx_fut).unwrap();
 ///
-///     tx.send_all("test").await.0.unwrap();
+///     tx.write_all("test").await.0.unwrap();
 ///
-///     let (_, buf) = rx.recv_exact(Vec::with_capacity(4)).await.unwrap();
+///     let (_, buf) = rx.read_exact(Vec::with_capacity(4)).await.unwrap();
 ///
 ///     assert_eq!(buf, b"test");
 /// });
@@ -127,6 +129,7 @@ impl_attachable!(TcpListener, inner);
 /// ```no_run
 /// use std::net::SocketAddr;
 ///
+/// use compio_io::AsyncWrite;
 /// use compio_net::TcpStream;
 ///
 /// compio_runtime::block_on(async {
@@ -134,7 +137,7 @@ impl_attachable!(TcpListener, inner);
 ///     let mut stream = TcpStream::connect("127.0.0.1:8080").await.unwrap();
 ///
 ///     // Write some data.
-///     stream.send("hello world!").await.unwrap();
+///     stream.write("hello world!").await.unwrap();
 /// })
 /// ```
 #[derive(Debug)]
@@ -188,54 +191,38 @@ impl TcpStream {
     pub fn local_addr(&self) -> io::Result<SockAddr> {
         self.inner.local_addr()
     }
+}
 
-    /// Shuts down the read, write, or both halves of this connection.
-    ///
-    /// This function will cause all pending and future I/O on the specified
-    /// portions to return immediately with an appropriate value (see the
-    /// documentation of [`Shutdown`]).
-    pub fn shutdown(&self, how: Shutdown) -> io::Result<()> {
-        self.inner.shutdown(how)
+#[cfg(feature = "runtime")]
+impl AsyncRead for TcpStream {
+    async fn read<B: IoBufMut>(&mut self, buf: B) -> BufResult<usize, B> {
+        self.inner.read(buf).await
     }
 
-    /// Receives a packet of data from the socket into the buffer, returning the
-    /// original buffer and quantity of data received.
-    #[cfg(feature = "runtime")]
-    pub async fn recv<T: IoBufMut>(&self, buffer: T) -> BufResult<usize, T> {
-        self.inner.recv(buffer).await
+    async fn read_vectored<V: IoVectoredBufMut>(&mut self, buf: V) -> BufResult<usize, V>
+    where
+        V: Unpin + 'static,
+    {
+        self.inner.read_vectored(buf).await
+    }
+}
+
+#[cfg(feature = "runtime")]
+impl AsyncWrite for TcpStream {
+    async fn write<T: IoBuf>(&mut self, buf: T) -> BufResult<usize, T> {
+        self.inner.write(buf).await
     }
 
-    /// Receives exact number of bytes from the socket.
-    #[cfg(feature = "runtime")]
-    pub async fn recv_exact<T: IoBufMut>(&self, buffer: T) -> BufResult<usize, T> {
-        self.inner.recv_exact(buffer).await
+    async fn write_vectored<T: IoVectoredBuf>(&mut self, buf: T) -> BufResult<usize, T> {
+        self.inner.write_vectored(buf).await
     }
 
-    /// Receives a packet of data from the socket into the buffer, returning the
-    /// original buffer and quantity of data received.
-    #[cfg(feature = "runtime")]
-    pub async fn recv_vectored<T: IoVectoredBufMut>(&self, buffer: T) -> BufResult<usize, T> {
-        self.inner.recv_vectored(buffer).await
+    async fn flush(&mut self) -> io::Result<()> {
+        self.inner.flush().await
     }
 
-    /// Sends some data to the socket from the buffer, returning the original
-    /// buffer and quantity of data sent.
-    #[cfg(feature = "runtime")]
-    pub async fn send<T: IoBuf>(&self, buffer: T) -> BufResult<usize, T> {
-        self.inner.send(buffer).await
-    }
-
-    /// Sends all data to the socket.
-    #[cfg(feature = "runtime")]
-    pub async fn send_all<T: IoBuf>(&self, buffer: T) -> BufResult<usize, T> {
-        self.inner.send_all(buffer).await
-    }
-
-    /// Sends some data to the socket from the buffer, returning the original
-    /// buffer and quantity of data sent.
-    #[cfg(feature = "runtime")]
-    pub async fn send_vectored<T: IoVectoredBuf>(&self, buffer: T) -> BufResult<usize, T> {
-        self.inner.send_vectored(buffer).await
+    async fn shutdown(&mut self) -> io::Result<()> {
+        self.inner.shutdown().await
     }
 }
 

--- a/compio/Cargo.toml
+++ b/compio/Cargo.toml
@@ -68,7 +68,7 @@ all = ["time", "macros", "signal", "dispatcher"]
 allocator_api = [
     "bumpalo/allocator_api",
     "compio-buf/allocator_api",
-    "compio-fs/allocator_api",
+    "compio-io/allocator_api",
 ]
 lazy_cell = ["compio-signal?/lazy_cell"]
 once_cell_try = [

--- a/compio/Cargo.toml
+++ b/compio/Cargo.toml
@@ -35,7 +35,7 @@ compio-driver = { workspace = true }
 compio-runtime = { workspace = true, optional = true }
 compio-macros = { workspace = true, optional = true }
 compio-fs = { workspace = true }
-compio-io = { workspace = true }
+compio-io = { workspace = true, optional = true }
 compio-net = { workspace = true }
 compio-signal = { workspace = true, optional = true }
 compio-dispatcher = { workspace = true, optional = true }
@@ -56,7 +56,13 @@ tokio = { version = "1", features = ["fs", "io-util", "macros", "net", "rt"] }
 default = ["runtime", "io-uring"]
 io-uring = ["compio-driver/io-uring"]
 polling = ["compio-driver/polling"]
-runtime = ["dep:compio-runtime", "compio-fs/runtime", "compio-net/runtime"]
+io = ["dep:compio-io"]
+runtime = [
+    "dep:compio-runtime",
+    "compio-fs/runtime",
+    "compio-net/runtime",
+    "io",
+]
 macros = ["dep:compio-macros", "runtime"]
 event = ["compio-runtime/event", "runtime"]
 signal = ["dep:compio-signal", "event"]
@@ -68,7 +74,7 @@ all = ["time", "macros", "signal", "dispatcher"]
 allocator_api = [
     "bumpalo/allocator_api",
     "compio-buf/allocator_api",
-    "compio-io/allocator_api",
+    "compio-io?/allocator_api",
 ]
 lazy_cell = ["compio-signal?/lazy_cell"]
 once_cell_try = [

--- a/compio/benches/fs.rs
+++ b/compio/benches/fs.rs
@@ -43,6 +43,8 @@ fn read(c: &mut Criterion) {
 
     group.bench_function("compio", |b| {
         b.to_async(CompioRuntime).iter(|| async {
+            use compio::io::AsyncReadAtExt;
+
             let file = compio::fs::File::open("Cargo.toml").unwrap();
             let buffer = Vec::with_capacity(1024);
             let (_, buffer) = file.read_to_end_at(buffer, 0).await.unwrap();
@@ -85,7 +87,9 @@ fn write(c: &mut Criterion) {
     group.bench_function("compio", |b| {
         let temp_file = NamedTempFile::new().unwrap();
         b.to_async(CompioRuntime).iter(|| async {
-            let file = compio::fs::File::create(temp_file.path()).unwrap();
+            use compio::io::AsyncWriteAtExt;
+
+            let mut file = compio::fs::File::create(temp_file.path()).unwrap();
             file.write_all_at(CONTENT, 0).await.unwrap();
         })
     });

--- a/compio/benches/named_pipe.rs
+++ b/compio/benches/named_pipe.rs
@@ -57,12 +57,13 @@ fn basic(c: &mut Criterion) {
                 use compio::{
                     buf::BufResult,
                     fs::named_pipe::{ClientOptions, ServerOptions},
+                    io::{AsyncReadExt, AsyncWriteExt},
                 };
 
                 const PIPE_NAME: &str = r"\\.\pipe\compio-named-pipe";
 
-                let server = ServerOptions::new().create(PIPE_NAME).unwrap();
-                let client = ClientOptions::new().open(PIPE_NAME).unwrap();
+                let mut server = ServerOptions::new().create(PIPE_NAME).unwrap();
+                let mut client = ClientOptions::new().open(PIPE_NAME).unwrap();
 
                 server.connect().await.unwrap();
 

--- a/compio/examples/basic.rs
+++ b/compio/examples/basic.rs
@@ -1,4 +1,4 @@
-use compio::fs::OpenOptions;
+use compio::{fs::OpenOptions, io::AsyncReadAtExt};
 
 #[compio::main(crate = "compio")]
 async fn main() {

--- a/compio/examples/named_pipe.rs
+++ b/compio/examples/named_pipe.rs
@@ -5,15 +5,16 @@ async fn main() {
         use compio::{
             buf::BufResult,
             fs::named_pipe::{ClientOptions, ServerOptions},
+            io::{AsyncReadExt, AsyncWriteExt},
         };
 
         const PIPE_NAME: &str = r"\\.\pipe\compio-named-pipe";
 
-        let server = ServerOptions::new()
+        let mut server = ServerOptions::new()
             .access_inbound(false)
             .create(PIPE_NAME)
             .unwrap();
-        let client = ClientOptions::new().write(false).open(PIPE_NAME).unwrap();
+        let mut client = ClientOptions::new().write(false).open(PIPE_NAME).unwrap();
 
         server.connect().await.unwrap();
 

--- a/compio/examples/net.rs
+++ b/compio/examples/net.rs
@@ -1,19 +1,22 @@
 use std::net::Ipv4Addr;
 
-use compio::net::{TcpListener, TcpStream};
+use compio::{
+    io::{AsyncReadExt, AsyncWriteExt},
+    net::{TcpListener, TcpStream},
+};
 
 #[compio::main(crate = "compio")]
 async fn main() {
     let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).unwrap();
     let addr = listener.local_addr().unwrap();
 
-    let (tx, (rx, _)) =
+    let (mut tx, (mut rx, _)) =
         futures_util::try_join!(TcpStream::connect(&addr), listener.accept()).unwrap();
 
-    tx.send_all("Hello world!").await.0.unwrap();
+    tx.write_all("Hello world!").await.0.unwrap();
 
     let buffer = Vec::with_capacity(12);
-    let (n, buffer) = rx.recv_exact(buffer).await.unwrap();
+    let (n, buffer) = rx.read_exact(buffer).await.unwrap();
     assert_eq!(n, buffer.len());
     println!("{}", String::from_utf8(buffer).unwrap());
 }

--- a/compio/examples/unix.rs
+++ b/compio/examples/unix.rs
@@ -1,4 +1,7 @@
-use compio::net::{UnixListener, UnixStream};
+use compio::{
+    io::{AsyncReadExt, AsyncWriteExt},
+    net::{UnixListener, UnixStream},
+};
 use tempfile::tempdir;
 
 #[compio::main(crate = "compio")]
@@ -9,14 +12,14 @@ async fn main() {
 
     let addr = listener.local_addr().unwrap();
 
-    let tx = UnixStream::connect_addr(&addr).unwrap();
-    let (rx, _) = listener.accept().await.unwrap();
+    let mut tx = UnixStream::connect_addr(&addr).unwrap();
+    let (mut rx, _) = listener.accept().await.unwrap();
 
     assert_eq!(addr, tx.peer_addr().unwrap());
 
-    tx.send_all("Hello world!").await.0.unwrap();
+    tx.write_all("Hello world!").await.0.unwrap();
 
     let buffer = Vec::with_capacity(12);
-    let (_, buffer) = rx.recv_exact(buffer).await.unwrap();
+    let (_, buffer) = rx.read_exact(buffer).await.unwrap();
     println!("{}", String::from_utf8(buffer).unwrap());
 }

--- a/compio/src/lib.rs
+++ b/compio/src/lib.rs
@@ -6,7 +6,7 @@
 //! ## Quick start
 //! ```rust
 //! # compio::runtime::block_on(async {
-//! use compio::fs::File;
+//! use compio::{fs::File, io::AsyncReadAtExt};
 //!
 //! let file = File::open("Cargo.toml").unwrap();
 //! let (read, buffer) = file
@@ -42,4 +42,6 @@ pub use runtime::event;
 #[doc(no_inline)]
 pub use runtime::time;
 #[doc(inline)]
-pub use {compio_buf as buf, compio_driver as driver, compio_fs as fs, compio_net as net};
+pub use {
+    compio_buf as buf, compio_driver as driver, compio_fs as fs, compio_io as io, compio_net as net,
+};

--- a/compio/src/lib.rs
+++ b/compio/src/lib.rs
@@ -27,6 +27,8 @@ pub use buf::BufResult;
 #[cfg(feature = "dispatcher")]
 #[doc(inline)]
 pub use compio_dispatcher as dispatcher;
+#[cfg(feature = "io")]
+pub use compio_io as io;
 #[cfg(feature = "macros")]
 pub use compio_macros::*;
 #[cfg(feature = "runtime")]
@@ -42,6 +44,4 @@ pub use runtime::event;
 #[doc(no_inline)]
 pub use runtime::time;
 #[doc(inline)]
-pub use {
-    compio_buf as buf, compio_driver as driver, compio_fs as fs, compio_io as io, compio_net as net,
-};
+pub use {compio_buf as buf, compio_driver as driver, compio_fs as fs, compio_net as net};

--- a/compio/tests/file.rs
+++ b/compio/tests/file.rs
@@ -1,6 +1,9 @@
 use std::io::prelude::*;
 
-use compio::fs::File;
+use compio::{
+    fs::File,
+    io::{AsyncReadAtExt, AsyncWriteAtExt},
+};
 use tempfile::NamedTempFile;
 
 const HELLO: &[u8] = b"hello world...";
@@ -26,7 +29,7 @@ async fn basic_read() {
 async fn basic_write() {
     let tempfile = tempfile();
 
-    let file = File::create(tempfile.path()).unwrap();
+    let mut file = File::create(tempfile.path()).unwrap();
 
     file.write_all_at(HELLO, 0).await.0.unwrap();
     file.sync_all().await.unwrap();
@@ -54,7 +57,7 @@ async fn drop_open() {
     let _ = File::create(tempfile.path());
 
     // Do something else
-    let file = File::create(tempfile.path()).unwrap();
+    let mut file = File::create(tempfile.path()).unwrap();
 
     file.write_all_at(HELLO, 0).await.0.unwrap();
 

--- a/compio/tests/runtime.rs
+++ b/compio/tests/runtime.rs
@@ -5,6 +5,7 @@ use std::net::Ipv4Addr;
 use compio::{
     buf::*,
     fs::File,
+    io::{AsyncReadAt, AsyncReadAtExt, AsyncWriteAt},
     net::{TcpListener, TcpStream},
 };
 use compio_runtime::Unattached;
@@ -135,7 +136,7 @@ async fn drop_on_complete() {
 async fn too_many_submissions() {
     let tempfile = tempfile();
 
-    let file = File::create(tempfile.path()).unwrap();
+    let mut file = File::create(tempfile.path()).unwrap();
     for _ in 0..600 {
         poll_once(async {
             file.write_at("hello world", 0).await.0.unwrap();

--- a/compio/tests/runtime.rs
+++ b/compio/tests/runtime.rs
@@ -5,7 +5,7 @@ use std::net::Ipv4Addr;
 use compio::{
     buf::*,
     fs::File,
-    io::{AsyncReadAt, AsyncReadAtExt, AsyncWriteAt},
+    io::{AsyncReadAt, AsyncReadAtExt, AsyncReadExt, AsyncWriteAt, AsyncWriteExt},
     net::{TcpListener, TcpStream},
 };
 use compio_runtime::Unattached;
@@ -18,17 +18,17 @@ async fn multi_threading() {
     let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).unwrap();
     let addr = listener.local_addr().unwrap();
 
-    let (tx, (rx, _)) =
+    let (mut tx, (rx, _)) =
         futures_util::try_join!(TcpStream::connect(&addr), listener.accept()).unwrap();
 
-    tx.send_all(DATA).await.0.unwrap();
+    tx.write_all(DATA).await.0.unwrap();
 
     let rx = Unattached::new(rx).unwrap();
     if let Err(e) = std::thread::spawn(move || {
-        let rx = rx.into_inner();
+        let mut rx = rx.into_inner();
         compio::runtime::block_on(async {
             let buffer = Vec::with_capacity(DATA.len());
-            let (n, buffer) = rx.recv_exact(buffer).await.unwrap();
+            let (n, buffer) = rx.read_exact(buffer).await.unwrap();
             assert_eq!(n, buffer.len());
             assert_eq!(DATA, String::from_utf8(buffer).unwrap());
         });
@@ -49,15 +49,15 @@ async fn try_clone() {
     let (tx, (rx, _)) =
         futures_util::try_join!(TcpStream::connect(&addr), listener.accept()).unwrap();
 
-    let tx = tx.try_clone().unwrap();
-    tx.send_all(DATA).await.0.unwrap();
+    let mut tx = tx.try_clone().unwrap();
+    tx.write_all(DATA).await.0.unwrap();
 
     let rx = Unattached::new(rx.try_clone().unwrap()).unwrap();
     if let Err(e) = std::thread::spawn(move || {
-        let rx = rx.into_inner();
+        let mut rx = rx.into_inner();
         compio::runtime::block_on(async {
             let buffer = Vec::with_capacity(DATA.len());
-            let (n, buffer) = rx.recv_exact(buffer).await.unwrap();
+            let (n, buffer) = rx.read_exact(buffer).await.unwrap();
             assert_eq!(n, buffer.len());
             assert_eq!(DATA, String::from_utf8(buffer).unwrap());
         });

--- a/compio/tests/udp.rs
+++ b/compio/tests/udp.rs
@@ -4,10 +4,10 @@ use compio::net::UdpSocket;
 async fn connect() {
     const MSG: &str = "foo bar baz";
 
-    let passive = UdpSocket::bind("127.0.0.1:0").unwrap();
+    let mut passive = UdpSocket::bind("127.0.0.1:0").unwrap();
     let passive_addr = passive.local_addr().unwrap();
 
-    let active = UdpSocket::bind("127.0.0.1:0").unwrap();
+    let mut active = UdpSocket::bind("127.0.0.1:0").unwrap();
     let active_addr = active.local_addr().unwrap();
 
     active.connect(&passive_addr).unwrap();
@@ -31,19 +31,19 @@ async fn send_to() {
         };
     }
 
-    let passive1 = UdpSocket::bind("127.0.0.1:0").unwrap();
+    let mut passive1 = UdpSocket::bind("127.0.0.1:0").unwrap();
     let passive1_addr = passive1.local_addr().unwrap();
 
     let passive01 = std::net::UdpSocket::bind("127.0.0.1:0").unwrap();
     let passive01_addr = passive01.local_addr().unwrap();
 
-    let passive2 = UdpSocket::bind("127.0.0.1:0").unwrap();
+    let mut passive2 = UdpSocket::bind("127.0.0.1:0").unwrap();
     let passive2_addr = passive2.local_addr().unwrap();
 
-    let passive3 = UdpSocket::bind("127.0.0.1:0").unwrap();
+    let mut passive3 = UdpSocket::bind("127.0.0.1:0").unwrap();
     let passive3_addr = passive3.local_addr().unwrap();
 
-    let active = UdpSocket::bind("127.0.0.1:0").unwrap();
+    let mut active = UdpSocket::bind("127.0.0.1:0").unwrap();
     let active_addr = active.local_addr().unwrap();
 
     active.send_to(MSG, &passive01_addr).await.0.unwrap();


### PR DESCRIPTION
And change *_at to use u64. We should use rustix's `pread` and `pwrite`, but that's a huge change. So I'm opening this first. After this PR, I'll work on #91 , and finally change `libc` to `rustix`.