### PR TITLE
refactor: change SockAddr return type to SocketAddr

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /Cargo.lock
 /.vscode
 /.cargo
+/.idea

--- a/compio/tests/runtime.rs
+++ b/compio/tests/runtime.rs
@@ -5,7 +5,7 @@ use std::net::Ipv4Addr;
 use compio::{
     buf::*,
     fs::File,
-    io::{AsyncReadAt, AsyncReadAtExt, AsyncReadExt, AsyncWriteAt, AsyncWriteExt},
+    io::{AsyncReadAt, AsyncReadExt, AsyncWriteAt, AsyncWriteExt},
     net::{TcpListener, TcpStream},
 };
 use compio_runtime::Unattached;
@@ -152,6 +152,8 @@ async fn arena() {
         alloc::{AllocError, Allocator, Layout},
         ptr::NonNull,
     };
+
+    use compio::io::AsyncReadAtExt;
 
     thread_local! {
         static ALLOCATOR: bumpalo::Bump = bumpalo::Bump::new();

--- a/compio/tests/tcp_connect.rs
+++ b/compio/tests/tcp_connect.rs
@@ -8,7 +8,7 @@ async fn test_connect_ip_impl(
 ) {
     let listener = TcpListener::bind(target).unwrap();
     let addr = listener.local_addr().unwrap();
-    assert!(assert_fn(&addr.as_socket().unwrap()));
+    assert!(assert_fn(&addr));
 
     let (tx, rx) = futures_channel::oneshot::channel();
 
@@ -73,24 +73,24 @@ macro_rules! test_connect {
 
 test_connect! {
     (ip_string, (|listener: &TcpListener| {
-        format!("127.0.0.1:{}", listener.local_addr().unwrap().as_socket().unwrap().port())
+        format!("127.0.0.1:{}", listener.local_addr().unwrap().port())
     })),
     (ip_str, (|listener: &TcpListener| {
-        let s = format!("127.0.0.1:{}", listener.local_addr().unwrap().as_socket().unwrap().port());
+        let s = format!("127.0.0.1:{}", listener.local_addr().unwrap().port());
         let slice: &str = &*Box::leak(s.into_boxed_str());
         slice
     })),
     (ip_port_tuple, (|listener: &TcpListener| {
-        let addr = listener.local_addr().unwrap().as_socket().unwrap();
+        let addr = listener.local_addr().unwrap();
         (addr.ip(), addr.port())
     })),
     (ip_port_tuple_ref, (|listener: &TcpListener| {
-        let addr = listener.local_addr().unwrap().as_socket().unwrap();
+        let addr = listener.local_addr().unwrap();
         let tuple_ref: &(IpAddr, u16) = &*Box::leak(Box::new((addr.ip(), addr.port())));
         tuple_ref
     })),
     (ip_str_port_tuple, (|listener: &TcpListener| {
-        let addr = listener.local_addr().unwrap().as_socket().unwrap();
+        let addr = listener.local_addr().unwrap();
         ("127.0.0.1", addr.port())
     })),
 }


### PR DESCRIPTION
`SockAddr` can be a tcp/udp socket addr, unix domain socket addr or others

but when using tcp/udp, the `SockAddr` is always ip+port, if users want to get the ip or port, or pass the addr to other other place which need a `SocketAddr`, user need to convert it to `SocketAddr` manually, so change tcp/udp addr type to `SocketAddr`