### PR TITLE
feat(driver,runtime): wake up proactor from other threads

### DIFF
--- a/compio-driver/Cargo.toml
+++ b/compio-driver/Cargo.toml
@@ -72,6 +72,9 @@ polling = "3.3.0"
 [target.'cfg(unix)'.dependencies]
 libc = { workspace = true }
 
+[dev-dependencies]
+compio-buf = { workspace = true, features = ["arrayvec"] }
+
 [features]
 default = ["io-uring"]
 polling = ["dep:polling", "dep:crossbeam-queue"]

--- a/compio-driver/src/iocp/mod.rs
+++ b/compio-driver/src/iocp/mod.rs
@@ -393,7 +393,7 @@ impl NotifyHandle {
         Self { user_data, handle }
     }
 
-    /// Notify the event.
+    /// Notify the inner driver.
     pub fn notify(&self) -> io::Result<()> {
         syscall!(
             BOOL,

--- a/compio-driver/src/iocp/mod.rs
+++ b/compio-driver/src/iocp/mod.rs
@@ -7,7 +7,8 @@ use std::{
         OwnedHandle, RawHandle,
     },
     pin::Pin,
-    ptr::NonNull,
+    ptr::{null_mut, NonNull},
+    sync::Arc,
     task::Poll,
     time::Duration,
 };
@@ -147,13 +148,15 @@ fn ntstatus_from_win32(x: i32) -> NTSTATUS {
 
 /// Low-level driver of IOCP.
 pub(crate) struct Driver {
-    port: OwnedHandle,
+    // IOCP handle could not be duplicated.
+    port: Arc<OwnedHandle>,
     cancelled: HashSet<usize>,
     pool: AsyncifyPool,
 }
 
 impl Driver {
     const DEFAULT_CAPACITY: usize = 1024;
+    const NOTIFY: usize = usize::MAX;
 
     pub fn new(builder: &ProactorBuilder) -> io::Result<Self> {
         instrument!(compio_log::Level::TRACE, "new", ?builder);
@@ -164,7 +167,7 @@ impl Driver {
         trace!("new iocp driver at port: {port}");
         let port = unsafe { OwnedHandle::from_raw_handle(port as _) };
         Ok(Self {
-            port,
+            port: Arc::new(port),
             cancelled: HashSet::default(),
             pool: builder.create_or_get_thread_pool(),
         })
@@ -205,12 +208,16 @@ impl Driver {
             // This entry is posted by `post_driver_nop`.
             let user_data = iocp_entry.lpCompletionKey;
             trace!("entry {user_data} is posted by post_driver_nop");
-            let result = if self.cancelled.remove(&user_data) {
-                Err(io::Error::from_raw_os_error(ERROR_OPERATION_ABORTED as _))
+            if user_data != Self::NOTIFY {
+                let result = if self.cancelled.remove(&user_data) {
+                    Err(io::Error::from_raw_os_error(ERROR_OPERATION_ABORTED as _))
+                } else {
+                    Ok(0)
+                };
+                Some(Entry::new(user_data, result))
             } else {
-                Ok(0)
-            };
-            Some(Entry::new(user_data, result))
+                None
+            }
         } else {
             let transferred = iocp_entry.dwNumberOfBytesTransferred;
             // Any thin pointer is OK because we don't use the type of opcode.
@@ -350,6 +357,14 @@ impl Driver {
 
         Ok(())
     }
+
+    pub fn handle(&self) -> io::Result<NotifyHandle> {
+        self.handle_for(Self::NOTIFY)
+    }
+
+    pub fn handle_for(&self, user_data: usize) -> io::Result<NotifyHandle> {
+        Ok(NotifyHandle::new(user_data, self.port.clone()))
+    }
 }
 
 impl AsRawFd for Driver {
@@ -361,6 +376,35 @@ impl AsRawFd for Driver {
 impl Drop for Driver {
     fn drop(&mut self) {
         syscall!(SOCKET, WSACleanup()).ok();
+    }
+}
+
+/// A notify handle to the inner driver.
+pub struct NotifyHandle {
+    user_data: usize,
+    handle: Arc<OwnedHandle>,
+}
+
+unsafe impl Send for NotifyHandle {}
+unsafe impl Sync for NotifyHandle {}
+
+impl NotifyHandle {
+    fn new(user_data: usize, handle: Arc<OwnedHandle>) -> Self {
+        Self { user_data, handle }
+    }
+
+    /// Notify the event.
+    pub fn notify(&self) -> io::Result<()> {
+        syscall!(
+            BOOL,
+            PostQueuedCompletionStatus(
+                self.handle.as_raw_handle() as _,
+                0,
+                self.user_data,
+                null_mut()
+            )
+        )?;
+        Ok(())
     }
 }
 

--- a/compio-driver/src/lib.rs
+++ b/compio-driver/src/lib.rs
@@ -255,8 +255,12 @@ impl Proactor {
     }
 
     /// Create a notify handle for specified user_data.
+    ///
+    /// # Safety
+    ///
+    /// The caller should ensure `user_data` being valid.
     #[cfg(windows)]
-    pub fn handle_for(&self, user_data: usize) -> io::Result<NotifyHandle> {
+    pub unsafe fn handle_for(&self, user_data: usize) -> io::Result<NotifyHandle> {
         self.driver.handle_for(user_data)
     }
 }

--- a/compio-driver/src/lib.rs
+++ b/compio-driver/src/lib.rs
@@ -248,6 +248,17 @@ impl Proactor {
             })
         })
     }
+
+    /// Create a notify handle to interrupt the inner driver.
+    pub fn handle(&self) -> io::Result<NotifyHandle> {
+        self.driver.handle()
+    }
+
+    /// Create a notify handle for specified user_data.
+    #[cfg(windows)]
+    pub fn handle_for(&self, user_data: usize) -> io::Result<NotifyHandle> {
+        self.driver.handle_for(user_data)
+    }
 }
 
 impl AsRawFd for Proactor {

--- a/compio-driver/src/poll/mod.rs
+++ b/compio-driver/src/poll/mod.rs
@@ -296,6 +296,10 @@ impl Driver {
         }
         Ok(())
     }
+
+    pub fn handle(&self) -> io::Result<NotifyHandle> {
+        Ok(NotifyHandle::new(self.poll.clone()))
+    }
 }
 
 impl AsRawFd for Driver {
@@ -320,4 +324,20 @@ fn entry_cancelled(user_data: usize) -> Entry {
         user_data,
         Err(io::Error::from_raw_os_error(libc::ETIMEDOUT)),
     )
+}
+
+/// A notify handle to the inner driver.
+pub struct NotifyHandle {
+    poll: Arc<Poller>,
+}
+
+impl NotifyHandle {
+    fn new(poll: Arc<Poller>) -> Self {
+        Self { poll }
+    }
+
+    /// Notify the inner driver.
+    pub fn notify(&self) -> io::Result<()> {
+        self.poll.notify()
+    }
 }

--- a/compio-driver/tests/file.rs
+++ b/compio-driver/tests/file.rs
@@ -133,3 +133,20 @@ fn register_multiple() {
     let op = CloseFile::new(fd);
     push_and_wait(&mut driver, op);
 }
+
+#[test]
+fn notify() {
+    let mut driver = Proactor::new().unwrap();
+
+    let handle = driver.handle().unwrap();
+
+    let thread = std::thread::spawn(move || {
+        std::thread::sleep(Duration::from_secs(1));
+        handle.notify().unwrap()
+    });
+
+    let mut entries = ArrayVec::<Entry, 1>::new();
+    driver.poll(None, &mut entries).unwrap();
+
+    thread.join().unwrap();
+}

--- a/compio-runtime/Cargo.toml
+++ b/compio-runtime/Cargo.toml
@@ -36,9 +36,9 @@ compio-log = { workspace = true }
 async-task = "4.5.0"
 cfg-if = { workspace = true, optional = true }
 criterion = { workspace = true, optional = true }
+crossbeam-queue = { workspace = true }
 futures-util = { workspace = true }
 once_cell = { workspace = true }
-send_wrapper = { workspace = true }
 slab = { workspace = true, optional = true }
 smallvec = "1.11.1"
 

--- a/compio-runtime/src/event/iocp.rs
+++ b/compio-runtime/src/event/iocp.rs
@@ -45,7 +45,7 @@ impl EventHandle {
     fn new(user_data: &Key<NopPending>) -> io::Result<Self> {
         let runtime = Runtime::current();
         Ok(Self {
-            handle: runtime.inner().handle_for(**user_data)?,
+            handle: unsafe { runtime.inner().handle_for(**user_data)? },
         })
     }
 

--- a/compio-runtime/src/runtime/mod.rs
+++ b/compio-runtime/src/runtime/mod.rs
@@ -56,7 +56,7 @@ impl RuntimeInner {
     }
 
     #[cfg(all(windows, feature = "event"))]
-    pub fn handle_for(&self, user_data: usize) -> io::Result<compio_driver::NotifyHandle> {
+    pub unsafe fn handle_for(&self, user_data: usize) -> io::Result<compio_driver::NotifyHandle> {
         self.driver.borrow().handle_for(user_data)
     }
 

--- a/compio-runtime/src/runtime/mod.rs
+++ b/compio-runtime/src/runtime/mod.rs
@@ -1,18 +1,20 @@
 use std::{
     cell::RefCell,
-    collections::VecDeque,
     future::{ready, Future},
     io,
     rc::{Rc, Weak},
-    sync::atomic::{AtomicUsize, Ordering},
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    },
     task::{Context, Poll},
 };
 
 use async_task::{Runnable, Task};
 use compio_driver::{AsRawFd, Entry, OpCode, Proactor, ProactorBuilder, PushEntry, RawFd};
 use compio_log::{debug, instrument};
+use crossbeam_queue::SegQueue;
 use futures_util::future::Either;
-use send_wrapper::SendWrapper;
 use smallvec::SmallVec;
 
 pub(crate) mod op;
@@ -31,7 +33,7 @@ static RUNTIME_COUNTER: AtomicUsize = AtomicUsize::new(0);
 pub(crate) struct RuntimeInner {
     id: usize,
     driver: RefCell<Proactor>,
-    runnables: Rc<RefCell<VecDeque<Runnable>>>,
+    runnables: Arc<SegQueue<Runnable>>,
     op_runtime: RefCell<OpRuntime>,
     #[cfg(feature = "time")]
     timer_runtime: RefCell<TimerRuntime>,
@@ -42,7 +44,7 @@ impl RuntimeInner {
         Ok(Self {
             id: RUNTIME_COUNTER.fetch_add(1, Ordering::AcqRel),
             driver: RefCell::new(builder.build()?),
-            runnables: Rc::new(RefCell::default()),
+            runnables: Arc::new(SegQueue::new()),
             op_runtime: RefCell::default(),
             #[cfg(feature = "time")]
             timer_runtime: RefCell::new(TimerRuntime::new()),
@@ -53,13 +55,22 @@ impl RuntimeInner {
         self.id
     }
 
+    #[cfg(all(windows, feature = "event"))]
+    pub fn handle_for(&self, user_data: usize) -> io::Result<compio_driver::NotifyHandle> {
+        self.driver.borrow().handle_for(user_data)
+    }
+
     // Safety: the return runnable should be scheduled.
     unsafe fn spawn_unchecked<F: Future>(&self, future: F) -> Task<F::Output> {
-        // clone is cheap because it is Rc;
-        // SendWrapper is used to avoid cross-thread scheduling.
-        let runnables = SendWrapper::new(self.runnables.clone());
+        let runnables = self.runnables.clone();
+        let handle = self
+            .driver
+            .borrow()
+            .handle()
+            .expect("cannot create notify handle of the proactor");
         let schedule = move |runnable| {
-            runnables.borrow_mut().push_back(runnable);
+            runnables.push(runnable);
+            handle.notify().ok();
         };
         let (runnable, task) = async_task::spawn_unchecked(future, schedule);
         runnable.schedule();
@@ -71,7 +82,7 @@ impl RuntimeInner {
         unsafe { self.spawn_unchecked(async { result = Some(future.await) }) }.detach();
         loop {
             loop {
-                let next_task = self.runnables.borrow_mut().pop_front();
+                let next_task = self.runnables.pop();
                 if let Some(task) = next_task {
                     task.run();
                 } else {

--- a/compio/Cargo.toml
+++ b/compio/Cargo.toml
@@ -48,6 +48,7 @@ compio-runtime = { workspace = true, features = ["criterion"] }
 compio-macros = { workspace = true }
 
 criterion = { workspace = true, features = ["async_tokio"] }
+futures-channel = { workspace = true }
 futures-util = { workspace = true }
 tempfile = { workspace = true }
 tokio = { workspace = true, features = [


### PR DESCRIPTION
Closes #144

See also: #108

The waker of compio could be waked in other threads. They will push the task into the queue safely and wake up the proactor.