### PR TITLE
refactor: ensure Event being oneshot

### DIFF
--- a/compio-net/src/resolve/windows.rs
+++ b/compio-net/src/resolve/windows.rs
@@ -42,9 +42,10 @@ impl AsyncResolver {
         _dwbytes: u32,
         lpoverlapped: *const OVERLAPPED,
     ) {
-        let overlapped_ptr = lpoverlapped.cast::<GAIOverlapped>();
-        if let Some(overlapped) = overlapped_ptr.as_ref() {
-            if let Some(handle) = overlapped.handle.as_ref() {
+        // We won't access the overlapped struct outside callback.
+        let overlapped_ptr = lpoverlapped.cast::<GAIOverlapped>().cast_mut();
+        if let Some(overlapped) = overlapped_ptr.as_mut() {
+            if let Some(handle) = overlapped.handle.take() {
                 handle.notify().ok();
             }
         }

--- a/compio-runtime/src/event/eventfd.rs
+++ b/compio-runtime/src/event/eventfd.rs
@@ -33,7 +33,7 @@ impl Event {
     }
 
     /// Wait for [`EventHandle::notify`] called.
-    pub async fn wait(&self) -> io::Result<()> {
+    pub async fn wait(self) -> io::Result<()> {
         self.attacher.attach(&self.fd)?;
         let buffer = ArrayVec::<u8, 8>::new();
         // Trick: Recv uses readv which doesn't seek.
@@ -61,7 +61,7 @@ impl EventHandle {
     }
 
     /// Notify the event.
-    pub fn notify(&self) -> io::Result<()> {
+    pub fn notify(self) -> io::Result<()> {
         let data = 1u64;
         syscall!(libc::write(
             self.fd.as_raw_fd(),

--- a/compio-runtime/src/event/iocp.rs
+++ b/compio-runtime/src/event/iocp.rs
@@ -29,7 +29,7 @@ impl Event {
     }
 
     /// Wait for [`EventHandle::notify`] called.
-    pub async fn wait(&self) -> io::Result<()> {
+    pub async fn wait(self) -> io::Result<()> {
         let future = OpFuture::new(self.user_data);
         future.await.0?;
         Ok(())
@@ -56,7 +56,7 @@ impl EventHandle {
     }
 
     /// Notify the event.
-    pub fn notify(&self) -> io::Result<()> {
+    pub fn notify(self) -> io::Result<()> {
         post_driver_nop(self.handle, self.user_data)
     }
 }

--- a/compio-runtime/src/event/pipe.rs
+++ b/compio-runtime/src/event/pipe.rs
@@ -42,7 +42,7 @@ impl Event {
     }
 
     /// Wait for [`EventHandle::notify`] called.
-    pub async fn wait(&self) -> io::Result<()> {
+    pub async fn wait(self) -> io::Result<()> {
         self.attacher.attach(&self.receiver)?;
         let buffer = ArrayVec::<u8, 1>::new();
         // Trick: Recv uses readv which doesn't seek.
@@ -70,7 +70,7 @@ impl EventHandle {
     }
 
     /// Notify the event.
-    pub fn notify(&self) -> io::Result<()> {
+    pub fn notify(self) -> io::Result<()> {
         let data = &[1];
         syscall!(libc::write(self.fd.as_raw_fd(), data.as_ptr() as _, 1))?;
         Ok(())

--- a/compio-signal/src/windows.rs
+++ b/compio-signal/src/windows.rs
@@ -64,7 +64,7 @@ fn unregister(ctrltype: u32, key: usize) {
 #[derive(Debug)]
 struct CtrlEvent {
     ctrltype: u32,
-    event: Event,
+    event: Option<Event>,
     handler_key: usize,
 }
 
@@ -76,13 +76,17 @@ impl CtrlEvent {
         let handler_key = register(ctrltype, &event)?;
         Ok(Self {
             ctrltype,
-            event,
+            event: Some(event),
             handler_key,
         })
     }
 
-    pub async fn wait(&self) -> io::Result<()> {
-        self.event.wait().await
+    pub async fn wait(mut self) -> io::Result<()> {
+        self.event
+            .take()
+            .expect("event could not be None")
+            .wait()
+            .await
     }
 }
 


### PR DESCRIPTION
We should ensure that `Event` is oneshot. `wait` and `notify` should be called only once.