### PR TITLE
feat: async open named pipe client

### DIFF
--- a/compio-fs/src/open_options/mod.rs
+++ b/compio-fs/src/open_options/mod.rs
@@ -8,6 +8,9 @@ mod sys;
 
 use std::{io, path::Path};
 
+#[cfg(windows)]
+use windows_sys::Win32::Security::SECURITY_ATTRIBUTES;
+
 use crate::File;
 
 /// Options and flags which can be used to configure how a file is opened.
@@ -240,6 +243,18 @@ impl OpenOptions {
     #[cfg(windows)]
     pub fn security_qos_flags(&mut self, flags: u32) -> &mut Self {
         self.0.security_qos_flags(flags);
+        self
+    }
+
+    /// Set the security attributes for the file handle.
+    ///
+    /// # Safety
+    ///
+    /// The `attrs` argument must either be null or point at a valid instance of
+    /// the [`SECURITY_ATTRIBUTES`] structure.
+    #[cfg(windows)]
+    pub unsafe fn security_attributes(&mut self, attrs: *const SECURITY_ATTRIBUTES) -> &mut Self {
+        self.0.security_attributes(attrs);
         self
     }
 

--- a/compio-fs/src/open_options/unix.rs
+++ b/compio-fs/src/open_options/unix.rs
@@ -19,13 +19,11 @@ pub struct OpenOptions {
 impl OpenOptions {
     pub fn new() -> OpenOptions {
         OpenOptions {
-            // generic
             read: false,
             write: false,
             truncate: false,
             create: false,
             create_new: false,
-            // system-specific
             custom_flags: 0,
             mode: 0o666,
         }

--- a/compio/benches/named_pipe.rs
+++ b/compio/benches/named_pipe.rs
@@ -63,7 +63,7 @@ fn basic(c: &mut Criterion) {
                 const PIPE_NAME: &str = r"\\.\pipe\compio-named-pipe";
 
                 let mut server = ServerOptions::new().create(PIPE_NAME).unwrap();
-                let mut client = ClientOptions::new().open(PIPE_NAME).unwrap();
+                let mut client = ClientOptions::new().open(PIPE_NAME).await.unwrap();
 
                 server.connect().await.unwrap();
 

--- a/compio/examples/named_pipe.rs
+++ b/compio/examples/named_pipe.rs
@@ -15,7 +15,11 @@ async fn main() {
             .access_inbound(false)
             .create(PIPE_NAME)
             .unwrap();
-        let mut client = ClientOptions::new().write(false).open(PIPE_NAME).unwrap();
+        let mut client = ClientOptions::new()
+            .write(false)
+            .open(PIPE_NAME)
+            .await
+            .unwrap();
 
         server.connect().await.unwrap();
 


### PR DESCRIPTION
A named pipe client can connect to a remote named pipe, so we should make the `open` method async.