### PR TITLE
refactor(runtime): make Attacher a container

### DIFF
--- a/compio-driver/src/fusion/mod.rs
+++ b/compio-driver/src/fusion/mod.rs
@@ -6,15 +6,14 @@ mod iour;
 
 pub(crate) mod op;
 
-pub use iour::OpCode as IourOpCode;
-pub use poll::OpCode as PollOpCode;
 #[cfg_attr(all(doc, docsrs), doc(cfg(all())))]
 pub use std::os::fd::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
 use std::{io, task::Poll, time::Duration};
 
 pub use driver_type::DriverType;
+pub use iour::OpCode as IourOpCode;
 pub(crate) use iour::{sockaddr_storage, socklen_t};
-pub use poll::Decision;
+pub use poll::{Decision, OpCode as PollOpCode};
 use slab::Slab;
 
 pub(crate) use crate::unix::RawOp;
@@ -34,7 +33,7 @@ mod driver_type {
     #[derive(Debug, Clone, Copy, PartialEq, Eq)]
     pub enum DriverType {
         /// Using `polling` driver
-        Poll = POLLING,
+        Poll    = POLLING,
 
         /// Using `io-uring` driver
         IoUring = IO_URING,

--- a/compio-fs/Cargo.toml
+++ b/compio-fs/Cargo.toml
@@ -16,10 +16,10 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
 # Workspace dependencies
-compio-buf = { workspace = true, optional = true }
+compio-buf = { workspace = true }
 compio-driver = { workspace = true }
-compio-io = { workspace = true, optional = true }
-compio-runtime = { workspace = true, optional = true }
+compio-io = { workspace = true }
+compio-runtime = { workspace = true }
 
 # Windows specific dependencies
 [target.'cfg(windows)'.dependencies]
@@ -55,6 +55,3 @@ windows-sys = { workspace = true, features = ["Win32_Security_Authorization"] }
 # Unix specific dev dependencies
 [target.'cfg(unix)'.dev-dependencies]
 nix = { workspace = true, features = ["fs"] }
-
-[features]
-runtime = ["dep:compio-buf", "dep:compio-io", "dep:compio-runtime"]

--- a/compio-fs/src/file.rs
+++ b/compio-fs/src/file.rs
@@ -1,20 +1,20 @@
-use std::{fs::Metadata, io};
+use std::{fs::Metadata, future::Future, io, mem::ManuallyDrop, path::Path};
 
-use compio_driver::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
-#[cfg(feature = "runtime")]
-use {
-    crate::OpenOptions,
-    compio_buf::{buf_try, BufResult, IntoInner, IoBuf, IoBufMut},
-    compio_driver::op::{BufResultExt, CloseFile, ReadAt, Sync, WriteAt},
-    compio_io::{AsyncReadAt, AsyncWriteAt},
-    compio_runtime::{Attachable, Attacher, Runtime},
-    std::{future::Future, mem::ManuallyDrop, path::Path},
+use compio_buf::{buf_try, BufResult, IntoInner, IoBuf, IoBufMut};
+use compio_driver::{
+    impl_raw_fd,
+    op::{BufResultExt, CloseFile, ReadAt, Sync, WriteAt},
+    AsRawFd,
 };
-#[cfg(all(feature = "runtime", unix))]
+use compio_io::{AsyncReadAt, AsyncWriteAt};
+use compio_runtime::{impl_attachable, Attacher, Runtime, TryClone};
+#[cfg(unix)]
 use {
     compio_buf::{IoVectoredBuf, IoVectoredBufMut},
     compio_driver::op::{ReadVectoredAt, WriteVectoredAt},
 };
+
+use crate::OpenOptions;
 
 /// A reference to an open file on the filesystem.
 ///
@@ -24,16 +24,13 @@ use {
 /// required to specify an offset when issuing an operation.
 #[derive(Debug)]
 pub struct File {
-    inner: std::fs::File,
-    #[cfg(feature = "runtime")]
-    attacher: Attacher,
+    inner: Attacher<std::fs::File>,
 }
 
 impl File {
     /// Attempts to open a file in read-only mode.
     ///
     /// See the [`OpenOptions::open`] method for more details.
-    #[cfg(feature = "runtime")]
     pub async fn open(path: impl AsRef<Path>) -> io::Result<Self> {
         OpenOptions::new().read(true).open(path).await
     }
@@ -44,7 +41,6 @@ impl File {
     /// and will truncate it if it does.
     ///
     /// See the [`OpenOptions::open`] function for more details.
-    #[cfg(feature = "runtime")]
     pub async fn create(path: impl AsRef<Path>) -> io::Result<Self> {
         OpenOptions::new()
             .create(true)
@@ -56,14 +52,13 @@ impl File {
 
     /// Close the file. If the returned future is dropped before polling, the
     /// file won't be closed.
-    #[cfg(feature = "runtime")]
     pub fn close(self) -> impl Future<Output = io::Result<()>> {
         // Make sure that self won't be dropped after `close` called.
         // Users may call this method and drop the future immediately. In that way the
         // `close` should be cancelled.
         let this = ManuallyDrop::new(self);
         async move {
-            let op = CloseFile::new(this.as_raw_fd());
+            let op = CloseFile::new(this.inner.try_get()?.as_raw_fd());
             Runtime::current().submit(op).await.0?;
             Ok(())
         }
@@ -75,22 +70,20 @@ impl File {
     /// It does not clear the attach state.
     pub fn try_clone(&self) -> io::Result<Self> {
         let inner = self.inner.try_clone()?;
-        Ok(Self {
-            #[cfg(feature = "runtime")]
-            attacher: self.attacher.try_clone(&inner)?,
-            inner,
-        })
+        Ok(Self { inner })
+    }
+
+    pub(crate) fn try_get(&self) -> io::Result<&std::fs::File> {
+        self.inner.try_get()
     }
 
     /// Queries metadata about the underlying file.
     pub fn metadata(&self) -> io::Result<Metadata> {
-        self.inner.metadata()
+        self.try_get()?.metadata()
     }
 
-    #[cfg(feature = "runtime")]
     async fn sync_impl(&self, datasync: bool) -> io::Result<()> {
-        self.attach()?;
-        let op = Sync::new(self.as_raw_fd(), datasync);
+        let op = Sync::new(self.try_get()?.as_raw_fd(), datasync);
         Runtime::current().submit(op).await.0?;
         Ok(())
     }
@@ -99,7 +92,6 @@ impl File {
     ///
     /// This function will attempt to ensure that all in-memory data reaches the
     /// filesystem before returning.
-    #[cfg(feature = "runtime")]
     pub async fn sync_all(&self) -> io::Result<()> {
         self.sync_impl(false).await
     }
@@ -115,17 +107,15 @@ impl File {
     /// [`sync_all`].
     ///
     /// [`sync_all`]: File::sync_all
-    #[cfg(feature = "runtime")]
     pub async fn sync_data(&self) -> io::Result<()> {
         self.sync_impl(true).await
     }
 }
 
-#[cfg(feature = "runtime")]
 impl AsyncReadAt for File {
     async fn read_at<T: IoBufMut>(&self, buffer: T, pos: u64) -> BufResult<usize, T> {
-        let ((), buffer) = buf_try!(self.attach(), buffer);
-        let op = ReadAt::new(self.as_raw_fd(), pos, buffer);
+        let (inner, buffer) = buf_try!(self.try_get(), buffer);
+        let op = ReadAt::new(inner.as_raw_fd(), pos, buffer);
         Runtime::current()
             .submit(op)
             .await
@@ -139,8 +129,8 @@ impl AsyncReadAt for File {
         buffer: T,
         pos: u64,
     ) -> BufResult<usize, T> {
-        let ((), buffer) = buf_try!(self.attach(), buffer);
-        let op = ReadVectoredAt::new(self.as_raw_fd(), pos, buffer);
+        let (inner, buffer) = buf_try!(self.try_get(), buffer);
+        let op = ReadVectoredAt::new(inner.as_raw_fd(), pos, buffer);
         Runtime::current()
             .submit(op)
             .await
@@ -149,7 +139,6 @@ impl AsyncReadAt for File {
     }
 }
 
-#[cfg(feature = "runtime")]
 impl AsyncWriteAt for File {
     #[inline]
     async fn write_at<T: IoBuf>(&mut self, buf: T, pos: u64) -> BufResult<usize, T> {
@@ -167,11 +156,10 @@ impl AsyncWriteAt for File {
     }
 }
 
-#[cfg(feature = "runtime")]
 impl AsyncWriteAt for &File {
     async fn write_at<T: IoBuf>(&mut self, buffer: T, pos: u64) -> BufResult<usize, T> {
-        let ((), buffer) = buf_try!(self.attach(), buffer);
-        let op = WriteAt::new(self.as_raw_fd(), pos, buffer);
+        let (inner, buffer) = buf_try!(self.try_get(), buffer);
+        let op = WriteAt::new(inner.as_raw_fd(), pos, buffer);
         Runtime::current().submit(op).await.into_inner()
     }
 
@@ -181,41 +169,12 @@ impl AsyncWriteAt for &File {
         buffer: T,
         pos: u64,
     ) -> BufResult<usize, T> {
-        let ((), buffer) = buf_try!(self.attach(), buffer);
-        let op = WriteVectoredAt::new(self.as_raw_fd(), pos, buffer);
+        let (inner, buffer) = buf_try!(self.try_get(), buffer);
+        let op = WriteVectoredAt::new(inner.as_raw_fd(), pos, buffer);
         Runtime::current().submit(op).await.into_inner()
     }
 }
 
-impl AsRawFd for File {
-    fn as_raw_fd(&self) -> RawFd {
-        self.inner.as_raw_fd()
-    }
-}
+impl_raw_fd!(File, inner);
 
-impl FromRawFd for File {
-    unsafe fn from_raw_fd(fd: RawFd) -> Self {
-        Self {
-            inner: FromRawFd::from_raw_fd(fd),
-            #[cfg(feature = "runtime")]
-            attacher: compio_runtime::Attacher::new(),
-        }
-    }
-}
-
-impl IntoRawFd for File {
-    fn into_raw_fd(self) -> RawFd {
-        self.inner.into_raw_fd()
-    }
-}
-
-#[cfg(feature = "runtime")]
-impl Attachable for File {
-    fn attach(&self) -> io::Result<()> {
-        self.attacher.attach(self)
-    }
-
-    fn is_attached(&self) -> bool {
-        self.attacher.is_attached()
-    }
-}
+impl_attachable!(File, inner);

--- a/compio-fs/src/file.rs
+++ b/compio-fs/src/file.rs
@@ -1,10 +1,7 @@
 use std::{fs::Metadata, future::Future, io, mem::ManuallyDrop, path::Path};
 
 use compio_buf::{buf_try, BufResult, IntoInner, IoBuf, IoBufMut};
-use compio_driver::{
-    op::{BufResultExt, CloseFile, ReadAt, Sync, WriteAt},
-    AsRawFd,
-};
+use compio_driver::op::{BufResultExt, CloseFile, ReadAt, Sync, WriteAt};
 use compio_io::{AsyncReadAt, AsyncWriteAt};
 use compio_runtime::{
     impl_attachable, impl_try_as_raw_fd, Attacher, Runtime, TryAsRawFd, TryClone,

--- a/compio-fs/src/file.rs
+++ b/compio-fs/src/file.rs
@@ -2,12 +2,11 @@ use std::{fs::Metadata, future::Future, io, mem::ManuallyDrop, path::Path};
 
 use compio_buf::{buf_try, BufResult, IntoInner, IoBuf, IoBufMut};
 use compio_driver::{
-    impl_raw_fd,
     op::{BufResultExt, CloseFile, ReadAt, Sync, WriteAt},
     AsRawFd,
 };
 use compio_io::{AsyncReadAt, AsyncWriteAt};
-use compio_runtime::{impl_attachable, Attacher, Runtime, TryClone};
+use compio_runtime::{impl_attachable, impl_try_as_raw_fd, Attacher, Runtime, TryClone};
 #[cfg(unix)]
 use {
     compio_buf::{IoVectoredBuf, IoVectoredBufMut},
@@ -175,6 +174,6 @@ impl AsyncWriteAt for &File {
     }
 }
 
-impl_raw_fd!(File, inner);
+impl_try_as_raw_fd!(File, inner);
 
 impl_attachable!(File, inner);

--- a/compio-fs/src/lib.rs
+++ b/compio-fs/src/lib.rs
@@ -6,9 +6,7 @@
 mod file;
 pub use file::*;
 
-#[cfg(feature = "runtime")]
 mod open_options;
-#[cfg(feature = "runtime")]
 pub use open_options::*;
 
 #[cfg(windows)]

--- a/compio-fs/src/pipe.rs
+++ b/compio-fs/src/pipe.rs
@@ -5,7 +5,7 @@ use std::{future::Future, io, path::Path};
 use compio_buf::{buf_try, BufResult, IntoInner, IoBuf, IoBufMut, IoVectoredBuf, IoVectoredBufMut};
 use compio_driver::{
     op::{BufResultExt, Recv, RecvVectored, Send, SendVectored},
-    syscall, AsRawFd, FromRawFd, IntoRawFd,
+    syscall, FromRawFd, IntoRawFd,
 };
 use compio_io::{AsyncRead, AsyncWrite};
 use compio_runtime::{impl_attachable, impl_try_as_raw_fd, Runtime, TryAsRawFd};

--- a/compio-fs/src/pipe.rs
+++ b/compio-fs/src/pipe.rs
@@ -9,7 +9,7 @@ use compio_driver::{
     syscall, AsRawFd, FromRawFd, IntoRawFd,
 };
 use compio_io::{AsyncRead, AsyncWrite};
-use compio_runtime::{impl_attachable, Attachable, Runtime};
+use compio_runtime::{impl_attachable, Runtime};
 
 use crate::File;
 

--- a/compio-io/src/lib.rs
+++ b/compio-io/src/lib.rs
@@ -66,8 +66,8 @@
 //! # })
 //! ```
 //!
-//! Writing to `Vec<u8>`, which is extendable. Notice that the implementation will
-//! append the content to the end:
+//! Writing to `Vec<u8>`, which is extendable. Notice that the implementation
+//! will append the content to the end:
 //!
 //! ```
 //! use compio_buf::BufResult;

--- a/compio-net/Cargo.toml
+++ b/compio-net/Cargo.toml
@@ -18,8 +18,8 @@ rustdoc-args = ["--cfg", "docsrs"]
 # Workspace dependencies
 compio-buf = { workspace = true }
 compio-driver = { workspace = true }
-compio-io = { workspace = true, optional = true }
-compio-runtime = { workspace = true, optional = true, features = ["event"] }
+compio-io = { workspace = true }
+compio-runtime = { workspace = true, features = ["event"] }
 
 cfg-if = { workspace = true }
 either = "1.9.0"
@@ -42,6 +42,3 @@ compio-macros = { workspace = true }
 futures-channel = { workspace = true }
 futures-util = { workspace = true }
 tempfile = { workspace = true }
-
-[features]
-runtime = ["dep:compio-io", "dep:compio-runtime"]

--- a/compio-net/src/lib.rs
+++ b/compio-net/src/lib.rs
@@ -5,16 +5,13 @@
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 #![warn(missing_docs)]
 
-#[cfg(feature = "runtime")]
 mod resolve;
 mod socket;
 mod tcp;
 mod udp;
 mod unix;
 
-#[cfg(feature = "runtime")]
 pub use resolve::ToSocketAddrsAsync;
-#[cfg(feature = "runtime")]
 pub(crate) use resolve::{each_addr, first_addr_buf};
 pub(crate) use socket::*;
 pub use tcp::*;

--- a/compio-net/src/socket.rs
+++ b/compio-net/src/socket.rs
@@ -88,6 +88,8 @@ impl Socket {
 
     #[cfg(unix)]
     pub async fn accept(&self) -> io::Result<(Self, SockAddr)> {
+        use compio_driver::FromRawFd;
+
         let op = Accept::new(self.try_get()?.as_raw_fd());
         let BufResult(res, op) = Runtime::current().submit(op).await;
         let accept_sock = unsafe { Socket2::from_raw_fd(res? as _) };

--- a/compio-net/src/socket.rs
+++ b/compio-net/src/socket.rs
@@ -108,17 +108,18 @@ impl Socket {
     #[cfg(windows)]
     pub async fn accept(&self) -> io::Result<(Self, SockAddr)> {
         let local_addr = self.local_addr()?;
-        let accept_sock = Self::new(
+        // We should allow users sending this accepted socket to a new thread.
+        let accept_sock = Socket2::new(
             local_addr.domain(),
             self.try_get()?.r#type()?,
             self.try_get()?.protocol()?,
         )?;
-        let op = Accept::new(self.as_raw_fd(), accept_sock.as_raw_fd() as _);
+        let op = Accept::new(self.try_as_raw_fd()?, accept_sock.as_raw_fd() as _);
         let BufResult(res, op) = Runtime::current().submit(op).await;
         res?;
         op.update_context()?;
         let addr = op.into_addr()?;
-        Ok((accept_sock, addr))
+        Ok((Self::from_socket2(accept_sock), addr))
     }
 
     pub fn close(self) -> impl Future<Output = io::Result<()>> {

--- a/compio-net/src/socket.rs
+++ b/compio-net/src/socket.rs
@@ -1,12 +1,9 @@
 use std::{future::Future, io, mem::ManuallyDrop};
 
 use compio_buf::{buf_try, BufResult, IntoInner, IoBuf, IoBufMut, IoVectoredBuf, IoVectoredBufMut};
-use compio_driver::{
-    op::{
-        Accept, BufResultExt, CloseSocket, Connect, Recv, RecvFrom, RecvFromVectored,
-        RecvResultExt, RecvVectored, Send, SendTo, SendToVectored, SendVectored, ShutdownSocket,
-    },
-    AsRawFd,
+use compio_driver::op::{
+    Accept, BufResultExt, CloseSocket, Connect, Recv, RecvFrom, RecvFromVectored, RecvResultExt,
+    RecvVectored, Send, SendTo, SendToVectored, SendVectored, ShutdownSocket,
 };
 use compio_runtime::{
     impl_attachable, impl_try_as_raw_fd, Attacher, Runtime, TryAsRawFd, TryClone,
@@ -103,6 +100,8 @@ impl Socket {
 
     #[cfg(windows)]
     pub async fn accept(&self) -> io::Result<(Self, SockAddr)> {
+        use compio_driver::AsRawFd;
+
         let local_addr = self.local_addr()?;
         // We should allow users sending this accepted socket to a new thread.
         let accept_sock = Socket2::new(

--- a/compio-net/src/tcp.rs
+++ b/compio-net/src/tcp.rs
@@ -1,9 +1,8 @@
 use std::{future::Future, io, net::SocketAddr};
 
 use compio_buf::{BufResult, IoBuf, IoBufMut, IoVectoredBuf, IoVectoredBufMut};
-use compio_driver::impl_raw_fd;
 use compio_io::{AsyncRead, AsyncWrite};
-use compio_runtime::impl_attachable;
+use compio_runtime::{impl_attachable, impl_try_as_raw_fd};
 use socket2::{Protocol, SockAddr, Type};
 
 use crate::{Socket, ToSocketAddrsAsync};
@@ -118,7 +117,7 @@ impl TcpListener {
     }
 }
 
-impl_raw_fd!(TcpListener, inner);
+impl_try_as_raw_fd!(TcpListener, inner);
 
 impl_attachable!(TcpListener, inner);
 
@@ -274,6 +273,6 @@ impl AsyncWrite for &TcpStream {
     }
 }
 
-impl_raw_fd!(TcpStream, inner);
+impl_try_as_raw_fd!(TcpStream, inner);
 
 impl_attachable!(TcpStream, inner);

--- a/compio-net/src/udp.rs
+++ b/compio-net/src/udp.rs
@@ -1,16 +1,11 @@
-use std::{io, net::SocketAddr};
+use std::{future::Future, io, net::SocketAddr};
 
+use compio_buf::{BufResult, IoBuf, IoBufMut, IoVectoredBuf, IoVectoredBufMut};
 use compio_driver::impl_raw_fd;
-#[cfg(feature = "runtime")]
-use {
-    crate::ToSocketAddrsAsync,
-    compio_buf::{BufResult, IoBuf, IoBufMut, IoVectoredBuf, IoVectoredBufMut},
-    compio_runtime::impl_attachable,
-    socket2::{Protocol, SockAddr, Type},
-    std::future::Future,
-};
+use compio_runtime::impl_attachable;
+use socket2::{Protocol, SockAddr, Type};
 
-use crate::Socket;
+use crate::{Socket, ToSocketAddrsAsync};
 
 /// A UDP socket.
 ///
@@ -98,7 +93,6 @@ pub struct UdpSocket {
 
 impl UdpSocket {
     /// Creates a new UDP socket and attempt to bind it to the addr provided.
-    #[cfg(feature = "runtime")]
     pub async fn bind(addr: impl ToSocketAddrsAsync) -> io::Result<Self> {
         super::each_addr(addr, |addr| async move {
             Ok(Self {
@@ -115,7 +109,6 @@ impl UdpSocket {
     /// Note that usually, a successful `connect` call does not specify
     /// that there is a remote server listening on the port, rather, such an
     /// error would only be detected after the first send.
-    #[cfg(feature = "runtime")]
     pub async fn connect(&self, addr: impl ToSocketAddrsAsync) -> io::Result<()> {
         super::each_addr(addr, |addr| async move {
             self.inner.connect(&SockAddr::from(addr))
@@ -125,7 +118,6 @@ impl UdpSocket {
 
     /// Close the socket. If the returned future is dropped before polling, the
     /// socket won't be closed.
-    #[cfg(feature = "runtime")]
     pub fn close(self) -> impl Future<Output = io::Result<()>> {
         self.inner.close()
     }
@@ -196,35 +188,30 @@ impl UdpSocket {
 
     /// Receives a packet of data from the socket into the buffer, returning the
     /// original buffer and quantity of data received.
-    #[cfg(feature = "runtime")]
     pub async fn recv<T: IoBufMut>(&self, buffer: T) -> BufResult<usize, T> {
         self.inner.recv(buffer).await
     }
 
     /// Receives a packet of data from the socket into the buffer, returning the
     /// original buffer and quantity of data received.
-    #[cfg(feature = "runtime")]
     pub async fn recv_vectored<T: IoVectoredBufMut>(&self, buffer: T) -> BufResult<usize, T> {
         self.inner.recv_vectored(buffer).await
     }
 
     /// Sends some data to the socket from the buffer, returning the original
     /// buffer and quantity of data sent.
-    #[cfg(feature = "runtime")]
     pub async fn send<T: IoBuf>(&self, buffer: T) -> BufResult<usize, T> {
         self.inner.send(buffer).await
     }
 
     /// Sends some data to the socket from the buffer, returning the original
     /// buffer and quantity of data sent.
-    #[cfg(feature = "runtime")]
     pub async fn send_vectored<T: IoVectoredBuf>(&self, buffer: T) -> BufResult<usize, T> {
         self.inner.send_vectored(buffer).await
     }
 
     /// Receives a single datagram message on the socket. On success, returns
     /// the number of bytes received and the origin.
-    #[cfg(feature = "runtime")]
     pub async fn recv_from<T: IoBufMut>(&self, buffer: T) -> BufResult<(usize, SocketAddr), T> {
         self.inner
             .recv_from(buffer)
@@ -234,7 +221,6 @@ impl UdpSocket {
 
     /// Receives a single datagram message on the socket. On success, returns
     /// the number of bytes received and the origin.
-    #[cfg(feature = "runtime")]
     pub async fn recv_from_vectored<T: IoVectoredBufMut>(
         &self,
         buffer: T,
@@ -247,7 +233,6 @@ impl UdpSocket {
 
     /// Sends data on the socket to the given address. On success, returns the
     /// number of bytes sent.
-    #[cfg(feature = "runtime")]
     pub async fn send_to<T: IoBuf>(
         &self,
         buffer: T,
@@ -261,7 +246,6 @@ impl UdpSocket {
 
     /// Sends data on the socket to the given address. On success, returns the
     /// number of bytes sent.
-    #[cfg(feature = "runtime")]
     pub async fn send_to_vectored<T: IoVectoredBuf>(
         &self,
         buffer: T,
@@ -278,5 +262,4 @@ impl UdpSocket {
 
 impl_raw_fd!(UdpSocket, inner);
 
-#[cfg(feature = "runtime")]
 impl_attachable!(UdpSocket, inner);

--- a/compio-net/src/udp.rs
+++ b/compio-net/src/udp.rs
@@ -1,8 +1,7 @@
 use std::{future::Future, io, net::SocketAddr};
 
 use compio_buf::{BufResult, IoBuf, IoBufMut, IoVectoredBuf, IoVectoredBufMut};
-use compio_driver::impl_raw_fd;
-use compio_runtime::impl_attachable;
+use compio_runtime::{impl_attachable, impl_try_as_raw_fd};
 use socket2::{Protocol, SockAddr, Type};
 
 use crate::{Socket, ToSocketAddrsAsync};
@@ -260,6 +259,6 @@ impl UdpSocket {
     }
 }
 
-impl_raw_fd!(UdpSocket, inner);
+impl_try_as_raw_fd!(UdpSocket, inner);
 
 impl_attachable!(UdpSocket, inner);

--- a/compio-net/src/unix.rs
+++ b/compio-net/src/unix.rs
@@ -1,9 +1,8 @@
 use std::{future::Future, io, path::Path};
 
 use compio_buf::{BufResult, IoBuf, IoBufMut, IoVectoredBuf, IoVectoredBufMut};
-use compio_driver::impl_raw_fd;
 use compio_io::{AsyncRead, AsyncWrite};
-use compio_runtime::impl_attachable;
+use compio_runtime::{impl_attachable, impl_try_as_raw_fd};
 use socket2::{Domain, SockAddr, Type};
 
 use crate::Socket;
@@ -90,7 +89,7 @@ impl UnixListener {
     }
 }
 
-impl_raw_fd!(UnixListener, inner);
+impl_try_as_raw_fd!(UnixListener, inner);
 
 impl_attachable!(UnixListener, inner);
 
@@ -230,6 +229,6 @@ impl AsyncWrite for &UnixStream {
     }
 }
 
-impl_raw_fd!(UnixStream, inner);
+impl_try_as_raw_fd!(UnixStream, inner);
 
 impl_attachable!(UnixStream, inner);

--- a/compio-net/src/unix.rs
+++ b/compio-net/src/unix.rs
@@ -1,14 +1,10 @@
-use std::{io, path::Path};
+use std::{future::Future, io, path::Path};
 
+use compio_buf::{BufResult, IoBuf, IoBufMut, IoVectoredBuf, IoVectoredBufMut};
 use compio_driver::impl_raw_fd;
+use compio_io::{AsyncRead, AsyncWrite};
+use compio_runtime::impl_attachable;
 use socket2::{Domain, SockAddr, Type};
-#[cfg(feature = "runtime")]
-use {
-    compio_buf::{BufResult, IoBuf, IoBufMut, IoVectoredBuf, IoVectoredBufMut},
-    compio_io::{AsyncRead, AsyncWrite},
-    compio_runtime::impl_attachable,
-    std::future::Future,
-};
 
 use crate::Socket;
 
@@ -64,7 +60,6 @@ impl UnixListener {
 
     /// Close the socket. If the returned future is dropped before polling, the
     /// socket won't be closed.
-    #[cfg(feature = "runtime")]
     pub fn close(self) -> impl Future<Output = io::Result<()>> {
         self.inner.close()
     }
@@ -83,7 +78,6 @@ impl UnixListener {
     /// This function will yield once a new Unix domain socket connection
     /// is established. When established, the corresponding [`UnixStream`] and
     /// will be returned.
-    #[cfg(feature = "runtime")]
     pub async fn accept(&self) -> io::Result<(UnixStream, SockAddr)> {
         let (socket, addr) = self.inner.accept().await?;
         let stream = UnixStream { inner: socket };
@@ -98,7 +92,6 @@ impl UnixListener {
 
 impl_raw_fd!(UnixListener, inner);
 
-#[cfg(feature = "runtime")]
 impl_attachable!(UnixListener, inner);
 
 /// A Unix stream between two local sockets on Windows & WSL.
@@ -145,7 +138,6 @@ impl UnixStream {
 
     /// Close the socket. If the returned future is dropped before polling, the
     /// socket won't be closed.
-    #[cfg(feature = "runtime")]
     pub fn close(self) -> impl Future<Output = io::Result<()>> {
         self.inner.close()
     }
@@ -170,7 +162,6 @@ impl UnixStream {
     }
 }
 
-#[cfg(feature = "runtime")]
 impl AsyncRead for UnixStream {
     #[inline]
     async fn read<B: IoBufMut>(&mut self, buf: B) -> BufResult<usize, B> {
@@ -183,7 +174,6 @@ impl AsyncRead for UnixStream {
     }
 }
 
-#[cfg(feature = "runtime")]
 impl AsyncRead for &UnixStream {
     #[inline]
     async fn read<B: IoBufMut>(&mut self, buf: B) -> BufResult<usize, B> {
@@ -196,7 +186,6 @@ impl AsyncRead for &UnixStream {
     }
 }
 
-#[cfg(feature = "runtime")]
 impl AsyncWrite for UnixStream {
     #[inline]
     async fn write<T: IoBuf>(&mut self, buf: T) -> BufResult<usize, T> {
@@ -219,7 +208,6 @@ impl AsyncWrite for UnixStream {
     }
 }
 
-#[cfg(feature = "runtime")]
 impl AsyncWrite for &UnixStream {
     #[inline]
     async fn write<T: IoBuf>(&mut self, buf: T) -> BufResult<usize, T> {
@@ -244,5 +232,4 @@ impl AsyncWrite for &UnixStream {
 
 impl_raw_fd!(UnixStream, inner);
 
-#[cfg(feature = "runtime")]
 impl_attachable!(UnixStream, inner);

--- a/compio-runtime/Cargo.toml
+++ b/compio-runtime/Cargo.toml
@@ -41,6 +41,7 @@ futures-util = { workspace = true }
 once_cell = { workspace = true }
 slab = { workspace = true, optional = true }
 smallvec = "1.11.1"
+socket2 = { workspace = true }
 
 # Windows specific dependencies
 [target.'cfg(windows)'.dependencies]

--- a/compio-runtime/src/attacher.rs
+++ b/compio-runtime/src/attacher.rs
@@ -17,9 +17,8 @@ use crate::Runtime;
 
 /// Attach a handle to the driver of current thread.
 ///
-/// A handle can and only can attach once to one driver. However, the handle
-/// itself is Send & Sync. We mark it !Send & !Sync to warn users, making them
-/// ensure that they are using it in the correct thread.
+/// A handle can and only can attach once to one driver. The attacher will check
+/// if it is attached to the current driver.
 #[derive(Debug, Clone)]
 pub struct Attacher<S> {
     source: S,
@@ -29,7 +28,7 @@ pub struct Attacher<S> {
 
 impl<S> Attacher<S> {
     /// Create [`Attacher`].
-    pub fn new(source: S) -> Self {
+    pub const fn new(source: S) -> Self {
         Self {
             source,
             once: OnceLock::new(),
@@ -222,7 +221,7 @@ impl<S: AsRawFd> TryAsRawFd for Attacher<S> {
 
 /// A [`Send`] wrapper for attachable resource that has not been attached. The
 /// resource should be able to send to another thread before attaching.
-pub struct Unattached<T: Attachable>(T);
+pub struct Unattached<T>(T);
 
 impl<T: Attachable> Unattached<T> {
     /// Create the [`Unattached`] wrapper, or fail if the resource has already

--- a/compio-runtime/src/attacher.rs
+++ b/compio-runtime/src/attacher.rs
@@ -63,10 +63,30 @@ impl<S: AsRawFd> Attacher<S> {
         Ok(&self.source)
     }
 
+    /// Get the reference of the inner source without attaching it.
+    ///
+    /// # Safety
+    ///
+    /// The caller should ensure it is attached before submit an operation with
+    /// it.
+    pub unsafe fn get_unchecked(&self) -> &S {
+        &self.source
+    }
+
     /// Attach the inner source and get the mutable reference.
     pub fn try_get_mut(&mut self) -> io::Result<&mut S> {
         self.attach()?;
         Ok(&mut self.source)
+    }
+
+    /// Get the mutable reference of the inner source without attaching it.
+    ///
+    /// # Safety
+    ///
+    /// The caller should ensure it is attached before submit an operation with
+    /// it.
+    pub unsafe fn get_unchecked_mut(&mut self) -> &mut S {
+        &mut self.source
     }
 }
 

--- a/compio-runtime/src/event/eventfd.rs
+++ b/compio-runtime/src/event/eventfd.rs
@@ -34,7 +34,7 @@ impl Event {
     pub async fn wait(self) -> io::Result<()> {
         let buffer = ArrayVec::<u8, 8>::new();
         // Trick: Recv uses readv which doesn't seek.
-        let op = Recv::new(self.fd.try_get()?.as_raw_fd(), buffer);
+        let op = Recv::new(self.fd.try_as_raw_fd()?, buffer);
         let BufResult(res, _) = Runtime::current().submit(op).await;
         res?;
         Ok(())

--- a/compio-runtime/src/event/eventfd.rs
+++ b/compio-runtime/src/event/eventfd.rs
@@ -6,7 +6,7 @@ use std::{
 use compio_buf::{arrayvec::ArrayVec, BufResult, IntoInner};
 use compio_driver::{impl_raw_fd, op::Recv, syscall};
 
-use crate::{attacher::Attacher, impl_try_as_raw_fd, Runtime, TryClone};
+use crate::{attacher::Attacher, impl_try_as_raw_fd, Runtime, TryAsRawFd, TryClone};
 
 /// An event that won't wake until [`EventHandle::notify`] is called
 /// successfully.

--- a/compio-runtime/src/event/pipe.rs
+++ b/compio-runtime/src/event/pipe.rs
@@ -50,12 +50,6 @@ impl Event {
     }
 }
 
-impl AsRawFd for Event {
-    fn as_raw_fd(&self) -> RawFd {
-        self.receiver.as_raw_fd()
-    }
-}
-
 /// A handle to [`Event`].
 pub struct EventHandle {
     fd: OwnedFd,

--- a/compio-runtime/src/event/pipe.rs
+++ b/compio-runtime/src/event/pipe.rs
@@ -6,7 +6,7 @@ use std::{
 use compio_buf::{arrayvec::ArrayVec, BufResult};
 use compio_driver::{impl_raw_fd, op::Recv, syscall};
 
-use crate::{attacher::Attacher, Runtime};
+use crate::{attacher::Attacher, Runtime, TryAsRawFd};
 
 /// An event that won't wake until [`EventHandle::notify`] is called
 /// successfully.
@@ -47,6 +47,16 @@ impl Event {
         let BufResult(res, _) = Runtime::current().submit(op).await;
         res?;
         Ok(())
+    }
+}
+
+impl TryAsRawFd for Event {
+    fn try_as_raw_fd(&self) -> io::Result<RawFd> {
+        self.receiver.try_as_raw_fd()
+    }
+
+    unsafe fn as_raw_fd_unchecked(&self) -> RawFd {
+        self.receiver.as_raw_fd_unchecked()
     }
 }
 

--- a/compio-signal/src/unix.rs
+++ b/compio-signal/src/unix.rs
@@ -1,13 +1,11 @@
 //! Unix-specific types for signal handling.
 
-use std::{
-    cell::RefCell,
-    collections::HashMap,
-    io,
-    os::fd::{AsRawFd, RawFd},
-};
+use std::{cell::RefCell, collections::HashMap, io, os::fd::RawFd};
 
-use compio_runtime::event::{Event, EventHandle};
+use compio_runtime::{
+    event::{Event, EventHandle},
+    TryAsRawFd,
+};
 
 thread_local! {
     static HANDLER: RefCell<HashMap<i32, HashMap<RawFd, EventHandle>>> =
@@ -37,7 +35,7 @@ unsafe fn uninit(sig: i32) {
 
 fn register(sig: i32, fd: &Event) -> io::Result<()> {
     unsafe { init(sig) };
-    let raw_fd = fd.as_raw_fd();
+    let raw_fd = fd.try_as_raw_fd()?;
     let handle = fd.handle()?;
     HANDLER.with_borrow_mut(|handler| handler.entry(sig).or_default().insert(raw_fd, handle));
     Ok(())
@@ -72,7 +70,7 @@ impl SignalFd {
         register(sig, &event)?;
         Ok(Self {
             sig,
-            fd: event.as_raw_fd(),
+            fd: event.try_as_raw_fd()?,
             event: Some(event),
         })
     }

--- a/compio/Cargo.toml
+++ b/compio/Cargo.toml
@@ -34,9 +34,9 @@ compio-buf = { workspace = true }
 compio-driver = { workspace = true }
 compio-runtime = { workspace = true, optional = true }
 compio-macros = { workspace = true, optional = true }
-compio-fs = { workspace = true }
+compio-fs = { workspace = true, optional = true }
 compio-io = { workspace = true, optional = true }
-compio-net = { workspace = true }
+compio-net = { workspace = true, optional = true }
 compio-signal = { workspace = true, optional = true }
 compio-dispatcher = { workspace = true, optional = true }
 compio-log = { workspace = true }
@@ -75,12 +75,7 @@ io-uring = ["compio-driver/io-uring"]
 polling = ["compio-driver/polling"]
 io = ["dep:compio-io"]
 io-compat = ["io", "compio-io/compat"]
-runtime = [
-    "dep:compio-runtime",
-    "compio-fs/runtime",
-    "compio-net/runtime",
-    "io",
-]
+runtime = ["dep:compio-runtime", "dep:compio-fs", "dep:compio-net", "io"]
 macros = ["dep:compio-macros", "runtime"]
 event = ["compio-runtime/event", "runtime"]
 signal = ["dep:compio-signal", "event"]

--- a/compio/src/lib.rs
+++ b/compio/src/lib.rs
@@ -38,9 +38,6 @@ pub use compio_dispatcher as dispatcher;
 pub use compio_io as io;
 #[cfg(feature = "macros")]
 pub use compio_macros::*;
-#[cfg(feature = "runtime")]
-#[doc(inline)]
-pub use compio_runtime as runtime;
 #[cfg(feature = "signal")]
 #[doc(inline)]
 pub use compio_signal as signal;
@@ -58,4 +55,7 @@ pub use tls::native_tls;
 #[cfg(feature = "rustls")]
 pub use tls::rustls;
 #[doc(inline)]
-pub use {compio_buf as buf, compio_driver as driver, compio_fs as fs, compio_net as net};
+pub use {compio_buf as buf, compio_driver as driver};
+#[cfg(feature = "runtime")]
+#[doc(inline)]
+pub use {compio_fs as fs, compio_net as net, compio_runtime as runtime};


### PR DESCRIPTION
This is an experimental PR. It tries to force the user of `Attacher` to attach the source before using it. As a side-effect, `compio-fs` and `compio-net` must depend on `compio-runtime`.