### PR TITLE
feat: make `Runtime` public

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ compio-tls = { path = "./compio-tls", version = "0.1.0" }
 
 
 cfg-if = "1.0.0"
+criterion = "0.5.1"
 crossbeam-channel = "0.5.8"
 crossbeam-queue = "0.3.8"
 futures-channel = "0.3.29"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ repository = "https://github.com/compio-rs/compio"
 [workspace.dependencies]
 compio-buf = { path = "./compio-buf", version = "0.2.0" }
 compio-driver = { path = "./compio-driver", version = "0.2.0", default-features = false }
-compio-runtime = { path = "./compio-runtime", version = "0.1.1" }
+compio-runtime = { path = "./compio-runtime", version = "0.2.0" }
 compio-macros = { path = "./compio-macros", version = "0.1.1" }
 compio-fs = { path = "./compio-fs", version = "0.2.0" }
 compio-io = { path = "./compio-io", version = "0.1.0" }

--- a/compio-fs/src/named_pipe.rs
+++ b/compio-fs/src/named_pipe.rs
@@ -68,32 +68,27 @@ use crate::{File, OpenOptions};
 ///     .create(PIPE_NAME)?;
 ///
 /// // Spawn the server loop.
-/// let server = compio_runtime::Runtime::new()
-///     .unwrap()
-///     .block_on(async move {
-///         loop {
-///             // Wait for a client to connect.
-///             let connected = server.connect().await?;
+/// # compio_runtime::Runtime::new().unwrap().block_on(async move {
+/// loop {
+///     // Wait for a client to connect.
+///     let connected = server.connect().await?;
 ///
-///             // Construct the next server to be connected before sending the one
-///             // we already have of onto a task. This ensures that the server
-///             // isn't closed (after it's done in the task) before a new one is
-///             // available. Otherwise the client might error with
-///             // `io::ErrorKind::NotFound`.
-///             server = ServerOptions::new().create(PIPE_NAME)?;
+///     // Construct the next server to be connected before sending the one
+///     // we already have of onto a task. This ensures that the server
+///     // isn't closed (after it's done in the task) before a new one is
+///     // available. Otherwise the client might error with
+///     // `io::ErrorKind::NotFound`.
+///     server = ServerOptions::new().create(PIPE_NAME)?;
 ///
-///             let client = compio_runtime::spawn(async move {
-///                 // use the connected client
-/// #           Ok::<_, std::io::Error>(())
-///             });
-/// #       if true { break } // needed for type inference to work
-///         }
-///
-///         Ok::<_, io::Error>(())
+///     let client = compio_runtime::spawn(async move {
+///         // use the connected client
+/// #       Ok::<_, std::io::Error>(())
 ///     });
-///
-/// // do something else not server related here
-/// # Ok(()) }
+/// # if true { break } // needed for type inference to work
+/// }
+/// # Ok::<_, io::Error>(())
+/// # })
+/// # }
 /// ```
 ///
 /// [Windows named pipe]: https://docs.microsoft.com/en-us/windows/win32/ipc/named-pipes

--- a/compio-fs/src/open_options/mod.rs
+++ b/compio-fs/src/open_options/mod.rs
@@ -33,7 +33,7 @@ use crate::File;
 /// ```no_run
 /// use compio_fs::OpenOptions;
 ///
-/// # compio_runtime::block_on(async {
+/// # compio_runtime::Runtime::new().unwrap().block_on(async {
 /// let file = OpenOptions::new().read(true).open("foo.txt").await.unwrap();
 /// # });
 /// ```
@@ -44,7 +44,7 @@ use crate::File;
 /// ```no_run
 /// use compio_fs::OpenOptions;
 ///
-/// # compio_runtime::block_on(async {
+/// # compio_runtime::Runtime::new().unwrap().block_on(async {
 /// let file = OpenOptions::new()
 ///     .read(true)
 ///     .write(true)

--- a/compio-fs/src/open_options/unix.rs
+++ b/compio-fs/src/open_options/unix.rs
@@ -1,7 +1,7 @@
 use std::{ffi::CString, io, os::unix::prelude::OsStrExt, path::Path};
 
 use compio_driver::{op::OpenFile, FromRawFd, RawFd};
-use compio_runtime::submit;
+use compio_runtime::Runtime;
 
 use crate::File;
 
@@ -96,7 +96,7 @@ impl OpenOptions {
             )
         })?;
         let op = OpenFile::new(p, flags, self.mode);
-        let fd = submit(op).await.0? as RawFd;
+        let fd = Runtime::current().submit(op).await.0? as RawFd;
         Ok(unsafe { File::from_raw_fd(fd) })
     }
 }

--- a/compio-fs/src/open_options/windows.rs
+++ b/compio-fs/src/open_options/windows.rs
@@ -1,7 +1,7 @@
 use std::{io, path::Path, ptr::null};
 
 use compio_driver::{op::OpenFile, FromRawFd, RawFd};
-use compio_runtime::submit;
+use compio_runtime::Runtime;
 use widestring::U16CString;
 use windows_sys::Win32::{
     Foundation::{ERROR_INVALID_PARAMETER, GENERIC_READ, GENERIC_WRITE},
@@ -145,7 +145,7 @@ impl OpenOptions {
             self.get_creation_mode()?,
             self.get_flags_and_attributes(),
         );
-        let fd = submit(op).await.0? as RawFd;
+        let fd = Runtime::current().submit(op).await.0? as RawFd;
         Ok(unsafe { File::from_raw_fd(fd) })
     }
 }

--- a/compio-io/src/lib.rs
+++ b/compio-io/src/lib.rs
@@ -34,7 +34,7 @@
 //! ```
 //! use compio_buf::BufResult;
 //! use compio_io::AsyncRead;
-//! # compio_runtime::block_on(async {
+//! # compio_runtime::Runtime::new().unwrap().block_on(async {
 //!
 //! let mut reader = "Hello, world!".as_bytes();
 //! let (res, buf) = reader.read(Vec::with_capacity(20)).await.unwrap();
@@ -55,7 +55,7 @@
 //!
 //! use compio_buf::BufResult;
 //! use compio_io::AsyncWrite;
-//! # compio_runtime::block_on(async {
+//! # compio_runtime::Runtime::new().unwrap().block_on(async {
 //!
 //! let mut writer = Cursor::new([0; 6]);
 //! writer.set_position(2);
@@ -72,7 +72,7 @@
 //! ```
 //! use compio_buf::BufResult;
 //! use compio_io::AsyncWrite;
-//! # compio_runtime::block_on(async {
+//! # compio_runtime::Runtime::new().unwrap().block_on(async {
 //!
 //! let mut writer = vec![1, 2, 3];
 //! let (_, buf) = writer.write(vec![3, 2, 1]).await.unwrap();

--- a/compio-io/src/util/null.rs
+++ b/compio-io/src/util/null.rs
@@ -53,7 +53,7 @@ impl AsyncWrite for Null {
 /// ```
 /// use compio_io::{null, AsyncRead, AsyncWrite};
 ///
-/// # compio_runtime::block_on(async {
+/// # compio_runtime::Runtime::new().unwrap().block_on(async {
 /// let mut buf = Vec::with_capacity(10);
 /// let mut null = null();
 ///

--- a/compio-io/src/util/repeat.rs
+++ b/compio-io/src/util/repeat.rs
@@ -12,7 +12,7 @@ use crate::{AsyncBufRead, AsyncRead, IoResult};
 /// # Examples
 ///
 /// ```rust
-/// # compio_runtime::block_on(async {
+/// # compio_runtime::Runtime::new().unwrap().block_on(async {
 /// use compio_io::{self, AsyncRead, AsyncReadExt};
 ///
 /// let (len, buffer) = compio_io::repeat(42)
@@ -57,7 +57,7 @@ impl AsyncBufRead for Repeat {
 /// # Examples
 ///
 /// ```rust
-/// # compio_runtime::block_on(async {
+/// # compio_runtime::Runtime::new().unwrap().block_on(async {
 /// use compio_io::{self, AsyncRead, AsyncReadExt};
 ///
 /// let (len, buffer) = compio_io::repeat(42)

--- a/compio-macros/src/main_fn.rs
+++ b/compio-macros/src/main_fn.rs
@@ -54,7 +54,7 @@ impl ToTokens for CompioMain {
         let block = &self.0.body;
         let runtime_mod = self.0.crate_name().unwrap_or_else(retrieve_runtime_mod);
         tokens.append_all(quote!({
-            #runtime_mod::block_on(async move #block)
+            #runtime_mod::Runtime::new().expect("cannot create runtime").block_on(async move #block)
         }));
     }
 }

--- a/compio-macros/src/test_fn.rs
+++ b/compio-macros/src/test_fn.rs
@@ -48,7 +48,7 @@ impl ToTokens for CompioTest {
         let block = &self.0.body;
         let runtime_mod = self.0.crate_name().unwrap_or_else(retrieve_runtime_mod);
         tokens.append_all(quote!({
-            #runtime_mod::block_on(async move #block)
+            #runtime_mod::Runtime::new().expect("cannot create runtime").block_on(async move #block)
         }));
     }
 }

--- a/compio-net/src/tcp.rs
+++ b/compio-net/src/tcp.rs
@@ -27,23 +27,23 @@ use crate::Socket;
 /// use compio_net::{TcpListener, TcpStream};
 /// use socket2::SockAddr;
 ///
+/// # compio_runtime::Runtime::new().unwrap().block_on(async move {
 /// let addr = "127.0.0.1:2345".parse::<SocketAddr>().unwrap();
 ///
-/// compio_runtime::block_on(async move {
-///     let listener = TcpListener::bind(&addr).await.unwrap();
+/// let listener = TcpListener::bind(&addr).await.unwrap();
 ///
-///     let tx_fut = TcpStream::connect(&addr);
+/// let tx_fut = TcpStream::connect(&addr);
 ///
-///     let rx_fut = listener.accept();
+/// let rx_fut = listener.accept();
 ///
-///     let (mut tx, (mut rx, _)) = futures_util::try_join!(tx_fut, rx_fut).unwrap();
+/// let (mut tx, (mut rx, _)) = futures_util::try_join!(tx_fut, rx_fut).unwrap();
 ///
-///     tx.write_all("test").await.0.unwrap();
+/// tx.write_all("test").await.0.unwrap();
 ///
-///     let (_, buf) = rx.read_exact(Vec::with_capacity(4)).await.unwrap();
+/// let (_, buf) = rx.read_exact(Vec::with_capacity(4)).await.unwrap();
 ///
-///     assert_eq!(buf, b"test");
-/// });
+/// assert_eq!(buf, b"test");
+/// # });
 /// ```
 #[derive(Debug)]
 pub struct TcpListener {
@@ -109,7 +109,7 @@ impl TcpListener {
     /// use compio_net::TcpListener;
     /// use socket2::SockAddr;
     ///
-    /// # compio_runtime::block_on(async {
+    /// # compio_runtime::Runtime::new().unwrap().block_on(async {
     /// let listener = TcpListener::bind("127.0.0.1:8080").await.unwrap();
     ///
     /// let addr = listener.local_addr().expect("Couldn't get local address");
@@ -144,13 +144,13 @@ impl_attachable!(TcpListener, inner);
 /// use compio_io::AsyncWrite;
 /// use compio_net::TcpStream;
 ///
-/// compio_runtime::block_on(async {
-///     // Connect to a peer
-///     let mut stream = TcpStream::connect("127.0.0.1:8080").await.unwrap();
+/// # compio_runtime::Runtime::new().unwrap().block_on(async {
+/// // Connect to a peer
+/// let mut stream = TcpStream::connect("127.0.0.1:8080").await.unwrap();
 ///
-///     // Write some data.
-///     stream.write("hello world!").await.unwrap();
-/// })
+/// // Write some data.
+/// stream.write("hello world!").await.unwrap();
+/// # })
 /// ```
 #[derive(Debug)]
 pub struct TcpStream {

--- a/compio-net/src/udp.rs
+++ b/compio-net/src/udp.rs
@@ -34,31 +34,31 @@ use crate::Socket;
 ///
 /// use compio_net::UdpSocket;
 ///
-/// compio_runtime::block_on(async {
-///     let first_addr: SocketAddr = "127.0.0.1:0".parse().unwrap();
-///     let second_addr: SocketAddr = "127.0.0.1:0".parse().unwrap();
+/// # compio_runtime::Runtime::new().unwrap().block_on(async {
+/// let first_addr: SocketAddr = "127.0.0.1:0".parse().unwrap();
+/// let second_addr: SocketAddr = "127.0.0.1:0".parse().unwrap();
 ///
-///     // bind sockets
-///     let mut socket = UdpSocket::bind(first_addr).await.unwrap();
-///     let first_addr = socket.local_addr().unwrap();
-///     let mut other_socket = UdpSocket::bind(second_addr).await.unwrap();
-///     let second_addr = other_socket.local_addr().unwrap();
+/// // bind sockets
+/// let mut socket = UdpSocket::bind(first_addr).await.unwrap();
+/// let first_addr = socket.local_addr().unwrap();
+/// let mut other_socket = UdpSocket::bind(second_addr).await.unwrap();
+/// let second_addr = other_socket.local_addr().unwrap();
 ///
-///     // connect sockets
-///     socket.connect(second_addr).await.unwrap();
-///     other_socket.connect(first_addr).await.unwrap();
+/// // connect sockets
+/// socket.connect(second_addr).await.unwrap();
+/// other_socket.connect(first_addr).await.unwrap();
 ///
-///     let buf = Vec::with_capacity(12);
+/// let buf = Vec::with_capacity(12);
 ///
-///     // write data
-///     socket.send("Hello world!").await.unwrap();
+/// // write data
+/// socket.send("Hello world!").await.unwrap();
 ///
-///     // read data
-///     let (n_bytes, buf) = other_socket.recv(buf).await.unwrap();
+/// // read data
+/// let (n_bytes, buf) = other_socket.recv(buf).await.unwrap();
 ///
-///     assert_eq!(n_bytes, buf.len());
-///     assert_eq!(buf, b"Hello world!");
-/// });
+/// assert_eq!(n_bytes, buf.len());
+/// assert_eq!(buf, b"Hello world!");
+/// # });
 /// ```
 /// Send and receive packets without connecting:
 ///
@@ -68,28 +68,28 @@ use crate::Socket;
 /// use compio_net::UdpSocket;
 /// use socket2::SockAddr;
 ///
-/// compio_runtime::block_on(async {
-///     let first_addr: SocketAddr = "127.0.0.1:0".parse().unwrap();
-///     let second_addr: SocketAddr = "127.0.0.1:0".parse().unwrap();
+/// # compio_runtime::Runtime::new().unwrap().block_on(async {
+/// let first_addr: SocketAddr = "127.0.0.1:0".parse().unwrap();
+/// let second_addr: SocketAddr = "127.0.0.1:0".parse().unwrap();
 ///
-///     // bind sockets
-///     let mut socket = UdpSocket::bind(first_addr).await.unwrap();
-///     let first_addr = socket.local_addr().unwrap();
-///     let mut other_socket = UdpSocket::bind(second_addr).await.unwrap();
-///     let second_addr = other_socket.local_addr().unwrap();
+/// // bind sockets
+/// let mut socket = UdpSocket::bind(first_addr).await.unwrap();
+/// let first_addr = socket.local_addr().unwrap();
+/// let mut other_socket = UdpSocket::bind(second_addr).await.unwrap();
+/// let second_addr = other_socket.local_addr().unwrap();
 ///
-///     let buf = Vec::with_capacity(32);
+/// let buf = Vec::with_capacity(32);
 ///
-///     // write data
-///     socket.send_to("hello world", second_addr).await.unwrap();
+/// // write data
+/// socket.send_to("hello world", second_addr).await.unwrap();
 ///
-///     // read data
-///     let ((n_bytes, addr), buf) = other_socket.recv_from(buf).await.unwrap();
+/// // read data
+/// let ((n_bytes, addr), buf) = other_socket.recv_from(buf).await.unwrap();
 ///
-///     assert_eq!(addr, first_addr);
-///     assert_eq!(n_bytes, buf.len());
-///     assert_eq!(buf, b"hello world");
-/// });
+/// assert_eq!(addr, first_addr);
+/// assert_eq!(n_bytes, buf.len());
+/// assert_eq!(buf, b"hello world");
+/// # });
 /// ```
 #[derive(Debug)]
 pub struct UdpSocket {
@@ -150,7 +150,7 @@ impl UdpSocket {
     /// use compio_net::UdpSocket;
     /// use socket2::SockAddr;
     ///
-    /// # compio_runtime::block_on(async {
+    /// # compio_runtime::Runtime::new().unwrap().block_on(async {
     /// let socket = UdpSocket::bind("127.0.0.1:34254")
     ///     .await
     ///     .expect("couldn't bind to address");
@@ -180,7 +180,7 @@ impl UdpSocket {
     /// use compio_net::UdpSocket;
     /// use socket2::SockAddr;
     ///
-    /// # compio_runtime::block_on(async {
+    /// # compio_runtime::Runtime::new().unwrap().block_on(async {
     /// let addr: SocketAddr = "127.0.0.1:8080".parse().unwrap();
     /// let sock = UdpSocket::bind(&addr).await.unwrap();
     /// // the address the socket is bound to

--- a/compio-net/src/unix.rs
+++ b/compio-net/src/unix.rs
@@ -27,18 +27,18 @@ use crate::Socket;
 /// let dir = tempdir().unwrap();
 /// let sock_file = dir.path().join("unix-server.sock");
 ///
-/// compio_runtime::block_on(async move {
-///     let listener = UnixListener::bind(&sock_file).unwrap();
+/// # compio_runtime::Runtime::new().unwrap().block_on(async move {
+/// let listener = UnixListener::bind(&sock_file).unwrap();
 ///
-///     let mut tx = UnixStream::connect(&sock_file).unwrap();
-///     let (mut rx, _) = listener.accept().await.unwrap();
+/// let mut tx = UnixStream::connect(&sock_file).unwrap();
+/// let (mut rx, _) = listener.accept().await.unwrap();
 ///
-///     tx.write_all("test").await.0.unwrap();
+/// tx.write_all("test").await.0.unwrap();
 ///
-///     let (_, buf) = rx.read_exact(Vec::with_capacity(4)).await.unwrap();
+/// let (_, buf) = rx.read_exact(Vec::with_capacity(4)).await.unwrap();
 ///
-///     assert_eq!(buf, b"test");
-/// });
+/// assert_eq!(buf, b"test");
+/// # });
 /// ```
 #[derive(Debug)]
 pub struct UnixListener {
@@ -112,13 +112,13 @@ impl_attachable!(UnixListener, inner);
 /// use compio_io::AsyncWrite;
 /// use compio_net::UnixStream;
 ///
-/// compio_runtime::block_on(async {
-///     // Connect to a peer
-///     let mut stream = UnixStream::connect("unix-server.sock").unwrap();
+/// # compio_runtime::Runtime::new().unwrap().block_on(async {
+/// // Connect to a peer
+/// let mut stream = UnixStream::connect("unix-server.sock").unwrap();
 ///
-///     // Write some data.
-///     stream.write("hello world!").await.unwrap();
-/// })
+/// // Write some data.
+/// stream.write("hello world!").await.unwrap();
+/// # })
 /// ```
 #[derive(Debug)]
 pub struct UnixStream {

--- a/compio-runtime/Cargo.toml
+++ b/compio-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "compio-runtime"
-version = "0.1.1"
+version = "0.2.0"
 description = "high-level runtime for compio"
 categories = ["asynchronous"]
 keywords = ["async", "runtime"]

--- a/compio-runtime/Cargo.toml
+++ b/compio-runtime/Cargo.toml
@@ -40,6 +40,7 @@ once_cell = { workspace = true }
 send_wrapper = { workspace = true }
 slab = { workspace = true, optional = true }
 smallvec = "1.11.1"
+uuid = { version = "1.5.0", features = ["v4"] }
 
 # Windows specific dependencies
 [target.'cfg(windows)'.dependencies]

--- a/compio-runtime/Cargo.toml
+++ b/compio-runtime/Cargo.toml
@@ -35,6 +35,7 @@ compio-log = { workspace = true }
 
 async-task = "4.5.0"
 cfg-if = { workspace = true, optional = true }
+criterion = { workspace = true, optional = true }
 futures-util = { workspace = true }
 once_cell = { workspace = true }
 send_wrapper = { workspace = true }

--- a/compio-runtime/Cargo.toml
+++ b/compio-runtime/Cargo.toml
@@ -41,7 +41,6 @@ once_cell = { workspace = true }
 send_wrapper = { workspace = true }
 slab = { workspace = true, optional = true }
 smallvec = "1.11.1"
-uuid = { version = "1.5.0", features = ["v4"] }
 
 # Windows specific dependencies
 [target.'cfg(windows)'.dependencies]

--- a/compio-runtime/src/attacher.rs
+++ b/compio-runtime/src/attacher.rs
@@ -7,7 +7,7 @@ use compio_driver::AsRawFd;
 #[cfg(not(feature = "once_cell_try"))]
 use once_cell::sync::OnceCell as OnceLock;
 
-use crate::attach;
+use crate::Runtime;
 
 /// Attach a handle to the driver of current thread.
 ///
@@ -34,7 +34,8 @@ impl Attacher {
     /// Attach the source. This method could be called many times, but if the
     /// action fails, the error will only return once.
     pub fn attach(&self, source: &impl AsRawFd) -> io::Result<()> {
-        self.once.get_or_try_init(|| attach(source.as_raw_fd()))?;
+        self.once
+            .get_or_try_init(|| Runtime::current().inner().attach(source.as_raw_fd()))?;
         Ok(())
     }
 

--- a/compio-runtime/src/attacher.rs
+++ b/compio-runtime/src/attacher.rs
@@ -6,6 +6,7 @@ use compio_buf::IntoInner;
 use compio_driver::AsRawFd;
 #[cfg(not(feature = "once_cell_try"))]
 use once_cell::sync::OnceCell as OnceLock;
+use uuid::Uuid;
 
 use crate::Runtime;
 
@@ -17,7 +18,7 @@ use crate::Runtime;
 #[derive(Debug, Clone)]
 pub struct Attacher {
     // Make it thread safe.
-    once: OnceLock<()>,
+    once: OnceLock<Uuid>,
     // Make it !Send & !Sync.
     _p: PhantomData<*mut ()>,
 }
@@ -33,10 +34,24 @@ impl Attacher {
 
     /// Attach the source. This method could be called many times, but if the
     /// action fails, the error will only return once.
+    ///
+    /// You should always call this method before accessing the runtime. It
+    /// ensures that the current runtime is the exact runtime attached before.
     pub fn attach(&self, source: &impl AsRawFd) -> io::Result<()> {
-        self.once
-            .get_or_try_init(|| Runtime::current().inner().attach(source.as_raw_fd()))?;
-        Ok(())
+        let r = Runtime::current();
+        let inner = r.inner();
+        let id = self.once.get_or_try_init(|| {
+            inner.attach(source.as_raw_fd())?;
+            io::Result::Ok(inner.id())
+        })?;
+        if id != &inner.id() {
+            Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "the current runtime is not the attached runtime",
+            ))
+        } else {
+            Ok(())
+        }
     }
 
     /// Check if [`attach`] has been called.

--- a/compio-runtime/src/attacher.rs
+++ b/compio-runtime/src/attacher.rs
@@ -6,7 +6,6 @@ use compio_buf::IntoInner;
 use compio_driver::AsRawFd;
 #[cfg(not(feature = "once_cell_try"))]
 use once_cell::sync::OnceCell as OnceLock;
-use uuid::Uuid;
 
 use crate::Runtime;
 
@@ -18,7 +17,7 @@ use crate::Runtime;
 #[derive(Debug, Clone)]
 pub struct Attacher {
     // Make it thread safe.
-    once: OnceLock<Uuid>,
+    once: OnceLock<usize>,
     // Make it !Send & !Sync.
     _p: PhantomData<*mut ()>,
 }

--- a/compio-runtime/src/event/eventfd.rs
+++ b/compio-runtime/src/event/eventfd.rs
@@ -6,7 +6,7 @@ use std::{
 use compio_buf::{arrayvec::ArrayVec, BufResult};
 use compio_driver::{impl_raw_fd, op::Recv, syscall};
 
-use crate::{attacher::Attacher, submit};
+use crate::{attacher::Attacher, Runtime};
 
 /// An event that won't wake until [`EventHandle::notify`] is called
 /// successfully.
@@ -38,7 +38,7 @@ impl Event {
         let buffer = ArrayVec::<u8, 8>::new();
         // Trick: Recv uses readv which doesn't seek.
         let op = Recv::new(self.as_raw_fd(), buffer);
-        let BufResult(res, _) = submit(op).await;
+        let BufResult(res, _) = Runtime::current().submit(op).await;
         res?;
         Ok(())
     }

--- a/compio-runtime/src/event/pipe.rs
+++ b/compio-runtime/src/event/pipe.rs
@@ -6,7 +6,7 @@ use std::{
 use compio_buf::{arrayvec::ArrayVec, BufResult};
 use compio_driver::{impl_raw_fd, op::Recv, syscall};
 
-use crate::{attacher::Attacher, submit};
+use crate::{attacher::Attacher, Runtime};
 
 /// An event that won't wake until [`EventHandle::notify`] is called
 /// successfully.
@@ -47,7 +47,7 @@ impl Event {
         let buffer = ArrayVec::<u8, 1>::new();
         // Trick: Recv uses readv which doesn't seek.
         let op = Recv::new(self.receiver.as_raw_fd(), buffer);
-        let BufResult(res, _) = submit(op).await;
+        let BufResult(res, _) = Runtime::current().submit(op).await;
         res?;
         Ok(())
     }

--- a/compio-runtime/src/lib.rs
+++ b/compio-runtime/src/lib.rs
@@ -1,6 +1,4 @@
 //! The runtime of compio.
-//! We don't expose the runtime struct because there could be only one runtime
-//! in each thread.
 //!
 //! ```
 //! let ans = compio_runtime::Runtime::new().unwrap().block_on(async {

--- a/compio-runtime/src/lib.rs
+++ b/compio-runtime/src/lib.rs
@@ -3,7 +3,7 @@
 //! in each thread.
 //!
 //! ```
-//! let ans = compio_runtime::block_on(async {
+//! let ans = compio_runtime::Runtime::new().unwrap().block_on(async {
 //!     println!("Hello world!");
 //!     42
 //! });
@@ -11,87 +11,20 @@
 //! ```
 
 #![cfg_attr(feature = "once_cell_try", feature(once_cell_try))]
-#![cfg_attr(feature = "lazy_cell", feature(lazy_cell))]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 #![warn(missing_docs)]
 
 mod attacher;
 mod key;
-pub(crate) mod runtime;
+mod runtime;
 
 #[cfg(feature = "event")]
 pub mod event;
 #[cfg(feature = "time")]
 pub mod time;
 
-use std::{cell::RefCell, future::Future, io, mem::ManuallyDrop};
-
 pub use async_task::Task;
 pub use attacher::*;
 use compio_buf::BufResult;
-use compio_driver::{OpCode, ProactorBuilder, RawFd};
 pub(crate) use key::Key;
-// It cannot be replaced by std one because of lacking `get` method.
-use once_cell::unsync::Lazy as LazyCell;
-use runtime::Runtime;
-
-thread_local! {
-    pub(crate) static PROACTOR_BUILDER: RefCell<ProactorBuilder> = RefCell::new(ProactorBuilder::new());
-    // Use ManuallyDrop here to avoid misc bugs on some platforms when
-    // trying to get current thread id after thread local resources dropped.
-    pub(crate) static RUNTIME: LazyCell<ManuallyDrop<Runtime>> = LazyCell::new(|| {
-        ManuallyDrop::new(
-            PROACTOR_BUILDER
-                .with(|builder| Runtime::new(&builder.borrow()))
-                .expect("cannot create compio runtime")
-        )
-    });
-}
-
-/// Config the inner proactor with a [`ProactorBuilder`]. Note that if any
-/// runtime related method is called before, there will be no influence.
-/// The return value indicates whether the builder will be used when
-/// initializing the runtime.
-pub fn config_proactor(new_builder: ProactorBuilder) -> bool {
-    PROACTOR_BUILDER.with(|builder| *builder.borrow_mut() = new_builder);
-    RUNTIME.with(|runtime| LazyCell::get(runtime).is_none())
-}
-
-/// Start a compio runtime and block on the future till it completes.
-pub fn block_on<F: Future>(future: F) -> F::Output {
-    RUNTIME.with(|runtime| runtime.block_on(future))
-}
-
-/// Spawns a new asynchronous task, returning a [`Task`] for it.
-///
-/// Spawning a task enables the task to execute concurrently to other tasks.
-/// There is no guarantee that a spawned task will execute to completion.
-///
-/// ```
-/// compio_runtime::block_on(async {
-///     let task = compio_runtime::spawn(async {
-///         println!("Hello from a spawned task!");
-///         42
-///     });
-///
-///     assert_eq!(task.await, 42);
-/// })
-/// ```
-pub fn spawn<F: Future + 'static>(future: F) -> Task<F::Output> {
-    RUNTIME.with(|runtime| runtime.spawn(future))
-}
-
-/// Attach a raw file descriptor/handle/socket to the runtime.
-///
-/// You only need this when authoring your own high-level APIs. High-level
-/// resources in this crate are attached automatically.
-pub fn attach(fd: RawFd) -> io::Result<()> {
-    RUNTIME.with(|runtime| runtime.attach(fd))
-}
-
-/// Submit an operation to the runtime.
-///
-/// You only need this when authoring your own [`OpCode`].
-pub fn submit<T: OpCode + 'static>(op: T) -> impl Future<Output = BufResult<usize, T>> {
-    RUNTIME.with(|runtime| runtime.submit(op))
-}
+pub use runtime::{spawn, EnterGuard, Runtime, RuntimeBuilder};

--- a/compio-runtime/src/runtime/mod.rs
+++ b/compio-runtime/src/runtime/mod.rs
@@ -257,14 +257,17 @@ impl Runtime {
     }
 
     /// Get the current running [`Runtime`].
+    pub fn try_current() -> Option<Self> {
+        CURRENT_RUNTIME.with_borrow(|r| r.upgrade_runtime())
+    }
+
+    /// Get the current running [`Runtime`].
     ///
     /// ## Panics
     ///
     /// This method will panic if there are no running [`Runtime`].
     pub fn current() -> Self {
-        CURRENT_RUNTIME
-            .with_borrow(|r| r.upgrade_runtime())
-            .expect("not in a compio runtime")
+        Self::try_current().expect("not in a compio runtime")
     }
 
     pub(crate) fn inner(&self) -> &RuntimeInner {

--- a/compio-runtime/src/runtime/mod.rs
+++ b/compio-runtime/src/runtime/mod.rs
@@ -14,6 +14,7 @@ use compio_log::{debug, instrument};
 use futures_util::future::Either;
 use send_wrapper::SendWrapper;
 use smallvec::SmallVec;
+use uuid::Uuid;
 
 pub(crate) mod op;
 #[cfg(feature = "time")]
@@ -27,6 +28,7 @@ use crate::{
 };
 
 pub(crate) struct RuntimeInner {
+    id: Uuid,
     driver: RefCell<Proactor>,
     runnables: Rc<RefCell<VecDeque<Runnable>>>,
     op_runtime: RefCell<OpRuntime>,
@@ -37,12 +39,17 @@ pub(crate) struct RuntimeInner {
 impl RuntimeInner {
     pub fn new(builder: &ProactorBuilder) -> io::Result<Self> {
         Ok(Self {
+            id: Uuid::new_v4(),
             driver: RefCell::new(builder.build()?),
             runnables: Rc::new(RefCell::default()),
             op_runtime: RefCell::default(),
             #[cfg(feature = "time")]
             timer_runtime: RefCell::new(TimerRuntime::new()),
         })
+    }
+
+    pub fn id(&self) -> Uuid {
+        self.id
     }
 
     // Safety: the return runnable should be scheduled.

--- a/compio-runtime/src/runtime/mod.rs
+++ b/compio-runtime/src/runtime/mod.rs
@@ -335,6 +335,20 @@ impl AsRawFd for Runtime {
     }
 }
 
+#[cfg(feature = "criterion")]
+impl criterion::async_executor::AsyncExecutor for Runtime {
+    fn block_on<T>(&self, future: impl Future<Output = T>) -> T {
+        self.block_on(future)
+    }
+}
+
+#[cfg(feature = "criterion")]
+impl criterion::async_executor::AsyncExecutor for &Runtime {
+    fn block_on<T>(&self, future: impl Future<Output = T>) -> T {
+        (**self).block_on(future)
+    }
+}
+
 /// Builder for [`Runtime`].
 #[derive(Debug, Clone)]
 pub struct RuntimeBuilder {

--- a/compio-runtime/src/runtime/mod.rs
+++ b/compio-runtime/src/runtime/mod.rs
@@ -422,14 +422,14 @@ impl Drop for EnterGuard<'_> {
 /// There is no guarantee that a spawned task will execute to completion.
 ///
 /// ```
-/// compio_runtime::Runtime::new().unwrap().block_on(async {
-///     let task = compio_runtime::spawn(async {
-///         println!("Hello from a spawned task!");
-///         42
-///     });
+/// # compio_runtime::Runtime::new().unwrap().block_on(async {
+/// let task = compio_runtime::spawn(async {
+///     println!("Hello from a spawned task!");
+///     42
+/// });
 ///
-///     assert_eq!(task.await, 42);
-/// })
+/// assert_eq!(task.await, 42);
+/// # })
 /// ```
 ///
 /// ## Panics

--- a/compio-runtime/src/runtime/time.rs
+++ b/compio-runtime/src/runtime/time.rs
@@ -8,6 +8,8 @@ use std::{
 
 use slab::Slab;
 
+use crate::Runtime;
+
 #[derive(Debug)]
 struct TimerEntry {
     key: usize,
@@ -121,7 +123,7 @@ impl Future for TimerFuture {
     type Output = ();
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        let res = crate::RUNTIME.with(|runtime| runtime.poll_timer(cx, self.key));
+        let res = Runtime::current().inner().poll_timer(cx, self.key);
         if res.is_ready() {
             self.get_mut().completed = true;
         }
@@ -132,7 +134,7 @@ impl Future for TimerFuture {
 impl Drop for TimerFuture {
     fn drop(&mut self) {
         if !self.completed {
-            crate::RUNTIME.with(|runtime| runtime.cancel_timer(self.key));
+            Runtime::current().inner().cancel_timer(self.key);
         }
     }
 }

--- a/compio-runtime/src/time.rs
+++ b/compio-runtime/src/time.rs
@@ -9,6 +9,8 @@ use std::{
 
 use futures_util::{select, FutureExt};
 
+use crate::Runtime;
+
 /// Waits until `duration` has elapsed.
 ///
 /// Equivalent to [`sleep_until(Instant::now() + duration)`](sleep_until). An
@@ -25,15 +27,13 @@ use futures_util::{select, FutureExt};
 ///
 /// use compio_runtime::time::sleep;
 ///
-/// compio_runtime::block_on(async {
-///     sleep(Duration::from_millis(100)).await;
-///     println!("100 ms have elapsed");
-/// })
+/// # compio_runtime::Runtime::new().unwrap().block_on(async {
+/// sleep(Duration::from_millis(100)).await;
+/// println!("100 ms have elapsed");
+/// # })
 /// ```
 pub async fn sleep(duration: Duration) {
-    crate::RUNTIME
-        .with(|runtime| runtime.create_timer(duration))
-        .await
+    Runtime::current().inner().create_timer(duration).await
 }
 
 /// Waits until `deadline` is reached.
@@ -49,10 +49,10 @@ pub async fn sleep(duration: Duration) {
 ///
 /// use compio_runtime::time::sleep_until;
 ///
-/// compio_runtime::block_on(async {
-///     sleep_until(Instant::now() + Duration::from_millis(100)).await;
-///     println!("100 ms have elapsed");
-/// })
+/// # compio_runtime::Runtime::new().unwrap().block_on(async {
+/// sleep_until(Instant::now() + Duration::from_millis(100)).await;
+/// println!("100 ms have elapsed");
+/// # })
 /// ```
 pub async fn sleep_until(deadline: Instant) {
     sleep(deadline - Instant::now()).await
@@ -151,15 +151,15 @@ impl Interval {
 ///
 /// use compio_runtime::time::interval;
 ///
-/// compio_runtime::block_on(async {
-///     let mut interval = interval(Duration::from_millis(10));
+/// # compio_runtime::Runtime::new().unwrap().block_on(async {
+/// let mut interval = interval(Duration::from_millis(10));
 ///
-///     interval.tick().await; // ticks immediately
-///     interval.tick().await; // ticks after 10ms
-///     interval.tick().await; // ticks after 10ms
+/// interval.tick().await; // ticks immediately
+/// interval.tick().await; // ticks after 10ms
+/// interval.tick().await; // ticks after 10ms
 ///
-///     // approximately 20ms have elapsed.
-/// })
+/// // approximately 20ms have elapsed.
+/// # })
 /// ```
 ///
 /// A simple example using [`interval`] to execute a task every two seconds.
@@ -183,13 +183,13 @@ impl Interval {
 ///     sleep(Duration::from_secs(1)).await
 /// }
 ///
-/// compio_runtime::block_on(async {
-///     let mut interval = interval(Duration::from_secs(2));
-///     for _i in 0..5 {
-///         interval.tick().await;
-///         task_that_takes_a_second().await;
-///     }
-/// })
+/// # compio_runtime::Runtime::new().unwrap().block_on(async {
+/// let mut interval = interval(Duration::from_secs(2));
+/// for _i in 0..5 {
+///     interval.tick().await;
+///     task_that_takes_a_second().await;
+/// }
+/// # })
 /// ```
 ///
 /// [`sleep`]: crate::time::sleep()
@@ -215,16 +215,16 @@ pub fn interval(period: Duration) -> Interval {
 ///
 /// use compio_runtime::time::interval_at;
 ///
-/// compio_runtime::block_on(async {
-///     let start = Instant::now() + Duration::from_millis(50);
-///     let mut interval = interval_at(start, Duration::from_millis(10));
+/// # compio_runtime::Runtime::new().unwrap().block_on(async {
+/// let start = Instant::now() + Duration::from_millis(50);
+/// let mut interval = interval_at(start, Duration::from_millis(10));
 ///
-///     interval.tick().await; // ticks after 50ms
-///     interval.tick().await; // ticks after 10ms
-///     interval.tick().await; // ticks after 10ms
+/// interval.tick().await; // ticks after 50ms
+/// interval.tick().await; // ticks after 10ms
+/// interval.tick().await; // ticks after 10ms
 ///
-///     // approximately 70ms have elapsed.
-/// });
+/// // approximately 70ms have elapsed.
+/// # });
 /// ```
 pub fn interval_at(start: Instant, period: Duration) -> Interval {
     assert!(period > Duration::ZERO, "`period` must be non-zero.");

--- a/compio-runtime/tests/event.rs
+++ b/compio-runtime/tests/event.rs
@@ -2,7 +2,7 @@ use compio_runtime::event::Event;
 
 #[test]
 fn event_handle() {
-    compio_runtime::block_on(async {
+    compio_runtime::Runtime::new().unwrap().block_on(async {
         let event = Event::new().unwrap();
         let handle = event.handle().unwrap();
         std::thread::spawn(move || {

--- a/compio-signal/src/lib.rs
+++ b/compio-signal/src/lib.rs
@@ -7,10 +7,10 @@
 //! ```rust,no_run
 //! use compio_signal::ctrl_c;
 //!
-//! compio_runtime::block_on(async {
-//!     ctrl_c().await.unwrap();
-//!     println!("ctrl-c received!");
-//! })
+//! # compio_runtime::Runtime::new().unwrap().block_on(async {
+//! ctrl_c().await.unwrap();
+//! println!("ctrl-c received!");
+//! # })
 //! ```
 
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]

--- a/compio/Cargo.toml
+++ b/compio/Cargo.toml
@@ -44,9 +44,10 @@ compio-log = { workspace = true, optional = true }
 # Shared dev dependencies for all platforms
 [dev-dependencies]
 compio-buf = { workspace = true, features = ["bumpalo"] }
+compio-runtime = { workspace = true, features = ["criterion"] }
 compio-macros = { workspace = true }
 
-criterion = { version = "0.5.1", features = ["async_tokio"] }
+criterion = { workspace = true, features = ["async_tokio"] }
 futures-util = { workspace = true }
 tempfile = { workspace = true }
 tokio = { workspace = true, features = [
@@ -83,6 +84,8 @@ signal = ["dep:compio-signal", "event"]
 time = ["compio-runtime/time", "runtime"]
 dispatcher = ["dep:compio-dispatcher", "runtime"]
 all = ["time", "macros", "signal", "dispatcher"]
+
+criterion = ["compio-runtime?/criterion"]
 
 # Nightly features
 allocator_api = ["compio-buf/allocator_api", "compio-io?/allocator_api"]

--- a/compio/benches/fs.rs
+++ b/compio/benches/fs.rs
@@ -1,16 +1,8 @@
-use criterion::{async_executor::AsyncExecutor, criterion_group, criterion_main, Criterion};
+use criterion::{criterion_group, criterion_main, Criterion};
 use tempfile::NamedTempFile;
 
 criterion_group!(fs, read, write);
 criterion_main!(fs);
-
-struct CompioRuntime;
-
-impl AsyncExecutor for CompioRuntime {
-    fn block_on<T>(&self, future: impl std::future::Future<Output = T>) -> T {
-        compio::runtime::Runtime::new().unwrap().block_on(future)
-    }
-}
 
 fn read(c: &mut Criterion) {
     let mut group = c.benchmark_group("read");
@@ -42,7 +34,8 @@ fn read(c: &mut Criterion) {
     });
 
     group.bench_function("compio", |b| {
-        b.to_async(CompioRuntime).iter(|| async {
+        let runtime = compio::runtime::Runtime::new().unwrap();
+        b.to_async(&runtime).iter(|| async {
             use compio::io::AsyncReadAtExt;
 
             let file = compio::fs::File::open("Cargo.toml").await.unwrap();
@@ -85,8 +78,9 @@ fn write(c: &mut Criterion) {
     });
 
     group.bench_function("compio", |b| {
+        let runtime = compio::runtime::Runtime::new().unwrap();
         let temp_file = NamedTempFile::new().unwrap();
-        b.to_async(CompioRuntime).iter(|| async {
+        b.to_async(&runtime).iter(|| async {
             use compio::io::AsyncWriteAtExt;
 
             let mut file = compio::fs::File::create(temp_file.path()).await.unwrap();

--- a/compio/benches/fs.rs
+++ b/compio/benches/fs.rs
@@ -8,7 +8,7 @@ struct CompioRuntime;
 
 impl AsyncExecutor for CompioRuntime {
     fn block_on<T>(&self, future: impl std::future::Future<Output = T>) -> T {
-        compio::runtime::block_on(future)
+        compio::runtime::Runtime::new().unwrap().block_on(future)
     }
 }
 

--- a/compio/benches/named_pipe.rs
+++ b/compio/benches/named_pipe.rs
@@ -7,7 +7,7 @@ struct CompioRuntime;
 
 impl AsyncExecutor for CompioRuntime {
     fn block_on<T>(&self, future: impl std::future::Future<Output = T>) -> T {
-        compio::runtime::block_on(future)
+        compio::runtime::Runtime::new().unwrap().block_on(future)
     }
 }
 

--- a/compio/benches/named_pipe.rs
+++ b/compio/benches/named_pipe.rs
@@ -1,15 +1,7 @@
-use criterion::{async_executor::AsyncExecutor, criterion_group, criterion_main, Criterion};
+use criterion::{criterion_group, criterion_main, Criterion};
 
 criterion_group!(named_pipe, basic);
 criterion_main!(named_pipe);
-
-struct CompioRuntime;
-
-impl AsyncExecutor for CompioRuntime {
-    fn block_on<T>(&self, future: impl std::future::Future<Output = T>) -> T {
-        compio::runtime::Runtime::new().unwrap().block_on(future)
-    }
-}
 
 fn basic(c: &mut Criterion) {
     #[allow(dead_code)]
@@ -51,7 +43,8 @@ fn basic(c: &mut Criterion) {
     });
 
     group.bench_function("compio", |b| {
-        b.to_async(CompioRuntime).iter(|| async {
+        let runtime = compio::runtime::Runtime::new().unwrap();
+        b.to_async(&runtime).iter(|| async {
             #[cfg(windows)]
             {
                 use compio::{

--- a/compio/benches/net.rs
+++ b/compio/benches/net.rs
@@ -7,7 +7,7 @@ struct CompioRuntime;
 
 impl AsyncExecutor for CompioRuntime {
     fn block_on<T>(&self, future: impl std::future::Future<Output = T>) -> T {
-        compio::runtime::block_on(future)
+        compio::runtime::Runtime::new().unwrap().block_on(future)
     }
 }
 

--- a/compio/src/lib.rs
+++ b/compio/src/lib.rs
@@ -5,7 +5,7 @@
 //!
 //! ## Quick start
 //! ```rust
-//! # compio::runtime::block_on(async {
+//! # compio::runtime::Runtime::new().unwrap().block_on(async {
 //! use compio::{fs::File, io::AsyncReadAtExt};
 //!
 //! let file = File::open("Cargo.toml").await.unwrap();

--- a/compio/tests/runtime.rs
+++ b/compio/tests/runtime.rs
@@ -26,7 +26,7 @@ async fn multi_threading() {
     let rx = Unattached::new(rx).unwrap();
     if let Err(e) = std::thread::spawn(move || {
         let mut rx = rx.into_inner();
-        compio::runtime::block_on(async {
+        compio::runtime::Runtime::new().unwrap().block_on(async {
             let buffer = Vec::with_capacity(DATA.len());
             let (n, buffer) = rx.read_exact(buffer).await.unwrap();
             assert_eq!(n, buffer.len());
@@ -55,7 +55,7 @@ async fn try_clone() {
     let rx = Unattached::new(rx.try_clone().unwrap()).unwrap();
     if let Err(e) = std::thread::spawn(move || {
         let mut rx = rx.into_inner();
-        compio::runtime::block_on(async {
+        compio::runtime::Runtime::new().unwrap().block_on(async {
             let buffer = Vec::with_capacity(DATA.len());
             let (n, buffer) = rx.read_exact(buffer).await.unwrap();
             assert_eq!(n, buffer.len());


### PR DESCRIPTION
It's a little painful to force the users to use a thread local runtime, especially when dropping it. We need to expose the runtime type. This makes some logic a bit more complex. Here I write a guard type `EnterGuard` to control the "current" runtime. `Attacher` will also check if the attached runtime is the current runtime.