### PR TITLE
feat(buf): redesign IoBufMut

### DIFF
--- a/compio-buf/src/io_buf.rs
+++ b/compio-buf/src/io_buf.rs
@@ -192,6 +192,20 @@ impl IoBuf for &'static str {
     }
 }
 
+impl<const N: usize> IoBuf for [u8; N] {
+    fn as_buf_ptr(&self) -> *const u8 {
+        self.as_ptr()
+    }
+
+    fn buf_len(&self) -> usize {
+        N
+    }
+
+    fn buf_capacity(&self) -> usize {
+        N
+    }
+}
+
 #[cfg(feature = "bytes")]
 impl IoBuf for bytes::Bytes {
     fn as_buf_ptr(&self) -> *const u8 {
@@ -289,6 +303,18 @@ pub trait IoBufMut: IoBuf + SetBufInit {
 impl<#[cfg(feature = "allocator_api")] A: Allocator + Unpin + 'static> IoBufMut
     for vec_alloc!(u8, A)
 {
+    fn as_buf_mut_ptr(&mut self) -> *mut u8 {
+        self.as_mut_ptr()
+    }
+}
+
+impl IoBufMut for &'static mut [u8] {
+    fn as_buf_mut_ptr(&mut self) -> *mut u8 {
+        self.as_mut_ptr()
+    }
+}
+
+impl<const N: usize> IoBufMut for [u8; N] {
     fn as_buf_mut_ptr(&mut self) -> *mut u8 {
         self.as_mut_ptr()
     }
@@ -549,6 +575,18 @@ impl<#[cfg(feature = "allocator_api")] A: Allocator + Unpin + 'static> SetBufIni
         if self.buf_len() < len {
             self.set_len(len);
         }
+    }
+}
+
+impl SetBufInit for &'static mut [u8] {
+    unsafe fn set_buf_init(&mut self, len: usize) {
+        debug_assert!(len <= self.len());
+    }
+}
+
+impl<const N: usize> SetBufInit for [u8; N] {
+    unsafe fn set_buf_init(&mut self, len: usize) {
+        debug_assert!(len <= N);
     }
 }
 

--- a/compio-buf/src/io_buf.rs
+++ b/compio-buf/src/io_buf.rs
@@ -560,7 +560,7 @@ impl<T: IoBufMut, const N: usize> IoIndexedBufMut for arrayvec::ArrayVec<T, N> {
 /// A helper trait for `set_len` like methods.
 pub trait SetBufInit {
     /// Set the buffer length. If `len` is less than the current length, nothing
-    /// will happen.
+    /// should happen.
     ///
     /// # Safety
     ///

--- a/compio-buf/src/iter.rs
+++ b/compio-buf/src/iter.rs
@@ -42,7 +42,7 @@ impl<I: OwnedIterator> IntoInner for OwnedIter<I> {
     }
 }
 
-unsafe impl<I: OwnedIterator + Unpin + 'static> IoBuf for OwnedIter<I> {
+impl<I: OwnedIterator + Unpin + 'static> IoBuf for OwnedIter<I> {
     fn as_buf_ptr(&self) -> *const u8 {
         self.0.current().as_buf_ptr()
     }
@@ -56,7 +56,7 @@ unsafe impl<I: OwnedIterator + Unpin + 'static> IoBuf for OwnedIter<I> {
     }
 }
 
-unsafe impl<I: OwnedIteratorMut + Unpin + 'static> IoBufMut for OwnedIter<I> {
+impl<I: OwnedIteratorMut + Unpin + 'static> IoBufMut for OwnedIter<I> {
     fn as_buf_mut_ptr(&mut self) -> *mut u8 {
         self.0.current_mut().as_buf_mut_ptr()
     }

--- a/compio-buf/src/slice.rs
+++ b/compio-buf/src/slice.rs
@@ -80,7 +80,7 @@ impl<T: IoBufMut> DerefMut for Slice<T> {
     }
 }
 
-unsafe impl<T: IoBuf> IoBuf for Slice<T> {
+impl<T: IoBuf> IoBuf for Slice<T> {
     fn as_buf_ptr(&self) -> *const u8 {
         self.buffer.as_slice()[self.begin..].as_ptr()
     }
@@ -94,7 +94,7 @@ unsafe impl<T: IoBuf> IoBuf for Slice<T> {
     }
 }
 
-unsafe impl<T: IoBufMut> IoBufMut for Slice<T> {
+impl<T: IoBufMut> IoBufMut for Slice<T> {
     fn as_buf_mut_ptr(&mut self) -> *mut u8 {
         slice_mut(&mut self.buffer)[self.begin..].as_mut_ptr()
     }
@@ -102,7 +102,7 @@ unsafe impl<T: IoBufMut> IoBufMut for Slice<T> {
 
 impl<T: SetBufInit> SetBufInit for Slice<T> {
     unsafe fn set_buf_init(&mut self, len: usize) {
-        self.buffer.set_buf_init(len)
+        self.buffer.set_buf_init(self.begin + len)
     }
 }
 

--- a/compio-driver/src/iocp/op.rs
+++ b/compio-driver/src/iocp/op.rs
@@ -108,7 +108,7 @@ impl<T: IoBufMut> OpCode for ReadAt<T> {
             overlapped.Anonymous.Anonymous.OffsetHigh = (self.offset >> 32) as _;
         }
         let fd = self.fd as _;
-        let slice = self.buffer.as_uninit_slice();
+        let slice = self.buffer.as_mut_slice();
         let mut transferred = 0;
         let res = ReadFile(
             fd,
@@ -321,7 +321,7 @@ impl<T: IoBufMut> IntoInner for Recv<T> {
 impl<T: IoBufMut> OpCode for Recv<T> {
     unsafe fn operate(mut self: Pin<&mut Self>, optr: *mut OVERLAPPED) -> Poll<io::Result<usize>> {
         let fd = self.fd as _;
-        let slice = self.buffer.as_uninit_slice();
+        let slice = self.buffer.as_mut_slice();
         let mut transferred = 0;
         let res = ReadFile(
             fd,

--- a/compio-driver/src/iour/op.rs
+++ b/compio-driver/src/iour/op.rs
@@ -18,7 +18,7 @@ pub use crate::unix::op::*;
 impl<T: IoBufMut> OpCode for ReadAt<T> {
     fn create_entry(mut self: Pin<&mut Self>) -> Entry {
         let fd = Fd(self.fd);
-        let slice = self.buffer.as_uninit_slice();
+        let slice = self.buffer.as_mut_slice();
         opcode::Read::new(fd, slice.as_mut_ptr() as _, slice.len() as _)
             .offset(self.offset)
             .build()
@@ -92,7 +92,7 @@ impl OpCode for Connect {
 impl<T: IoBufMut> OpCode for Recv<T> {
     fn create_entry(mut self: Pin<&mut Self>) -> Entry {
         let fd = self.fd;
-        let slice = self.buffer.as_uninit_slice();
+        let slice = self.buffer.as_mut_slice();
         opcode::Read::new(Fd(fd), slice.as_mut_ptr() as _, slice.len() as _).build()
     }
 }

--- a/compio-driver/src/poll/op.rs
+++ b/compio-driver/src/poll/op.rs
@@ -17,7 +17,7 @@ pub use crate::unix::op::*;
 impl<T: IoBufMut> ReadAt<T> {
     unsafe fn call(&mut self) -> libc::ssize_t {
         let fd = self.fd;
-        let slice = self.buffer.as_uninit_slice();
+        let slice = self.buffer.as_mut_slice();
         pread(
             fd,
             slice.as_mut_ptr() as _,
@@ -199,7 +199,7 @@ impl<T: IoBufMut> OpCode for Recv<T> {
         debug_assert!(event.readable);
 
         let fd = self.fd;
-        let slice = self.buffer.as_uninit_slice();
+        let slice = self.buffer.as_mut_slice();
         syscall!(break libc::read(fd, slice.as_mut_ptr() as _, slice.len()))
     }
 }
@@ -264,7 +264,7 @@ impl<T: IoBufMut> RecvFrom<T> {
 
     unsafe fn call(&mut self) -> libc::ssize_t {
         let fd = self.fd;
-        let slice = self.buffer.as_uninit_slice();
+        let slice = self.buffer.as_mut_slice();
         libc::recvfrom(
             fd,
             slice.as_mut_ptr() as _,

--- a/compio-io/src/buffer.rs
+++ b/compio-io/src/buffer.rs
@@ -35,7 +35,7 @@ impl Inner {
     }
 }
 
-unsafe impl IoBuf for Inner {
+impl IoBuf for Inner {
     #[inline]
     fn as_buf_ptr(&self) -> *const u8 {
         self.buf.as_ptr()
@@ -55,11 +55,11 @@ unsafe impl IoBuf for Inner {
 impl SetBufInit for Inner {
     #[inline]
     unsafe fn set_buf_init(&mut self, len: usize) {
-        self.buf.set_len(len);
+        self.buf.set_buf_init(len);
     }
 }
 
-unsafe impl IoBufMut for Inner {
+impl IoBufMut for Inner {
     #[inline]
     fn as_buf_mut_ptr(&mut self) -> *mut u8 {
         self.buf.as_mut_ptr()

--- a/compio-io/src/read/ext.rs
+++ b/compio-io/src/read/ext.rs
@@ -116,14 +116,14 @@ macro_rules! loop_read_to_end {
         let mut $tracker: $tracker_ty = 0;
         let mut read;
         loop {
+            if $buf.len() == $buf.capacity() {
+                $buf.reserve(32);
+            }
             (read, $buf) = buf_try!($read_expr.await.into_inner());
             if read == 0 {
                 break;
             } else {
                 $tracker += read as $tracker_ty;
-                if $buf.len() == $buf.capacity() {
-                    $buf.reserve(32);
-                }
             }
         }
         BufResult(Ok($tracker as usize), $buf)

--- a/compio-io/src/read/mod.rs
+++ b/compio-io/src/read/mod.rs
@@ -1,6 +1,6 @@
 use std::{io::Cursor, rc::Rc, sync::Arc};
 
-use compio_buf::{buf_try, BufResult, IntoInner, IoBufMut, IoVectoredBufMut};
+use compio_buf::{buf_try, BufResult, IntoInner, IoBuf, IoBufMut, IoVectoredBufMut};
 
 mod buf;
 #[macro_use]

--- a/compio-io/src/util/internal.rs
+++ b/compio-io/src/util/internal.rs
@@ -14,7 +14,7 @@ pub(crate) fn slice_to_uninit(src: &[u8], dst: &mut [MaybeUninit<u8>]) -> usize 
 /// Copy the contents of a slice into a buffer implementing [`IoBufMut`].
 #[inline]
 pub(crate) fn slice_to_buf<B: IoBufMut + ?Sized>(src: &[u8], buf: &mut B) -> usize {
-    let len = slice_to_uninit(src, buf.as_uninit_slice());
+    let len = slice_to_uninit(src, buf.as_mut_slice());
     unsafe { buf.set_buf_init(len) };
 
     len

--- a/compio-io/src/util/repeat.rs
+++ b/compio-io/src/util/repeat.rs
@@ -31,7 +31,7 @@ impl AsyncRead for Repeat {
         &mut self,
         mut buf: B,
     ) -> compio_buf::BufResult<usize, B> {
-        let slice = buf.as_uninit_slice();
+        let slice = buf.as_mut_slice();
 
         let len = slice.len();
         slice.fill(MaybeUninit::new(self.0));

--- a/compio/tests/io.rs
+++ b/compio/tests/io.rs
@@ -1,7 +1,13 @@
 use std::io::Cursor;
 
-use compio_buf::arrayvec::ArrayVec;
-use compio_io::{AsyncRead, AsyncReadAt, AsyncWrite, AsyncWriteAt};
+use compio::{
+    buf::{arrayvec::ArrayVec, IoBuf, IoBufMut},
+    io::{
+        AsyncRead, AsyncReadAt, AsyncReadAtExt, AsyncReadExt, AsyncWrite, AsyncWriteAt,
+        AsyncWriteAtExt, AsyncWriteExt,
+    },
+    BufResult,
+};
 
 #[compio_macros::test]
 async fn io_read() {
@@ -158,4 +164,180 @@ async fn writev_at() {
 
     assert_eq!(len, 3);
     assert_eq!(dst, [0, 0, 1, 1, 4]);
+}
+
+struct RepeatOne(u8);
+
+impl AsyncRead for RepeatOne {
+    async fn read<B: IoBufMut>(&mut self, mut buf: B) -> compio_buf::BufResult<usize, B> {
+        let slice = buf.as_mut_slice();
+        if !slice.is_empty() {
+            slice[0].write(self.0);
+            unsafe { buf.set_buf_init(1) };
+            BufResult(Ok(1), buf)
+        } else {
+            BufResult(Ok(0), buf)
+        }
+    }
+}
+
+impl AsyncReadAt for RepeatOne {
+    async fn read_at<T: IoBufMut>(&self, mut buf: T, pos: u64) -> BufResult<usize, T> {
+        let slice = buf.as_mut_slice();
+        if !slice.is_empty() {
+            if pos == 0 {
+                slice[0].write(0);
+            } else {
+                slice[0].write(self.0);
+            }
+            unsafe { buf.set_buf_init(1) };
+            BufResult(Ok(1), buf)
+        } else {
+            BufResult(Ok(0), buf)
+        }
+    }
+}
+
+#[compio_macros::test]
+async fn read_exact() {
+    let mut src = RepeatOne(114);
+
+    let (len, buf) = src.read_exact(Vec::with_capacity(5)).await.unwrap();
+    assert_eq!(len, 5);
+    assert_eq!(buf, [114; 5]);
+
+    let (len, buf) = src.read_exact_at(Vec::with_capacity(5), 0).await.unwrap();
+    assert_eq!(len, 5);
+    assert_eq!(buf, [0, 114, 114, 114, 114]);
+}
+
+struct WriteOne(Vec<u8>);
+
+impl AsyncWrite for WriteOne {
+    async fn write<T: IoBuf>(&mut self, buf: T) -> BufResult<usize, T> {
+        let slice = buf.as_slice();
+        if !slice.is_empty() {
+            self.0.push(slice[0]);
+            BufResult(Ok(1), buf)
+        } else {
+            BufResult(Ok(0), buf)
+        }
+    }
+
+    async fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+
+    async fn shutdown(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+impl AsyncWriteAt for WriteOne {
+    async fn write_at<T: IoBuf>(&mut self, buf: T, pos: u64) -> BufResult<usize, T> {
+        let pos = pos as usize;
+        if pos > self.0.len() {
+            BufResult(
+                Err(std::io::Error::new(
+                    std::io::ErrorKind::InvalidInput,
+                    "invalid position",
+                )),
+                buf,
+            )
+        } else {
+            let slice = buf.as_slice();
+            if !slice.is_empty() {
+                if pos == self.0.len() {
+                    self.0.push(slice[0]);
+                } else {
+                    self.0[pos] = slice[0];
+                }
+                BufResult(Ok(1), buf)
+            } else {
+                BufResult(Ok(0), buf)
+            }
+        }
+    }
+}
+
+#[compio_macros::test]
+async fn write_all() {
+    let mut dst = WriteOne(vec![]);
+
+    let (len, _) = dst.write_all([1, 1, 4, 5, 1, 4]).await.unwrap();
+    assert_eq!(len, 6);
+    assert_eq!(dst.0, [1, 1, 4, 5, 1, 4]);
+
+    let (len, _) = dst.write_all_at([114, 114, 114], 2).await.unwrap();
+    assert_eq!(len, 3);
+    assert_eq!(dst.0, [1, 1, 114, 114, 114, 4]);
+}
+
+struct ReadOne(Cursor<Vec<u8>>);
+
+impl AsyncRead for ReadOne {
+    async fn read<B: IoBufMut>(&mut self, mut buf: B) -> BufResult<usize, B> {
+        let slice = buf.as_mut_slice();
+        if !slice.is_empty() {
+            let ob = [0];
+            match self.0.read(ob).await {
+                BufResult(Ok(res), ob) => {
+                    if res == 0 {
+                        BufResult(Ok(0), buf)
+                    } else {
+                        slice[0].write(ob[0]);
+                        unsafe { buf.set_buf_init(1) };
+                        BufResult(Ok(1), buf)
+                    }
+                }
+                BufResult(Err(e), _) => BufResult(Err(e), buf),
+            }
+        } else {
+            BufResult(Ok(0), buf)
+        }
+    }
+}
+
+#[compio_macros::test]
+async fn read_to_end() {
+    let mut src = ReadOne(Cursor::new(vec![1, 1, 4, 5, 1, 4]));
+
+    let (len, buf) = src.read_to_end(vec![]).await.unwrap();
+    assert_eq!(len, 6);
+    assert_eq!(buf, [1, 1, 4, 5, 1, 4]);
+}
+
+struct ReadOneAt(Vec<u8>);
+
+impl AsyncReadAt for ReadOneAt {
+    async fn read_at<T: IoBufMut>(&self, mut buf: T, pos: u64) -> BufResult<usize, T> {
+        let pos = pos as usize;
+        if pos > self.0.len() {
+            BufResult(
+                Err(std::io::Error::new(
+                    std::io::ErrorKind::InvalidInput,
+                    "invalid position",
+                )),
+                buf,
+            )
+        } else {
+            let slice = buf.as_mut_slice();
+            if !slice.is_empty() && pos < self.0.len() {
+                slice[0].write(self.0[pos]);
+                unsafe { buf.set_buf_init(1) };
+                BufResult(Ok(1), buf)
+            } else {
+                BufResult(Ok(0), buf)
+            }
+        }
+    }
+}
+
+#[compio_macros::test]
+async fn read_to_end_at() {
+    let src = ReadOneAt(vec![1, 1, 4, 5, 1, 4]);
+
+    let (len, buf) = src.read_to_end_at(vec![], 2).await.unwrap();
+    assert_eq!(len, 4);
+    assert_eq!(buf, [4, 5, 1, 4]);
 }

--- a/compio/tests/io.rs
+++ b/compio/tests/io.rs
@@ -6,15 +6,15 @@ use compio_io::{AsyncRead, AsyncReadAt, AsyncWrite, AsyncWriteAt};
 #[compio_macros::test]
 async fn io_read() {
     let mut src = "Hello, World";
-    let (len, buf) = src.read(Vec::with_capacity(10)).await.unwrap();
+    let (len, buf) = src.read(vec![1; 10]).await.unwrap();
 
     assert_eq!(len, 10);
     assert_eq!(buf, b"Hello, Wor");
 
-    let (len, buf) = src.read(Vec::with_capacity(20)).await.unwrap();
+    let (len, buf) = src.read(vec![0; 20]).await.unwrap();
     assert_eq!(len, 12);
-    assert_eq!(buf.len(), 12);
-    assert_eq!(buf, b"Hello, World");
+    assert_eq!(buf.len(), 20);
+    assert_eq!(&buf[..12], b"Hello, World");
 }
 
 #[compio_macros::test]
@@ -78,7 +78,7 @@ async fn readv() {
     assert_eq!(buf[1], b", wor");
 
     let (len, buf) = src
-        .read_vectored([Vec::with_capacity(5), Vec::with_capacity(10)])
+        .read_vectored([vec![0; 5], Vec::with_capacity(10)])
         .await
         .unwrap();
     assert_eq!(len, 12);
@@ -130,7 +130,7 @@ async fn readv_at() {
     assert!(buf[1].is_empty());
 
     let (len, buf) = SRC
-        .read_vectored_at([Vec::with_capacity(3), Vec::with_capacity(1)], 2)
+        .read_vectored_at([vec![0; 3], Vec::with_capacity(1)], 2)
         .await
         .unwrap();
 

--- a/compio/tests/io.rs
+++ b/compio/tests/io.rs
@@ -169,7 +169,7 @@ async fn writev_at() {
 struct RepeatOne(u8);
 
 impl AsyncRead for RepeatOne {
-    async fn read<B: IoBufMut>(&mut self, mut buf: B) -> compio_buf::BufResult<usize, B> {
+    async fn read<B: IoBufMut>(&mut self, mut buf: B) -> BufResult<usize, B> {
         let slice = buf.as_mut_slice();
         if !slice.is_empty() {
             slice[0].write(self.0);

--- a/compio/tests/runtime.rs
+++ b/compio/tests/runtime.rs
@@ -77,7 +77,7 @@ async fn drop_on_complete() {
         _ref_cnt: Arc<()>,
     }
 
-    unsafe impl IoBuf for MyBuf {
+    impl IoBuf for MyBuf {
         fn as_buf_ptr(&self) -> *const u8 {
             self.data.as_buf_ptr()
         }
@@ -91,7 +91,7 @@ async fn drop_on_complete() {
         }
     }
 
-    unsafe impl IoBufMut for MyBuf {
+    impl IoBufMut for MyBuf {
         fn as_buf_mut_ptr(&mut self) -> *mut u8 {
             self.data.as_buf_mut_ptr()
         }


### PR DESCRIPTION
According to complains, we need to redesign IoBufMut and read series methods. Now these methods read data into both init and uninit region of the buffer.

Closes #113 
Closes #107 

/cc @George-Miao @nazar-pc