### PR TITLE
fix(signal,unix): use pipe

### DIFF
--- a/compio-signal/Cargo.toml
+++ b/compio-signal/Cargo.toml
@@ -18,11 +18,12 @@ rustdoc-args = ["--cfg", "docsrs"]
 # Workspace dependencies
 compio-runtime = { workspace = true, features = ["event"] }
 
+once_cell = { workspace = true }
+slab = { workspace = true }
+
 # Windows specific dependencies
 [target.'cfg(windows)'.dependencies]
 compio-driver = { workspace = true }
-once_cell = { workspace = true }
-slab = { workspace = true }
 windows-sys = { workspace = true, features = [
     "Win32_Foundation",
     "Win32_System_Console",
@@ -30,6 +31,7 @@ windows-sys = { workspace = true, features = [
 
 # Unix specific dependencies
 [target.'cfg(unix)'.dependencies]
+os_pipe = { workspace = true }
 libc = { workspace = true }
 
 [features]

--- a/compio-signal/src/unix.rs
+++ b/compio-signal/src/unix.rs
@@ -1,31 +1,72 @@
 //! Unix-specific types for signal handling.
 
-use std::{cell::RefCell, collections::HashMap, io, os::fd::RawFd};
-
-use compio_runtime::{
-    event::{Event, EventHandle},
-    TryAsRawFd,
+#[cfg(feature = "lazy_cell")]
+use std::sync::LazyLock;
+use std::{
+    collections::HashMap,
+    io::{self, Read, Write},
+    ops::Deref,
+    sync::Mutex,
 };
 
-thread_local! {
-    static HANDLER: RefCell<HashMap<i32, HashMap<RawFd, EventHandle>>> =
-        RefCell::new(HashMap::new());
+use compio_runtime::event::{Event, EventHandle};
+#[cfg(not(feature = "lazy_cell"))]
+use once_cell::sync::Lazy as LazyLock;
+use os_pipe::{PipeReader, PipeWriter};
+use slab::Slab;
+
+static HANDLER: LazyLock<Mutex<HashMap<i32, Slab<EventHandle>>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
+static PIPE: LazyLock<Pipe> = LazyLock::new(|| Pipe::new().unwrap());
+
+struct Pipe {
+    sender: PipeWriter,
+}
+
+impl Pipe {
+    pub fn new() -> io::Result<Self> {
+        let (receiver, sender) = os_pipe::pipe()?;
+
+        std::thread::spawn(move || {
+            real_signal_handler(receiver);
+        });
+
+        Ok(Self { sender })
+    }
+
+    pub fn send(&self, sig: i32) -> io::Result<()> {
+        (&self.sender).write_all(&sig.to_ne_bytes())?;
+        Ok(())
+    }
 }
 
 unsafe extern "C" fn signal_handler(sig: i32) {
-    HANDLER.with_borrow_mut(|handler| {
-        if let Some(fds) = handler.get_mut(&sig) {
-            if !fds.is_empty() {
-                let fds = std::mem::take(fds);
-                for (_, fd) in fds {
-                    fd.notify().ok();
+    PIPE.send(sig).unwrap();
+}
+
+fn real_signal_handler(mut receiver: PipeReader) {
+    loop {
+        let mut buffer = [0u8; 4];
+        let res = receiver.read_exact(&mut buffer);
+        if let Ok(()) = res {
+            let sig = i32::from_ne_bytes(buffer);
+            let mut handler = HANDLER.lock().unwrap();
+            if let Some(fds) = handler.get_mut(&sig) {
+                if !fds.is_empty() {
+                    let fds = std::mem::take(fds);
+                    for (_, fd) in fds {
+                        fd.notify().ok();
+                    }
                 }
             }
+        } else {
+            break;
         }
-    });
+    }
 }
 
 unsafe fn init(sig: i32) {
+    let _ = PIPE.deref();
     libc::signal(sig, signal_handler as *const () as usize);
 }
 
@@ -33,24 +74,29 @@ unsafe fn uninit(sig: i32) {
     libc::signal(sig, libc::SIG_DFL);
 }
 
-fn register(sig: i32, fd: &Event) -> io::Result<()> {
+fn register(sig: i32, fd: &Event) -> io::Result<usize> {
     unsafe { init(sig) };
-    let raw_fd = fd.try_as_raw_fd()?;
     let handle = fd.handle()?;
-    HANDLER.with_borrow_mut(|handler| handler.entry(sig).or_default().insert(raw_fd, handle));
-    Ok(())
+    let key = HANDLER
+        .lock()
+        .unwrap()
+        .entry(sig)
+        .or_default()
+        .insert(handle);
+    Ok(key)
 }
 
-fn unregister(sig: i32, fd: RawFd) {
-    let need_uninit = HANDLER.with_borrow_mut(|handler| {
+fn unregister(sig: i32, key: usize) {
+    let need_uninit = (|| {
+        let mut handler = HANDLER.lock().unwrap();
         if let Some(fds) = handler.get_mut(&sig) {
-            fds.remove(&fd);
+            fds.try_remove(key);
             if !fds.is_empty() {
                 return false;
             }
         }
         true
-    });
+    })();
     if need_uninit {
         unsafe { uninit(sig) };
     }
@@ -60,17 +106,17 @@ fn unregister(sig: i32, fd: RawFd) {
 #[derive(Debug)]
 struct SignalFd {
     sig: i32,
-    fd: RawFd,
+    key: usize,
     event: Option<Event>,
 }
 
 impl SignalFd {
     fn new(sig: i32) -> io::Result<Self> {
         let event = Event::new()?;
-        register(sig, &event)?;
+        let key = register(sig, &event)?;
         Ok(Self {
             sig,
-            fd: event.try_as_raw_fd()?,
+            key,
             event: Some(event),
         })
     }
@@ -86,7 +132,7 @@ impl SignalFd {
 
 impl Drop for SignalFd {
     fn drop(&mut self) {
-        unregister(self.sig, self.fd);
+        unregister(self.sig, self.key);
     }
 }
 


### PR DESCRIPTION
Closes #182 

The signal handler may be called at any time in the thread, so it's not safe to use `RefCell`. Here we use a OS pipe to avoid any possible signal-unsafe functions. However, it needs another thread to notify the events.