### PR TITLE
feat(driver,runtime): add Asyncify op and `spawn_blocking`

### DIFF
--- a/compio-driver/Cargo.toml
+++ b/compio-driver/Cargo.toml
@@ -60,16 +60,15 @@ windows-sys = { workspace = true, features = [
 # Linux specific dependencies
 [target.'cfg(target_os = "linux")'.dependencies]
 io-uring = { version = "0.6.2", optional = true }
-crossbeam-queue = { workspace = true, optional = true }
 polling = { version = "3.3.0", optional = true }
 paste = { workspace = true }
 
 # Other platform dependencies
 [target.'cfg(all(not(target_os = "linux"), unix))'.dependencies]
-crossbeam-queue = { workspace = true }
 polling = "3.3.0"
 
 [target.'cfg(unix)'.dependencies]
+crossbeam-queue = { workspace = true }
 libc = { workspace = true }
 
 [dev-dependencies]
@@ -77,7 +76,7 @@ compio-buf = { workspace = true, features = ["arrayvec"] }
 
 [features]
 default = ["io-uring"]
-polling = ["dep:polling", "dep:crossbeam-queue"]
+polling = ["dep:polling"]
 
 # Nightly features
 once_cell_try = []

--- a/compio-driver/src/fusion/mod.rs
+++ b/compio-driver/src/fusion/mod.rs
@@ -11,8 +11,8 @@ pub use std::os::fd::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
 use std::{io, task::Poll, time::Duration};
 
 pub use driver_type::DriverType;
-pub use iour::OpCode as IourOpCode;
 pub(crate) use iour::{sockaddr_storage, socklen_t};
+pub use iour::{OpCode as IourOpCode, OpEntry};
 pub use poll::{Decision, OpCode as PollOpCode};
 use slab::Slab;
 

--- a/compio-driver/src/fusion/op.rs
+++ b/compio-driver/src/fusion/op.rs
@@ -77,7 +77,7 @@ macro_rules! op {
         }
 
         impl<$($ty: $trait),*> iour::OpCode for $name<$($ty),*> {
-            fn create_entry(self: std::pin::Pin<&mut Self>) -> io_uring::squeue::Entry {
+            fn create_entry(self: std::pin::Pin<&mut Self>) -> OpEntry {
                 unsafe { self.map_unchecked_mut(|x| x.inner.iour() ) }.create_entry()
             }
         }

--- a/compio-driver/src/iocp/op.rs
+++ b/compio-driver/src/iocp/op.rs
@@ -109,7 +109,7 @@ fn get_wsa_fn<F>(handle: RawFd, fguid: GUID) -> io::Result<Option<F>> {
 
 impl<
     D: std::marker::Send + Unpin + 'static,
-    F: (FnOnce(D) -> BufResult<usize, D>) + std::marker::Send + std::marker::Sync + Unpin + 'static,
+    F: (FnOnce() -> BufResult<usize, D>) + std::marker::Send + std::marker::Sync + Unpin + 'static,
 > OpCode for Asyncify<F, D>
 {
     fn is_overlapped(&self) -> bool {
@@ -121,7 +121,7 @@ impl<
             .f
             .take()
             .expect("the operate method could only be called once");
-        let BufResult(res, data) = f(self.data.take().expect("the data could not be None"));
+        let BufResult(res, data) = f();
         self.data = Some(data);
         Poll::Ready(res)
     }

--- a/compio-driver/src/iour/op.rs
+++ b/compio-driver/src/iour/op.rs
@@ -16,7 +16,7 @@ use crate::{op::*, OpEntry};
 
 impl<
     D: std::marker::Send + Unpin + 'static,
-    F: (FnOnce(D) -> BufResult<usize, D>) + std::marker::Send + std::marker::Sync + Unpin + 'static,
+    F: (FnOnce() -> BufResult<usize, D>) + std::marker::Send + std::marker::Sync + Unpin + 'static,
 > OpCode for Asyncify<F, D>
 {
     fn create_entry(self: Pin<&mut Self>) -> OpEntry {
@@ -28,7 +28,7 @@ impl<
             .f
             .take()
             .expect("the operate method could only be called once");
-        let BufResult(res, data) = f(self.data.take().expect("the data could not be None"));
+        let BufResult(res, data) = f();
         self.data = Some(data);
         res
     }

--- a/compio-driver/src/iour/op.rs
+++ b/compio-driver/src/iour/op.rs
@@ -1,47 +1,64 @@
-use std::{os::fd::RawFd, pin::Pin};
+use std::{io, os::fd::RawFd, pin::Pin};
 
 use compio_buf::{
     IntoInner, IoBuf, IoBufMut, IoSlice, IoSliceMut, IoVectoredBuf, IoVectoredBufMut,
 };
 use io_uring::{
     opcode,
-    squeue::Entry,
     types::{Fd, FsyncFlags},
 };
 use libc::{sockaddr_storage, socklen_t};
 use socket2::SockAddr;
 
 use super::OpCode;
-use crate::op::*;
 pub use crate::unix::op::*;
+use crate::{op::*, OpEntry};
+
+impl<F: (FnOnce() -> io::Result<usize>) + std::marker::Send + std::marker::Sync + Unpin + 'static>
+    OpCode for Asyncify<F>
+{
+    fn create_entry(self: Pin<&mut Self>) -> OpEntry {
+        OpEntry::Blocking
+    }
+
+    fn call_blocking(mut self: Pin<&mut Self>) -> std::io::Result<usize> {
+        let f = self
+            .f
+            .take()
+            .expect("the operate method could only be called once");
+        f()
+    }
+}
 
 impl OpCode for OpenFile {
-    fn create_entry(self: Pin<&mut Self>) -> Entry {
+    fn create_entry(self: Pin<&mut Self>) -> OpEntry {
         opcode::OpenAt::new(Fd(libc::AT_FDCWD), self.path.as_ptr())
             .flags(self.flags)
             .mode(self.mode)
             .build()
+            .into()
     }
 }
 
 impl OpCode for CloseFile {
-    fn create_entry(self: Pin<&mut Self>) -> Entry {
-        opcode::Close::new(Fd(self.fd)).build()
+    fn create_entry(self: Pin<&mut Self>) -> OpEntry {
+        opcode::Close::new(Fd(self.fd)).build().into()
     }
 }
 
 impl<T: IoBufMut> OpCode for ReadAt<T> {
-    fn create_entry(mut self: Pin<&mut Self>) -> Entry {
+    fn create_entry(mut self: Pin<&mut Self>) -> OpEntry {
         let fd = Fd(self.fd);
         let slice = self.buffer.as_mut_slice();
         opcode::Read::new(fd, slice.as_mut_ptr() as _, slice.len() as _)
             .offset(self.offset)
             .build()
+            .into()
     }
 }
 
 impl<T: IoVectoredBufMut> OpCode for ReadVectoredAt<T> {
-    fn create_entry(mut self: Pin<&mut Self>) -> Entry {
+    fn create_entry(mut self: Pin<&mut Self>) -> OpEntry {
         self.slices = unsafe { self.buffer.as_io_slices_mut() };
         opcode::Readv::new(
             Fd(self.fd),
@@ -50,20 +67,22 @@ impl<T: IoVectoredBufMut> OpCode for ReadVectoredAt<T> {
         )
         .offset(self.offset)
         .build()
+        .into()
     }
 }
 
 impl<T: IoBuf> OpCode for WriteAt<T> {
-    fn create_entry(self: Pin<&mut Self>) -> Entry {
+    fn create_entry(self: Pin<&mut Self>) -> OpEntry {
         let slice = self.buffer.as_slice();
         opcode::Write::new(Fd(self.fd), slice.as_ptr(), slice.len() as _)
             .offset(self.offset)
             .build()
+            .into()
     }
 }
 
 impl<T: IoVectoredBuf> OpCode for WriteVectoredAt<T> {
-    fn create_entry(mut self: Pin<&mut Self>) -> Entry {
+    fn create_entry(mut self: Pin<&mut Self>) -> OpEntry {
         self.slices = unsafe { self.buffer.as_io_slices() };
         opcode::Write::new(
             Fd(self.fd),
@@ -72,11 +91,12 @@ impl<T: IoVectoredBuf> OpCode for WriteVectoredAt<T> {
         )
         .offset(self.offset)
         .build()
+        .into()
     }
 }
 
 impl OpCode for Sync {
-    fn create_entry(self: Pin<&mut Self>) -> Entry {
+    fn create_entry(self: Pin<&mut Self>) -> OpEntry {
         opcode::Fsync::new(Fd(self.fd))
             .flags(if self.datasync {
                 FsyncFlags::DATASYNC
@@ -84,48 +104,56 @@ impl OpCode for Sync {
                 FsyncFlags::empty()
             })
             .build()
+            .into()
     }
 }
 
 impl OpCode for ShutdownSocket {
-    fn create_entry(self: Pin<&mut Self>) -> Entry {
-        opcode::Shutdown::new(Fd(self.fd), self.how()).build()
+    fn create_entry(self: Pin<&mut Self>) -> OpEntry {
+        opcode::Shutdown::new(Fd(self.fd), self.how())
+            .build()
+            .into()
     }
 }
 
 impl OpCode for CloseSocket {
-    fn create_entry(self: Pin<&mut Self>) -> Entry {
-        opcode::Close::new(Fd(self.fd)).build()
+    fn create_entry(self: Pin<&mut Self>) -> OpEntry {
+        opcode::Close::new(Fd(self.fd)).build().into()
     }
 }
 
 impl OpCode for Accept {
-    fn create_entry(mut self: Pin<&mut Self>) -> Entry {
+    fn create_entry(mut self: Pin<&mut Self>) -> OpEntry {
         opcode::Accept::new(
             Fd(self.fd),
             &mut self.buffer as *mut sockaddr_storage as *mut libc::sockaddr,
             &mut self.addr_len,
         )
         .build()
+        .into()
     }
 }
 
 impl OpCode for Connect {
-    fn create_entry(self: Pin<&mut Self>) -> Entry {
-        opcode::Connect::new(Fd(self.fd), self.addr.as_ptr(), self.addr.len()).build()
+    fn create_entry(self: Pin<&mut Self>) -> OpEntry {
+        opcode::Connect::new(Fd(self.fd), self.addr.as_ptr(), self.addr.len())
+            .build()
+            .into()
     }
 }
 
 impl<T: IoBufMut> OpCode for Recv<T> {
-    fn create_entry(mut self: Pin<&mut Self>) -> Entry {
+    fn create_entry(mut self: Pin<&mut Self>) -> OpEntry {
         let fd = self.fd;
         let slice = self.buffer.as_mut_slice();
-        opcode::Read::new(Fd(fd), slice.as_mut_ptr() as _, slice.len() as _).build()
+        opcode::Read::new(Fd(fd), slice.as_mut_ptr() as _, slice.len() as _)
+            .build()
+            .into()
     }
 }
 
 impl<T: IoVectoredBufMut> OpCode for RecvVectored<T> {
-    fn create_entry(mut self: Pin<&mut Self>) -> Entry {
+    fn create_entry(mut self: Pin<&mut Self>) -> OpEntry {
         self.slices = unsafe { self.buffer.as_io_slices_mut() };
         opcode::Readv::new(
             Fd(self.fd),
@@ -133,18 +161,21 @@ impl<T: IoVectoredBufMut> OpCode for RecvVectored<T> {
             self.slices.len() as _,
         )
         .build()
+        .into()
     }
 }
 
 impl<T: IoBuf> OpCode for Send<T> {
-    fn create_entry(self: Pin<&mut Self>) -> Entry {
+    fn create_entry(self: Pin<&mut Self>) -> OpEntry {
         let slice = self.buffer.as_slice();
-        opcode::Write::new(Fd(self.fd), slice.as_ptr(), slice.len() as _).build()
+        opcode::Write::new(Fd(self.fd), slice.as_ptr(), slice.len() as _)
+            .build()
+            .into()
     }
 }
 
 impl<T: IoVectoredBuf> OpCode for SendVectored<T> {
-    fn create_entry(mut self: Pin<&mut Self>) -> Entry {
+    fn create_entry(mut self: Pin<&mut Self>) -> OpEntry {
         self.slices = unsafe { self.buffer.as_io_slices() };
         opcode::Writev::new(
             Fd(self.fd),
@@ -152,6 +183,7 @@ impl<T: IoVectoredBuf> OpCode for SendVectored<T> {
             self.slices.len() as _,
         )
         .build()
+        .into()
     }
 }
 
@@ -170,7 +202,7 @@ impl RecvFromHeader {
         }
     }
 
-    pub fn create_entry(&mut self, slices: &mut [IoSliceMut]) -> Entry {
+    pub fn create_entry(&mut self, slices: &mut [IoSliceMut]) -> OpEntry {
         self.msg = libc::msghdr {
             msg_name: &mut self.addr as *mut _ as _,
             msg_namelen: std::mem::size_of_val(&self.addr) as _,
@@ -180,7 +212,9 @@ impl RecvFromHeader {
             msg_controllen: 0,
             msg_flags: 0,
         };
-        opcode::RecvMsg::new(Fd(self.fd), &mut self.msg).build()
+        opcode::RecvMsg::new(Fd(self.fd), &mut self.msg)
+            .build()
+            .into()
     }
 
     pub fn into_addr(self) -> (sockaddr_storage, socklen_t) {
@@ -208,7 +242,7 @@ impl<T: IoBufMut> RecvFrom<T> {
 }
 
 impl<T: IoBufMut> OpCode for RecvFrom<T> {
-    fn create_entry(mut self: Pin<&mut Self>) -> Entry {
+    fn create_entry(mut self: Pin<&mut Self>) -> OpEntry {
         let this = &mut *self;
         this.slice[0] = unsafe { this.buffer.as_io_slice_mut() };
         this.header.create_entry(&mut this.slice)
@@ -243,7 +277,7 @@ impl<T: IoVectoredBufMut> RecvFromVectored<T> {
 }
 
 impl<T: IoVectoredBufMut> OpCode for RecvFromVectored<T> {
-    fn create_entry(mut self: Pin<&mut Self>) -> Entry {
+    fn create_entry(mut self: Pin<&mut Self>) -> OpEntry {
         let this = &mut *self;
         this.slice = unsafe { this.buffer.as_io_slices_mut() };
         this.header.create_entry(&mut this.slice)
@@ -274,7 +308,7 @@ impl SendToHeader {
         }
     }
 
-    pub fn create_entry(&mut self, slices: &mut [IoSlice]) -> Entry {
+    pub fn create_entry(&mut self, slices: &mut [IoSlice]) -> OpEntry {
         self.msg = libc::msghdr {
             msg_name: self.addr.as_ptr() as _,
             msg_namelen: self.addr.len(),
@@ -284,7 +318,7 @@ impl SendToHeader {
             msg_controllen: 0,
             msg_flags: 0,
         };
-        opcode::SendMsg::new(Fd(self.fd), &self.msg).build()
+        opcode::SendMsg::new(Fd(self.fd), &self.msg).build().into()
     }
 }
 
@@ -308,7 +342,7 @@ impl<T: IoBuf> SendTo<T> {
 }
 
 impl<T: IoBuf> OpCode for SendTo<T> {
-    fn create_entry(mut self: Pin<&mut Self>) -> Entry {
+    fn create_entry(mut self: Pin<&mut Self>) -> OpEntry {
         let this = &mut *self;
         this.slice[0] = unsafe { this.buffer.as_io_slice() };
         this.header.create_entry(&mut this.slice)
@@ -342,7 +376,7 @@ impl<T: IoVectoredBuf> SendToVectored<T> {
 }
 
 impl<T: IoVectoredBuf> OpCode for SendToVectored<T> {
-    fn create_entry(mut self: Pin<&mut Self>) -> Entry {
+    fn create_entry(mut self: Pin<&mut Self>) -> OpEntry {
         let this = &mut *self;
         this.slice = unsafe { this.buffer.as_io_slices() };
         this.header.create_entry(&mut this.slice)

--- a/compio-driver/src/op.rs
+++ b/compio-driver/src/op.rs
@@ -67,14 +67,18 @@ impl<T> RecvResultExt for BufResult<usize, (T, sockaddr_storage, socklen_t)> {
 }
 
 /// Spawn a blocking function in the thread pool.
-pub struct Asyncify<F> {
+pub struct Asyncify<F, D> {
     pub(crate) f: Option<F>,
+    pub(crate) data: Option<D>,
 }
 
-impl<F> Asyncify<F> {
+impl<F, D> Asyncify<F, D> {
     /// Create [`Asyncify`].
-    pub fn new(f: F) -> Self {
-        Self { f: Some(f) }
+    pub fn new(f: F, data: D) -> Self {
+        Self {
+            f: Some(f),
+            data: Some(data),
+        }
     }
 }
 

--- a/compio-driver/src/op.rs
+++ b/compio-driver/src/op.rs
@@ -66,6 +66,18 @@ impl<T> RecvResultExt for BufResult<usize, (T, sockaddr_storage, socklen_t)> {
     }
 }
 
+/// Spawn a blocking function in the thread pool.
+pub struct Asyncify<F> {
+    pub(crate) f: Option<F>,
+}
+
+impl<F> Asyncify<F> {
+    /// Create [`Asyncify`].
+    pub fn new(f: F) -> Self {
+        Self { f: Some(f) }
+    }
+}
+
 /// Close the file fd.
 pub struct CloseFile {
     pub(crate) fd: RawFd,

--- a/compio-driver/src/op.rs
+++ b/compio-driver/src/op.rs
@@ -82,6 +82,14 @@ impl<F, D> Asyncify<F, D> {
     }
 }
 
+impl<F, D> IntoInner for Asyncify<F, D> {
+    type Inner = D;
+
+    fn into_inner(mut self) -> Self::Inner {
+        self.data.take().expect("the data should not be None")
+    }
+}
+
 /// Close the file fd.
 pub struct CloseFile {
     pub(crate) fd: RawFd,

--- a/compio-driver/src/op.rs
+++ b/compio-driver/src/op.rs
@@ -74,10 +74,10 @@ pub struct Asyncify<F, D> {
 
 impl<F, D> Asyncify<F, D> {
     /// Create [`Asyncify`].
-    pub fn new(f: F, data: D) -> Self {
+    pub fn new(f: F) -> Self {
         Self {
             f: Some(f),
-            data: Some(data),
+            data: None,
         }
     }
 }

--- a/compio-driver/src/poll/op.rs
+++ b/compio-driver/src/poll/op.rs
@@ -1,7 +1,7 @@
 use std::{io, pin::Pin, task::Poll};
 
 use compio_buf::{
-    IntoInner, IoBuf, IoBufMut, IoSlice, IoSliceMut, IoVectoredBuf, IoVectoredBufMut,
+    BufResult, IntoInner, IoBuf, IoBufMut, IoSlice, IoSliceMut, IoVectoredBuf, IoVectoredBufMut,
 };
 #[cfg(not(all(target_os = "linux", target_env = "gnu")))]
 use libc::open;
@@ -18,8 +18,10 @@ use super::{sockaddr_storage, socklen_t, syscall, Decision, OpCode, RawFd};
 use crate::op::*;
 pub use crate::unix::op::*;
 
-impl<F: (FnOnce() -> io::Result<usize>) + std::marker::Send + std::marker::Sync + Unpin + 'static>
-    OpCode for Asyncify<F>
+impl<
+    D: std::marker::Sync + Unpin + 'static,
+    F: (FnOnce(D) -> BufResult<usize, D>) + std::marker::Send + std::marker::Sync + Unpin + 'static,
+> OpCode for Asyncify<F, D>
 {
     fn is_nonblocking(&self) -> bool {
         false
@@ -30,7 +32,9 @@ impl<F: (FnOnce() -> io::Result<usize>) + std::marker::Send + std::marker::Sync 
             .f
             .take()
             .expect("the operate method could only be called once");
-        f().map(Decision::Completed)
+        let BufResult(res, data) = f(self.data.take().expect("the data could not be None"));
+        self.data = Some(data);
+        res.map(Decision::Completed)
     }
 
     fn on_event(self: Pin<&mut Self>, _: &Event) -> Poll<io::Result<usize>> {

--- a/compio-driver/src/poll/op.rs
+++ b/compio-driver/src/poll/op.rs
@@ -20,7 +20,7 @@ pub use crate::unix::op::*;
 
 impl<
     D: std::marker::Send + Unpin + 'static,
-    F: (FnOnce(D) -> BufResult<usize, D>) + std::marker::Send + std::marker::Sync + Unpin + 'static,
+    F: (FnOnce() -> BufResult<usize, D>) + std::marker::Send + std::marker::Sync + Unpin + 'static,
 > OpCode for Asyncify<F, D>
 {
     fn pre_submit(self: Pin<&mut Self>) -> io::Result<Decision> {
@@ -32,7 +32,7 @@ impl<
             .f
             .take()
             .expect("the operate method could only be called once");
-        let BufResult(res, data) = f(self.data.take().expect("the data could not be None"));
+        let BufResult(res, data) = f();
         self.data = Some(data);
         Poll::Ready(res)
     }

--- a/compio-driver/tests/file.rs
+++ b/compio-driver/tests/file.rs
@@ -155,7 +155,7 @@ fn notify() {
 fn asyncify() {
     let mut driver = Proactor::new().unwrap();
 
-    let op = Asyncify::new(|()| BufResult(Ok(114514), ()), ());
+    let op = Asyncify::new(|| BufResult(Ok(114514), ()));
     let (res, _) = push_and_wait(&mut driver, op);
     assert_eq!(res, 114514);
 }

--- a/compio-driver/tests/file.rs
+++ b/compio-driver/tests/file.rs
@@ -155,7 +155,7 @@ fn notify() {
 fn asyncify() {
     let mut driver = Proactor::new().unwrap();
 
-    let op = Asyncify::new(|| std::io::Result::Ok(114514));
+    let op = Asyncify::new(|()| BufResult(Ok(114514), ()), ());
     let (res, _) = push_and_wait(&mut driver, op);
     assert_eq!(res, 114514);
 }

--- a/compio-driver/tests/file.rs
+++ b/compio-driver/tests/file.rs
@@ -2,7 +2,7 @@ use std::{io, time::Duration};
 
 use compio_buf::{arrayvec::ArrayVec, BufResult};
 use compio_driver::{
-    op::{CloseFile, OpenFile, ReadAt},
+    op::{Asyncify, CloseFile, OpenFile, ReadAt},
     Entry, OpCode, Proactor, PushEntry, RawFd,
 };
 
@@ -149,4 +149,13 @@ fn notify() {
     driver.poll(None, &mut entries).unwrap();
 
     thread.join().unwrap();
+}
+
+#[test]
+fn asyncify() {
+    let mut driver = Proactor::new().unwrap();
+
+    let op = Asyncify::new(|| std::io::Result::Ok(114514));
+    let (res, _) = push_and_wait(&mut driver, op);
+    assert_eq!(res, 114514);
 }

--- a/compio-runtime/src/lib.rs
+++ b/compio-runtime/src/lib.rs
@@ -25,4 +25,4 @@ pub use async_task::Task;
 pub use attacher::*;
 use compio_buf::BufResult;
 pub(crate) use key::Key;
-pub use runtime::{spawn, EnterGuard, Runtime, RuntimeBuilder};
+pub use runtime::{spawn, spawn_blocking, EnterGuard, Runtime, RuntimeBuilder};

--- a/compio-runtime/src/runtime/mod.rs
+++ b/compio-runtime/src/runtime/mod.rs
@@ -107,15 +107,11 @@ impl RuntimeInner {
         &self,
         f: impl (FnOnce() -> T) + Send + Sync + Unpin + 'static,
     ) -> impl Future<Output = T> {
-        let op = Asyncify::new(
-            move |_| {
-                let res = f();
-                BufResult(Ok(0), Some(res))
-            },
-            None::<T>,
-        );
-        self.submit(op)
-            .map(|BufResult(_, op)| op.into_inner().expect("the inner data should not be None"))
+        let op = Asyncify::new(move || {
+            let res = f();
+            BufResult(Ok(0), res)
+        });
+        self.submit(op).map(|BufResult(_, op)| op.into_inner())
     }
 
     pub fn attach(&self, fd: RawFd) -> io::Result<()> {

--- a/compio-runtime/src/runtime/mod.rs
+++ b/compio-runtime/src/runtime/mod.rs
@@ -11,10 +11,13 @@ use std::{
 };
 
 use async_task::{Runnable, Task};
-use compio_driver::{AsRawFd, Entry, OpCode, Proactor, ProactorBuilder, PushEntry, RawFd};
+use compio_buf::IntoInner;
+use compio_driver::{
+    op::Asyncify, AsRawFd, Entry, OpCode, Proactor, ProactorBuilder, PushEntry, RawFd,
+};
 use compio_log::{debug, instrument};
 use crossbeam_queue::SegQueue;
-use futures_util::future::Either;
+use futures_util::{future::Either, FutureExt};
 use smallvec::SmallVec;
 
 pub(crate) mod op;
@@ -98,6 +101,21 @@ impl RuntimeInner {
 
     pub fn spawn<F: Future + 'static>(&self, future: F) -> Task<F::Output> {
         unsafe { self.spawn_unchecked(future) }
+    }
+
+    pub fn spawn_blocking<T: Send + Unpin + 'static>(
+        &self,
+        f: impl (FnOnce() -> T) + Send + Sync + Unpin + 'static,
+    ) -> impl Future<Output = T> {
+        let op = Asyncify::new(
+            move |_| {
+                let res = f();
+                BufResult(Ok(0), Some(res))
+            },
+            None::<T>,
+        );
+        self.submit(op)
+            .map(|BufResult(_, op)| op.into_inner().expect("the inner data should not be None"))
     }
 
     pub fn attach(&self, fd: RawFd) -> io::Result<()> {
@@ -328,6 +346,16 @@ impl Runtime {
         self.inner.spawn(future)
     }
 
+    /// Spawns a blocking task in a new thread, and wait for it.
+    ///
+    /// The task will not be cancelled even if the future is dropped.
+    pub fn spawn_blocking<T: Send + Unpin + 'static>(
+        &self,
+        f: impl (FnOnce() -> T) + Send + Sync + Unpin + 'static,
+    ) -> impl Future<Output = T> {
+        self.inner.spawn_blocking(f)
+    }
+
     /// Attach a raw file descriptor/handle/socket to the runtime.
     ///
     /// You only need this when authoring your own high-level APIs. High-level
@@ -473,4 +501,18 @@ impl Drop for EnterGuard<'_> {
 /// by [`Runtime::current`].
 pub fn spawn<F: Future + 'static>(future: F) -> Task<F::Output> {
     Runtime::current().spawn(future)
+}
+
+/// Spawns a blocking task in a new thread, and wait for it.
+///
+/// The task will not be cancelled even if the future is dropped.
+///
+/// ## Panics
+///
+/// This method doesn't create runtime. It tries to obtain the current runtime
+/// by [`Runtime::current`].
+pub fn spawn_blocking<T: Send + Unpin + 'static>(
+    f: impl (FnOnce() -> T) + Send + Sync + Unpin + 'static,
+) -> impl Future<Output = T> {
+    Runtime::current().spawn_blocking(f)
 }

--- a/compio-runtime/tests/event.rs
+++ b/compio-runtime/tests/event.rs
@@ -5,9 +5,10 @@ fn event_handle() {
     compio_runtime::Runtime::new().unwrap().block_on(async {
         let event = Event::new().unwrap();
         let handle = event.handle().unwrap();
-        std::thread::spawn(move || {
+        let task = compio_runtime::spawn_blocking(move || {
             handle.notify().unwrap();
         });
         event.wait().await.unwrap();
+        task.await;
     })
 }


### PR DESCRIPTION
This is a requisite to fix #161 

An operation `Asyncify` is added to spawn a blocking method to a new thread.

In this PR, the thread poll is also added into io-uring driver. In the future, we may implement `CreateSocket` operation with that pool in case some old kernel doesn't support `socket` io-uring operation.