### PR TITLE
feat(driver,iour): add Entry128 support

### DIFF
--- a/compio-driver/Cargo.toml
+++ b/compio-driver/Cargo.toml
@@ -60,6 +60,7 @@ windows-sys = { workspace = true, features = [
 # Linux specific dependencies
 [target.'cfg(target_os = "linux")'.dependencies]
 io-uring = { version = "0.6.2", optional = true }
+once_cell = { workspace = true }
 polling = { version = "3.3.0", optional = true }
 paste = { workspace = true }
 


### PR DESCRIPTION
Closes #191 

This PR adds a new 128-bit sqe ring into the driver. It is lazy-initialized, and polled by the main ring. In that way we can support both types of submission entries.