### PR TITLE
fix(test): push_and_wait should poll in a loop

### DIFF
--- a/compio-driver/tests/file.rs
+++ b/compio-driver/tests/file.rs
@@ -46,7 +46,9 @@ fn push_and_wait<O: OpCode + 'static>(driver: &mut Proactor, op: O) -> (usize, O
         PushEntry::Ready(res) => res.unwrap(),
         PushEntry::Pending(user_data) => {
             let mut entries = ArrayVec::<Entry, 1>::new();
-            driver.poll(None, &mut entries).unwrap();
+            while entries.is_empty() {
+                driver.poll(None, &mut entries).unwrap();
+            }
             let (n, op) = driver
                 .pop(&mut entries.into_iter())
                 .next()

--- a/compio/examples/driver.rs
+++ b/compio/examples/driver.rs
@@ -47,7 +47,9 @@ fn push_and_wait<O: OpCode + 'static>(driver: &mut Proactor, op: O) -> (usize, O
         PushEntry::Ready(res) => res.unwrap(),
         PushEntry::Pending(user_data) => {
             let mut entries = ArrayVec::<Entry, 1>::new();
-            driver.poll(None, &mut entries).unwrap();
+            while entries.is_empty() {
+                driver.poll(None, &mut entries).unwrap();
+            }
             let (n, op) = driver
                 .pop(&mut entries.into_iter())
                 .next()


### PR DESCRIPTION
`Proactor::poll` doesn't ensure that `entries` will be filled with at least one entry. It may be still empty.