### PR TITLE
feat: update rustls to 0.22.0-alpha.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ widestring = "1.0.2"
 windows-sys = "0.48.0"
 
 native-tls = "0.2.11"
-rustls = "0.21.8"
-rustls-native-certs = "0.6.3"
+rustls = "0.22.0-alpha.4"
+rustls-native-certs = "0.7.0-alpha.1"
 
 hyper = "0.14"

--- a/compio-http/src/backend.rs
+++ b/compio-http/src/backend.rs
@@ -39,7 +39,7 @@ impl TlsBackend {
             Self::Rustls => {
                 let mut store = rustls::RootCertStore::empty();
                 for cert in rustls_native_certs::load_native_certs().unwrap() {
-                    store.add(&rustls::Certificate(cert.0)).unwrap();
+                    store.add(cert).unwrap();
                 }
 
                 Ok(TlsConnector::from(std::sync::Arc::new(

--- a/compio-tls/Cargo.toml
+++ b/compio-tls/Cargo.toml
@@ -31,5 +31,5 @@ rustls-native-certs = { workspace = true }
 default = ["native-tls"]
 all = ["native-tls", "rustls"]
 
-read_buf = ["compio-buf/read_buf", "compio-io/read_buf"]
+read_buf = ["compio-buf/read_buf", "compio-io/read_buf", "rustls?/read_buf"]
 nightly = ["read_buf"]

--- a/compio-tls/tests/connect.rs
+++ b/compio-tls/tests/connect.rs
@@ -30,7 +30,7 @@ async fn native() {
 async fn rtls() {
     let mut store = rustls::RootCertStore::empty();
     for cert in rustls_native_certs::load_native_certs().unwrap() {
-        store.add(&rustls::Certificate(cert.0)).unwrap();
+        store.add(cert).unwrap();
     }
 
     let connector = TlsConnector::from(Arc::new(


### PR DESCRIPTION
We can use the `read_buf` nightly feature with this new release.