### PR TITLE
feat(fs, net): add impl for &T

### DIFF
--- a/compio-fs/src/file.rs
+++ b/compio-fs/src/file.rs
@@ -161,6 +161,24 @@ impl AsyncReadAt for File {
 
 #[cfg(feature = "runtime")]
 impl AsyncWriteAt for File {
+    #[inline]
+    async fn write_at<T: IoBuf>(&mut self, buf: T, pos: u64) -> BufResult<usize, T> {
+        (&*self).write_at(buf, pos).await
+    }
+
+    #[cfg(unix)]
+    #[inline]
+    async fn write_vectored_at<T: IoVectoredBuf>(
+        &mut self,
+        buf: T,
+        pos: u64,
+    ) -> BufResult<usize, T> {
+        (&*self).write_vectored_at(buf, pos).await
+    }
+}
+
+#[cfg(feature = "runtime")]
+impl AsyncWriteAt for &File {
     async fn write_at<T: IoBuf>(&mut self, buffer: T, pos: u64) -> BufResult<usize, T> {
         let ((), buffer) = buf_try!(self.attach(), buffer);
         let op = WriteAt::new(self.as_raw_fd(), pos, buffer);

--- a/compio-fs/src/file.rs
+++ b/compio-fs/src/file.rs
@@ -106,7 +106,7 @@ impl File {
     }
 
     #[cfg(feature = "runtime")]
-    async fn sync_impl(&mut self, datasync: bool) -> io::Result<()> {
+    async fn sync_impl(&self, datasync: bool) -> io::Result<()> {
         self.attach()?;
         let op = Sync::new(self.as_raw_fd(), datasync);
         submit(op).await.0?;
@@ -118,7 +118,7 @@ impl File {
     /// This function will attempt to ensure that all in-memory data reaches the
     /// filesystem before returning.
     #[cfg(feature = "runtime")]
-    pub async fn sync_all(&mut self) -> io::Result<()> {
+    pub async fn sync_all(&self) -> io::Result<()> {
         self.sync_impl(false).await
     }
 
@@ -134,7 +134,7 @@ impl File {
     ///
     /// [`sync_all`]: File::sync_all
     #[cfg(feature = "runtime")]
-    pub async fn sync_data(&mut self) -> io::Result<()> {
+    pub async fn sync_data(&self) -> io::Result<()> {
         self.sync_impl(true).await
     }
 }

--- a/compio-fs/src/named_pipe.rs
+++ b/compio-fs/src/named_pipe.rs
@@ -209,6 +209,15 @@ impl NamedPipeServer {
 
 #[cfg(feature = "runtime")]
 impl AsyncRead for NamedPipeServer {
+    #[inline]
+    async fn read<B: IoBufMut>(&mut self, buf: B) -> BufResult<usize, B> {
+        (&*self).read(buf).await
+    }
+}
+
+#[cfg(feature = "runtime")]
+impl AsyncRead for &NamedPipeServer {
+    #[inline]
     async fn read<B: IoBufMut>(&mut self, buffer: B) -> BufResult<usize, B> {
         // The position is ignored.
         self.handle.read_at(buffer, 0).await
@@ -217,15 +226,36 @@ impl AsyncRead for NamedPipeServer {
 
 #[cfg(feature = "runtime")]
 impl AsyncWrite for NamedPipeServer {
-    async fn write<T: IoBuf>(&mut self, buffer: T) -> BufResult<usize, T> {
-        // The position is ignored.
-        self.handle.write_at(buffer, 0).await
+    #[inline]
+    async fn write<T: IoBuf>(&mut self, buf: T) -> BufResult<usize, T> {
+        (&*self).write(buf).await
     }
 
+    #[inline]
+    async fn flush(&mut self) -> io::Result<()> {
+        (&*self).flush().await
+    }
+
+    #[inline]
+    async fn shutdown(&mut self) -> io::Result<()> {
+        (&*self).shutdown().await
+    }
+}
+
+#[cfg(feature = "runtime")]
+impl AsyncWrite for &NamedPipeServer {
+    #[inline]
+    async fn write<T: IoBuf>(&mut self, buffer: T) -> BufResult<usize, T> {
+        // The position is ignored.
+        (&self.handle).write_at(buffer, 0).await
+    }
+
+    #[inline]
     async fn flush(&mut self) -> io::Result<()> {
         Ok(())
     }
 
+    #[inline]
     async fn shutdown(&mut self) -> io::Result<()> {
         Ok(())
     }
@@ -320,6 +350,15 @@ impl NamedPipeClient {
 
 #[cfg(feature = "runtime")]
 impl AsyncRead for NamedPipeClient {
+    #[inline]
+    async fn read<B: IoBufMut>(&mut self, buf: B) -> BufResult<usize, B> {
+        (&*self).read(buf).await
+    }
+}
+
+#[cfg(feature = "runtime")]
+impl AsyncRead for &NamedPipeClient {
+    #[inline]
     async fn read<B: IoBufMut>(&mut self, buffer: B) -> BufResult<usize, B> {
         // The position is ignored.
         self.handle.read_at(buffer, 0).await
@@ -328,15 +367,36 @@ impl AsyncRead for NamedPipeClient {
 
 #[cfg(feature = "runtime")]
 impl AsyncWrite for NamedPipeClient {
-    async fn write<T: IoBuf>(&mut self, buffer: T) -> BufResult<usize, T> {
-        // The position is ignored.
-        self.handle.write_at(buffer, 0).await
+    #[inline]
+    async fn write<T: IoBuf>(&mut self, buf: T) -> BufResult<usize, T> {
+        (&*self).write(buf).await
     }
 
+    #[inline]
+    async fn flush(&mut self) -> io::Result<()> {
+        (&*self).flush().await
+    }
+
+    #[inline]
+    async fn shutdown(&mut self) -> io::Result<()> {
+        (&*self).shutdown().await
+    }
+}
+
+#[cfg(feature = "runtime")]
+impl AsyncWrite for &NamedPipeClient {
+    #[inline]
+    async fn write<T: IoBuf>(&mut self, buffer: T) -> BufResult<usize, T> {
+        // The position is ignored.
+        (&self.handle).write_at(buffer, 0).await
+    }
+
+    #[inline]
     async fn flush(&mut self) -> io::Result<()> {
         Ok(())
     }
 
+    #[inline]
     async fn shutdown(&mut self) -> io::Result<()> {
         Ok(())
     }

--- a/compio-net/src/lib.rs
+++ b/compio-net/src/lib.rs
@@ -13,9 +13,9 @@ mod udp;
 mod unix;
 
 #[cfg(feature = "runtime")]
-pub(crate) use resolve::each_addr;
-#[cfg(feature = "runtime")]
 pub use resolve::ToSocketAddrsAsync;
+#[cfg(feature = "runtime")]
+pub(crate) use resolve::{each_addr, first_addr_buf};
 pub(crate) use socket::*;
 pub use tcp::*;
 pub use udp::*;

--- a/compio-net/src/tcp.rs
+++ b/compio-net/src/tcp.rs
@@ -204,31 +204,73 @@ impl TcpStream {
 
 #[cfg(feature = "runtime")]
 impl AsyncRead for TcpStream {
+    #[inline]
     async fn read<B: IoBufMut>(&mut self, buf: B) -> BufResult<usize, B> {
-        self.inner.read(buf).await
+        (&*self).read(buf).await
     }
 
+    #[inline]
     async fn read_vectored<V: IoVectoredBufMut>(&mut self, buf: V) -> BufResult<usize, V> {
-        self.inner.read_vectored(buf).await
+        (&*self).read_vectored(buf).await
+    }
+}
+
+#[cfg(feature = "runtime")]
+impl AsyncRead for &TcpStream {
+    #[inline]
+    async fn read<B: IoBufMut>(&mut self, buf: B) -> BufResult<usize, B> {
+        self.inner.recv(buf).await
+    }
+
+    #[inline]
+    async fn read_vectored<V: IoVectoredBufMut>(&mut self, buf: V) -> BufResult<usize, V> {
+        self.inner.recv_vectored(buf).await
     }
 }
 
 #[cfg(feature = "runtime")]
 impl AsyncWrite for TcpStream {
+    #[inline]
     async fn write<T: IoBuf>(&mut self, buf: T) -> BufResult<usize, T> {
-        self.inner.write(buf).await
+        (&*self).write(buf).await
     }
 
+    #[inline]
     async fn write_vectored<T: IoVectoredBuf>(&mut self, buf: T) -> BufResult<usize, T> {
-        self.inner.write_vectored(buf).await
+        (&*self).write_vectored(buf).await
     }
 
+    #[inline]
     async fn flush(&mut self) -> io::Result<()> {
-        self.inner.flush().await
+        (&*self).flush().await
     }
 
+    #[inline]
     async fn shutdown(&mut self) -> io::Result<()> {
-        self.inner.shutdown().await
+        (&*self).shutdown().await
+    }
+}
+
+#[cfg(feature = "runtime")]
+impl AsyncWrite for &TcpStream {
+    #[inline]
+    async fn write<T: IoBuf>(&mut self, buf: T) -> BufResult<usize, T> {
+        self.inner.send(buf).await
+    }
+
+    #[inline]
+    async fn write_vectored<T: IoVectoredBuf>(&mut self, buf: T) -> BufResult<usize, T> {
+        self.inner.send_vectored(buf).await
+    }
+
+    #[inline]
+    async fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+
+    #[inline]
+    async fn shutdown(&mut self) -> io::Result<()> {
+        self.inner.shutdown()
     }
 }
 

--- a/compio-net/src/udp.rs
+++ b/compio-net/src/udp.rs
@@ -5,7 +5,6 @@ use compio_driver::impl_raw_fd;
 use {
     crate::ToSocketAddrsAsync,
     compio_buf::{buf_try, BufResult, IoBuf, IoBufMut, IoVectoredBuf, IoVectoredBufMut},
-    compio_io::{AsyncRead, AsyncWrite},
     compio_runtime::impl_attachable,
     socket2::{Protocol, SockAddr, Type},
 };
@@ -190,35 +189,35 @@ impl UdpSocket {
     /// Receives a packet of data from the socket into the buffer, returning the
     /// original buffer and quantity of data received.
     #[cfg(feature = "runtime")]
-    pub async fn recv<T: IoBufMut>(&mut self, buffer: T) -> BufResult<usize, T> {
-        self.inner.read(buffer).await
+    pub async fn recv<T: IoBufMut>(&self, buffer: T) -> BufResult<usize, T> {
+        self.inner.recv(buffer).await
     }
 
     /// Receives a packet of data from the socket into the buffer, returning the
     /// original buffer and quantity of data received.
     #[cfg(feature = "runtime")]
-    pub async fn recv_vectored<T: IoVectoredBufMut>(&mut self, buffer: T) -> BufResult<usize, T> {
-        self.inner.read_vectored(buffer).await
+    pub async fn recv_vectored<T: IoVectoredBufMut>(&self, buffer: T) -> BufResult<usize, T> {
+        self.inner.recv_vectored(buffer).await
     }
 
     /// Sends some data to the socket from the buffer, returning the original
     /// buffer and quantity of data sent.
     #[cfg(feature = "runtime")]
-    pub async fn send<T: IoBuf>(&mut self, buffer: T) -> BufResult<usize, T> {
-        self.inner.write(buffer).await
+    pub async fn send<T: IoBuf>(&self, buffer: T) -> BufResult<usize, T> {
+        self.inner.send(buffer).await
     }
 
     /// Sends some data to the socket from the buffer, returning the original
     /// buffer and quantity of data sent.
     #[cfg(feature = "runtime")]
-    pub async fn send_vectored<T: IoVectoredBuf>(&mut self, buffer: T) -> BufResult<usize, T> {
-        self.inner.write_vectored(buffer).await
+    pub async fn send_vectored<T: IoVectoredBuf>(&self, buffer: T) -> BufResult<usize, T> {
+        self.inner.send_vectored(buffer).await
     }
 
     /// Receives a single datagram message on the socket. On success, returns
     /// the number of bytes received and the origin.
     #[cfg(feature = "runtime")]
-    pub async fn recv_from<T: IoBufMut>(&mut self, buffer: T) -> BufResult<(usize, SocketAddr), T> {
+    pub async fn recv_from<T: IoBufMut>(&self, buffer: T) -> BufResult<(usize, SocketAddr), T> {
         self.inner
             .recv_from(buffer)
             .await
@@ -229,7 +228,7 @@ impl UdpSocket {
     /// the number of bytes received and the origin.
     #[cfg(feature = "runtime")]
     pub async fn recv_from_vectored<T: IoVectoredBufMut>(
-        &mut self,
+        &self,
         buffer: T,
     ) -> BufResult<(usize, SocketAddr), T> {
         self.inner
@@ -242,7 +241,7 @@ impl UdpSocket {
     /// number of bytes sent.
     #[cfg(feature = "runtime")]
     pub async fn send_to<T: IoBuf>(
-        &mut self,
+        &self,
         buffer: T,
         addr: impl ToSocketAddrsAsync,
     ) -> BufResult<usize, T> {
@@ -265,7 +264,7 @@ impl UdpSocket {
     /// number of bytes sent.
     #[cfg(feature = "runtime")]
     pub async fn send_to_vectored<T: IoVectoredBuf>(
-        &mut self,
+        &self,
         buffer: T,
         addr: impl ToSocketAddrsAsync,
     ) -> BufResult<usize, T> {

--- a/compio-net/src/unix.rs
+++ b/compio-net/src/unix.rs
@@ -157,31 +157,73 @@ impl UnixStream {
 
 #[cfg(feature = "runtime")]
 impl AsyncRead for UnixStream {
+    #[inline]
     async fn read<B: IoBufMut>(&mut self, buf: B) -> BufResult<usize, B> {
-        self.inner.read(buf).await
+        (&*self).read(buf).await
     }
 
+    #[inline]
     async fn read_vectored<V: IoVectoredBufMut>(&mut self, buf: V) -> BufResult<usize, V> {
-        self.inner.read_vectored(buf).await
+        (&*self).read_vectored(buf).await
+    }
+}
+
+#[cfg(feature = "runtime")]
+impl AsyncRead for &UnixStream {
+    #[inline]
+    async fn read<B: IoBufMut>(&mut self, buf: B) -> BufResult<usize, B> {
+        self.inner.recv(buf).await
+    }
+
+    #[inline]
+    async fn read_vectored<V: IoVectoredBufMut>(&mut self, buf: V) -> BufResult<usize, V> {
+        self.inner.recv_vectored(buf).await
     }
 }
 
 #[cfg(feature = "runtime")]
 impl AsyncWrite for UnixStream {
+    #[inline]
     async fn write<T: IoBuf>(&mut self, buf: T) -> BufResult<usize, T> {
-        self.inner.write(buf).await
+        (&*self).write(buf).await
     }
 
+    #[inline]
     async fn write_vectored<T: IoVectoredBuf>(&mut self, buf: T) -> BufResult<usize, T> {
-        self.inner.write_vectored(buf).await
+        (&*self).write_vectored(buf).await
     }
 
+    #[inline]
     async fn flush(&mut self) -> io::Result<()> {
-        self.inner.flush().await
+        (&*self).flush().await
     }
 
+    #[inline]
     async fn shutdown(&mut self) -> io::Result<()> {
-        self.inner.shutdown().await
+        (&*self).shutdown().await
+    }
+}
+
+#[cfg(feature = "runtime")]
+impl AsyncWrite for &UnixStream {
+    #[inline]
+    async fn write<T: IoBuf>(&mut self, buf: T) -> BufResult<usize, T> {
+        self.inner.send(buf).await
+    }
+
+    #[inline]
+    async fn write_vectored<T: IoVectoredBuf>(&mut self, buf: T) -> BufResult<usize, T> {
+        self.inner.send_vectored(buf).await
+    }
+
+    #[inline]
+    async fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+
+    #[inline]
+    async fn shutdown(&mut self) -> io::Result<()> {
+        self.inner.shutdown()
     }
 }
 

--- a/compio/benches/net.rs
+++ b/compio/benches/net.rs
@@ -106,9 +106,9 @@ fn udp(c: &mut Criterion) {
 
     group.bench_function("compio", |b| {
         b.to_async(CompioRuntime).iter(|| async {
-            let mut rx = compio::net::UdpSocket::bind("127.0.0.1:0").await.unwrap();
+            let rx = compio::net::UdpSocket::bind("127.0.0.1:0").await.unwrap();
             let addr_rx = rx.local_addr().unwrap();
-            let mut tx = compio::net::UdpSocket::bind("127.0.0.1:0").await.unwrap();
+            let tx = compio::net::UdpSocket::bind("127.0.0.1:0").await.unwrap();
             let addr_tx = tx.local_addr().unwrap();
 
             rx.connect(addr_tx).await.unwrap();

--- a/compio/tests/udp.rs
+++ b/compio/tests/udp.rs
@@ -4,10 +4,10 @@ use compio::net::UdpSocket;
 async fn connect() {
     const MSG: &str = "foo bar baz";
 
-    let mut passive = UdpSocket::bind("127.0.0.1:0").await.unwrap();
+    let passive = UdpSocket::bind("127.0.0.1:0").await.unwrap();
     let passive_addr = passive.local_addr().unwrap();
 
-    let mut active = UdpSocket::bind("127.0.0.1:0").await.unwrap();
+    let active = UdpSocket::bind("127.0.0.1:0").await.unwrap();
     let active_addr = active.local_addr().unwrap();
 
     active.connect(passive_addr).await.unwrap();
@@ -31,19 +31,19 @@ async fn send_to() {
         };
     }
 
-    let mut passive1 = UdpSocket::bind("127.0.0.1:0").await.unwrap();
+    let passive1 = UdpSocket::bind("127.0.0.1:0").await.unwrap();
     let passive1_addr = passive1.local_addr().unwrap();
 
     let passive01 = std::net::UdpSocket::bind("127.0.0.1:0").unwrap();
     let passive01_addr = passive01.local_addr().unwrap();
 
-    let mut passive2 = UdpSocket::bind("127.0.0.1:0").await.unwrap();
+    let passive2 = UdpSocket::bind("127.0.0.1:0").await.unwrap();
     let passive2_addr = passive2.local_addr().unwrap();
 
-    let mut passive3 = UdpSocket::bind("127.0.0.1:0").await.unwrap();
+    let passive3 = UdpSocket::bind("127.0.0.1:0").await.unwrap();
     let passive3_addr = passive3.local_addr().unwrap();
 
-    let mut active = UdpSocket::bind("127.0.0.1:0").await.unwrap();
+    let active = UdpSocket::bind("127.0.0.1:0").await.unwrap();
     let active_addr = active.local_addr().unwrap();
 
     active.send_to(MSG, &passive01_addr).await.0.unwrap();


### PR DESCRIPTION
Add impl `AsyncRead`, `AsyncWrite`, `AsyncWriteAt` for &T. Don't need for `AsyncReadAt` because it already accepts `&self`.

This PR enables users to start IO tasks in parallel.