### PR TITLE
docs: fix rustdoc args

### DIFF
--- a/compio-buf/Cargo.toml
+++ b/compio-buf/Cargo.toml
@@ -12,7 +12,7 @@ repository = { workspace = true }
 
 [package.metadata.docs.rs]
 all-features = true
-rustdoc-args = ["--cfg docsrs"]
+rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
 bumpalo = { version = "3.14.0", optional = true }

--- a/compio-driver/Cargo.toml
+++ b/compio-driver/Cargo.toml
@@ -12,7 +12,7 @@ repository = { workspace = true }
 
 [package.metadata.docs.rs]
 all-features = true
-rustdoc-args = ["--cfg docsrs"]
+rustdoc-args = ["--cfg", "docsrs"]
 default-target = "x86_64-pc-windows-msvc"
 targets = [
     "x86_64-pc-windows-msvc",

--- a/compio-fs/Cargo.toml
+++ b/compio-fs/Cargo.toml
@@ -12,7 +12,7 @@ repository = { workspace = true }
 
 [package.metadata.docs.rs]
 all-features = true
-rustdoc-args = ["--cfg docsrs"]
+rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
 # Workspace dependencies

--- a/compio-http-client/Cargo.toml
+++ b/compio-http-client/Cargo.toml
@@ -11,7 +11,7 @@ repository = { workspace = true }
 
 [package.metadata.docs.rs]
 all-features = true
-rustdoc-args = ["--cfg docsrs"]
+rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
 compio-buf = { workspace = true, features = ["bytes"] }

--- a/compio-http/Cargo.toml
+++ b/compio-http/Cargo.toml
@@ -11,7 +11,7 @@ repository = { workspace = true }
 
 [package.metadata.docs.rs]
 all-features = true
-rustdoc-args = ["--cfg docsrs"]
+rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
 compio-buf = { workspace = true }

--- a/compio-net/Cargo.toml
+++ b/compio-net/Cargo.toml
@@ -12,7 +12,7 @@ repository = { workspace = true }
 
 [package.metadata.docs.rs]
 all-features = true
-rustdoc-args = ["--cfg docsrs"]
+rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
 # Workspace dependencies

--- a/compio-runtime/Cargo.toml
+++ b/compio-runtime/Cargo.toml
@@ -13,7 +13,7 @@ repository = { workspace = true }
 [package.metadata.docs.rs]
 all-features = true
 default-target = "x86_64-pc-windows-msvc"
-rustdoc-args = ["--cfg docsrs"]
+rustdoc-args = ["--cfg", "docsrs"]
 targets = [
     "x86_64-pc-windows-msvc",
     "x86_64-unknown-linux-gnu",

--- a/compio-signal/Cargo.toml
+++ b/compio-signal/Cargo.toml
@@ -12,7 +12,7 @@ repository = { workspace = true }
 
 [package.metadata.docs.rs]
 all-features = true
-rustdoc-args = ["--cfg docsrs"]
+rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
 # Workspace dependencies

--- a/compio-tls/Cargo.toml
+++ b/compio-tls/Cargo.toml
@@ -11,7 +11,7 @@ repository = { workspace = true }
 
 [package.metadata.docs.rs]
 all-features = true
-rustdoc-args = ["--cfg docsrs"]
+rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
 compio-buf = { workspace = true }

--- a/compio/Cargo.toml
+++ b/compio/Cargo.toml
@@ -13,7 +13,7 @@ repository = { workspace = true }
 [package.metadata.docs.rs]
 all-features = true
 default-target = "x86_64-pc-windows-msvc"
-rustdoc-args = ["--cfg docsrs"]
+rustdoc-args = ["--cfg", "docsrs"]
 targets = [
     "x86_64-pc-windows-msvc",
     "x86_64-unknown-linux-gnu",


### PR DESCRIPTION
Nearly all docs build failed:(

The arg `--cfg docsrs` was treated as one argument.