### PR TITLE
feat(driver): fusion driver

### DIFF
--- a/compio-driver/Cargo.toml
+++ b/compio-driver/Cargo.toml
@@ -57,6 +57,7 @@ windows-sys = { version = "0.48", features = [
 io-uring = { version = "0.6", optional = true }
 polling = { version = "3", optional = true }
 libc = "0.2"
+paste = "1.0.14"
 
 # Other platform dependencies
 [target.'cfg(all(not(target_os = "linux"), unix))'.dependencies]

--- a/compio-driver/src/fusion/mod.rs
+++ b/compio-driver/src/fusion/mod.rs
@@ -1,0 +1,169 @@
+#[path = "../poll/mod.rs"]
+mod poll;
+
+#[path = "../iour/mod.rs"]
+mod iour;
+
+pub(crate) mod op;
+
+#[cfg_attr(all(doc, docsrs), doc(cfg(all())))]
+pub use std::os::fd::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
+use std::{io, task::Poll, time::Duration};
+
+pub use driver_type::DriverType;
+pub(crate) use iour::{sockaddr_storage, socklen_t};
+pub use poll::Decision;
+use slab::Slab;
+
+pub(crate) use crate::unix::RawOp;
+use crate::Entry;
+
+mod driver_type {
+    use std::sync::atomic::{AtomicU8, Ordering};
+
+    const UNINIT: u8 = u8::MAX;
+    const IO_URING: u8 = 0;
+    const POLLING: u8 = 1;
+
+    static DRIVER_TYPE: AtomicU8 = AtomicU8::new(UNINIT);
+
+    /// Representing underlying driver type the fusion driver is using
+    #[repr(u8)]
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    pub enum DriverType {
+        /// Using `polling` driver
+        Poll    = POLLING,
+
+        /// Using `io-uring` driver
+        IoUring = IO_URING,
+    }
+
+    impl DriverType {
+        fn from_num(n: u8) -> Self {
+            match n {
+                IO_URING => Self::IoUring,
+                POLLING => Self::Poll,
+                _ => unreachable!("invalid driver type"),
+            }
+        }
+
+        /// Get the underlying driver type
+        pub fn current() -> DriverType {
+            match DRIVER_TYPE.load(Ordering::Acquire) {
+                UNINIT => {}
+                x => return DriverType::from_num(x),
+            }
+
+            let dev_ty = if uring_available() {
+                DriverType::IoUring
+            } else {
+                DriverType::Poll
+            };
+
+            DRIVER_TYPE.store(dev_ty as u8, Ordering::Release);
+
+            dev_ty
+        }
+    }
+
+    fn uring_available() -> bool {
+        use io_uring::opcode::*;
+
+        // Add more opcodes here if used
+        const USED_OP: &[u8] = &[
+            Read::CODE,
+            Readv::CODE,
+            Write::CODE,
+            Writev::CODE,
+            Fsync::CODE,
+            Accept::CODE,
+            Connect::CODE,
+            RecvMsg::CODE,
+            SendMsg::CODE,
+            AsyncCancel::CODE,
+        ];
+
+        Ok(())
+            .and_then(|_| {
+                let uring = io_uring::IoUring::new(2)?;
+                let mut probe = io_uring::Probe::new();
+                uring.submitter().register_probe(&mut probe)?;
+                std::io::Result::Ok(USED_OP.iter().all(|op| probe.is_supported(*op)))
+            })
+            .unwrap_or(false)
+    }
+}
+
+/// Fused [`OpCode`]
+///
+/// This trait encapsulates both operation for `io-uring` and `polling`
+pub trait OpCode: poll::OpCode + iour::OpCode {}
+
+impl<T: poll::OpCode + iour::OpCode + ?Sized> OpCode for T {}
+
+#[allow(clippy::large_enum_variant)]
+enum FuseDriver {
+    Poll(poll::Driver),
+    IoUring(iour::Driver),
+}
+
+/// Low-level fusion driver.
+pub(crate) struct Driver {
+    fuse: FuseDriver,
+}
+
+impl Driver {
+    /// Create a new fusion driver with given number of entries
+    pub fn new(entries: u32) -> io::Result<Self> {
+        match DriverType::current() {
+            DriverType::Poll => Ok(Self {
+                fuse: FuseDriver::Poll(poll::Driver::new(entries)?),
+            }),
+            DriverType::IoUring => Ok(Self {
+                fuse: FuseDriver::IoUring(iour::Driver::new(entries)?),
+            }),
+        }
+    }
+
+    pub fn attach(&mut self, fd: RawFd) -> io::Result<()> {
+        match &mut self.fuse {
+            FuseDriver::Poll(driver) => driver.attach(fd),
+            FuseDriver::IoUring(driver) => driver.attach(fd),
+        }
+    }
+
+    pub fn cancel(&mut self, user_data: usize, registry: &mut Slab<RawOp>) {
+        match &mut self.fuse {
+            FuseDriver::Poll(driver) => driver.cancel(user_data, registry),
+            FuseDriver::IoUring(driver) => driver.cancel(user_data, registry),
+        }
+    }
+
+    pub fn push(&mut self, user_data: usize, op: &mut RawOp) -> Poll<io::Result<usize>> {
+        match &mut self.fuse {
+            FuseDriver::Poll(driver) => driver.push(user_data, op),
+            FuseDriver::IoUring(driver) => driver.push(user_data, op),
+        }
+    }
+
+    pub unsafe fn poll(
+        &mut self,
+        timeout: Option<Duration>,
+        entries: &mut impl Extend<Entry>,
+        registry: &mut Slab<RawOp>,
+    ) -> io::Result<()> {
+        match &mut self.fuse {
+            FuseDriver::Poll(driver) => driver.poll(timeout, entries, registry),
+            FuseDriver::IoUring(driver) => driver.poll(timeout, entries, registry),
+        }
+    }
+}
+
+impl AsRawFd for Driver {
+    fn as_raw_fd(&self) -> RawFd {
+        match &self.fuse {
+            FuseDriver::Poll(driver) => driver.as_raw_fd(),
+            FuseDriver::IoUring(driver) => driver.as_raw_fd(),
+        }
+    }
+}

--- a/compio-driver/src/fusion/op.rs
+++ b/compio-driver/src/fusion/op.rs
@@ -1,0 +1,101 @@
+use compio_buf::{IntoInner, IoBuf, IoBufMut, IoVectoredBuf, IoVectoredBufMut};
+use socket2::SockAddr;
+
+use super::*;
+pub use crate::unix::op::*;
+
+macro_rules! op {
+    (<$($ty:ident: $trait:ident),* $(,)?> $name:ident( $($arg:ident: $arg_t:ident),* $(,)? )) => {
+        ::paste::paste!{
+            enum [< $name Inner >] <$($ty: $trait),*> {
+                Poll(poll::$name<$($ty),*>),
+                IoUring(iour::$name<$($ty),*>),
+            }
+
+            impl<$($ty: $trait),*> [< $name Inner >]<$($ty),*> {
+                fn poll(&mut self) -> &mut poll::$name<$($ty),*> {
+                    debug_assert!(DriverType::current() == DriverType::Poll);
+
+                    match self {
+                        Self::Poll(ref mut op) => op,
+                        Self::IoUring(_) => unreachable!("Current driver is not `io-uring`"),
+                    }
+                }
+
+                fn iour(&mut self) -> &mut iour::$name<$($ty),*> {
+                    debug_assert!(DriverType::current() == DriverType::IoUring);
+
+                    match self {
+                        Self::IoUring(ref mut op) => op,
+                        Self::Poll(_) => unreachable!("Current driver is not `polling`"),
+                    }
+                }
+            }
+
+            #[doc = concat!("A fused `", stringify!($name), "` operation")]
+            pub struct $name <$($ty: $trait),*> {
+                inner: [< $name Inner >] <$($ty),*>
+            }
+
+            impl<$($ty: $trait),*> IntoInner for $name <$($ty),*> {
+                type Inner = <poll::$name<$($ty),*> as IntoInner>::Inner;
+
+                fn into_inner(self) -> Self::Inner {
+                    match self.inner {
+                        [< $name Inner >]::Poll(op) => op.into_inner(),
+                        [< $name Inner >]::IoUring(op) => op.into_inner(),
+                    }
+                }
+            }
+
+            impl<$($ty: $trait),*> $name <$($ty),*> {
+                #[doc = concat!("Create a new `", stringify!($name), "`.")]
+                pub fn new($($arg: $arg_t),*) -> Self {
+                    match DriverType::current() {
+                        DriverType::Poll => Self {
+                            inner: [< $name Inner >]::Poll(poll::$name::new($($arg),*)),
+                        },
+                        DriverType::IoUring => Self {
+                            inner: [< $name Inner >]::IoUring(iour::$name::new($($arg),*)),
+                        },
+                    }
+                }
+            }
+
+
+        }
+
+
+        impl<$($ty: $trait),*> poll::OpCode for $name<$($ty),*> {
+            fn pre_submit(self: std::pin::Pin<&mut Self>) -> std::io::Result<crate::Decision> {
+                unsafe { self.map_unchecked_mut(|x| x.inner.poll() ) }.pre_submit()
+            }
+
+            fn on_event(
+                self: std::pin::Pin<&mut Self>,
+                event: &polling::Event,
+            ) -> std::task::Poll<std::io::Result<usize>> {
+                unsafe { self.map_unchecked_mut(|x| x.inner.poll() ) }.on_event(event)
+            }
+        }
+
+        impl<$($ty: $trait),*> iour::OpCode for $name<$($ty),*> {
+            fn create_entry(self: std::pin::Pin<&mut Self>) -> io_uring::squeue::Entry {
+                unsafe { self.map_unchecked_mut(|x| x.inner.iour() ) }.create_entry()
+            }
+        }
+
+
+
+    };
+}
+
+#[rustfmt::skip]
+mod iour { pub use crate::sys::iour::{op::*, OpCode}; }
+#[rustfmt::skip]
+mod poll { pub use crate::sys::poll::{op::*, OpCode}; }
+
+op!(<T: IoBufMut> RecvFrom(fd: RawFd, buffer: T));
+op!(<T: IoBuf> SendTo(fd: RawFd, buffer: T, addr: SockAddr));
+op!(<T: IoVectoredBufMut> RecvFromVectored(fd: RawFd, buffer: T));
+op!(<T: IoVectoredBuf> SendToVectored(fd: RawFd, buffer: T, addr: SockAddr));

--- a/compio-driver/src/fusion/op.rs
+++ b/compio-driver/src/fusion/op.rs
@@ -61,10 +61,7 @@ macro_rules! op {
                     }
                 }
             }
-
-
         }
-
 
         impl<$($ty: $trait),*> poll::OpCode for $name<$($ty),*> {
             fn pre_submit(self: std::pin::Pin<&mut Self>) -> std::io::Result<crate::Decision> {
@@ -84,9 +81,6 @@ macro_rules! op {
                 unsafe { self.map_unchecked_mut(|x| x.inner.iour() ) }.create_entry()
             }
         }
-
-
-
     };
 }
 

--- a/compio-driver/src/iour/op.rs
+++ b/compio-driver/src/iour/op.rs
@@ -11,8 +11,9 @@ use io_uring::{
 use libc::{sockaddr_storage, socklen_t};
 use socket2::SockAddr;
 
+use super::OpCode;
+use crate::op::*;
 pub use crate::unix::op::*;
-use crate::{op::*, OpCode};
 
 impl<T: IoBufMut> OpCode for ReadAt<T> {
     fn create_entry(mut self: Pin<&mut Self>) -> Entry {

--- a/compio-driver/src/op.rs
+++ b/compio-driver/src/op.rs
@@ -14,7 +14,7 @@ pub use crate::sys::op::{
 };
 #[cfg(unix)]
 pub use crate::sys::op::{ReadVectoredAt, WriteVectoredAt};
-use crate::{sockaddr_storage, socklen_t, RawFd};
+use crate::sys::{sockaddr_storage, socklen_t, RawFd};
 
 /// Trait to update the buffer length inside the [`BufResult`].
 pub trait BufResultExt {

--- a/compio-driver/src/poll/op.rs
+++ b/compio-driver/src/poll/op.rs
@@ -10,8 +10,9 @@ use libc::{pread64 as pread, preadv64 as preadv, pwrite64 as pwrite, pwritev64 a
 use polling::Event;
 use socket2::SockAddr;
 
+use super::{sockaddr_storage, socklen_t, syscall, Decision, OpCode, RawFd};
+use crate::op::*;
 pub use crate::unix::op::*;
-use crate::{op::*, sockaddr_storage, socklen_t, syscall, Decision, OpCode, RawFd};
 
 impl<T: IoBufMut> ReadAt<T> {
     unsafe fn call(&mut self) -> libc::ssize_t {

--- a/compio-driver/src/unix/op.rs
+++ b/compio-driver/src/unix/op.rs
@@ -6,7 +6,7 @@ use socket2::SockAddr;
 
 #[cfg(doc)]
 use crate::op::*;
-use crate::RawFd;
+use crate::sys::RawFd;
 
 /// Read a file at specified position into vectored buffer.
 pub struct ReadVectoredAt<T: IoVectoredBufMut> {


### PR DESCRIPTION
This PR added fusion driver, which will be enabled when both `io-uring` and `polling` are enabled, and will determine which to use during runtime. 

However, this does bring some overhead throughout the lifetime of the driver:

- The driver is an enum internally, meaning more branching
- Several OpCodes are now enum too due to divergence between `io-uring` and `polling` implementations.
- A one-time detection will be made when the first fusion driver is instantiated

@nazar-pc what do you think?

Closes #105