### PR TITLE
feat(driver,iour): add large sqe & cqe support

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -36,22 +36,24 @@ jobs:
       matrix:
         focal:
           image: ubuntu-20.04
+          features:
         jammy:
           image: ubuntu-22.04
+          features: io-uring-large-qe
     pool:
       vmImage: $(image)
 
     steps:
       - script: |
           rustup toolchain install nightly
-          cargo +nightly test --workspace --features all,nightly
+          cargo +nightly test --workspace --features all,nightly,$(features)
         displayName: TestNightly
       - script: |
           rustup toolchain install beta
-          cargo +beta test --workspace --features all
+          cargo +beta test --workspace --features all,$(features)
         displayName: TestBeta
       # - script: |
-      #     cargo test --workspace --features all
+      #     cargo test --workspace --features all,$(features)
       #   displayName: TestStable
 
       - script: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -39,7 +39,7 @@ jobs:
           features:
         jammy:
           image: ubuntu-22.04
-          features: io-uring-large-qe
+          features: io-uring-sqe128,io-uring-cqe32
     pool:
       vmImage: $(image)
 

--- a/compio-driver/Cargo.toml
+++ b/compio-driver/Cargo.toml
@@ -78,6 +78,8 @@ compio-buf = { workspace = true, features = ["arrayvec"] }
 default = ["io-uring"]
 polling = ["dep:polling"]
 
+io-uring-large-qe = []
+
 # Nightly features
 once_cell_try = []
 nightly = ["once_cell_try"]

--- a/compio-driver/Cargo.toml
+++ b/compio-driver/Cargo.toml
@@ -78,7 +78,8 @@ compio-buf = { workspace = true, features = ["arrayvec"] }
 default = ["io-uring"]
 polling = ["dep:polling"]
 
-io-uring-large-qe = []
+io-uring-sqe128 = []
+io-uring-cqe32 = []
 
 # Nightly features
 once_cell_try = []

--- a/compio-driver/src/fusion/mod.rs
+++ b/compio-driver/src/fusion/mod.rs
@@ -85,6 +85,9 @@ mod driver_type {
             OpenAt::CODE,
             Close::CODE,
             Shutdown::CODE,
+            // Linux kernel 5.19
+            #[cfg(any(feature = "io-uring-seq128", feature = "io-uring-cqe32"))]
+            Socket::CODE,
         ];
 
         Ok(())

--- a/compio-driver/src/iour/mod.rs
+++ b/compio-driver/src/iour/mod.rs
@@ -8,14 +8,20 @@ use std::{
 
 use compio_log::{instrument, trace};
 use crossbeam_queue::SegQueue;
-#[cfg(not(feature = "io-uring-cqe32"))]
-use io_uring::cqueue::Entry as CEntry;
-#[cfg(feature = "io-uring-cqe32")]
-use io_uring::cqueue::Entry32 as CEntry;
-#[cfg(not(feature = "io-uring-sqe128"))]
-use io_uring::squeue::Entry as SEntry;
-#[cfg(feature = "io-uring-sqe128")]
-use io_uring::squeue::Entry128 as SEntry;
+cfg_if::cfg_if! {
+    if #[cfg(feature = "io-uring-cqe32")] {
+        use io_uring::cqueue::Entry32 as CEntry;
+    } else {
+        use io_uring::cqueue::Entry as CEntry;
+    }
+}
+cfg_if::cfg_if! {
+    if #[cfg(feature = "io-uring-sqe128")] {
+        use io_uring::squeue::Entry128 as SEntry;
+    } else {
+        use io_uring::squeue::Entry as SEntry;
+    }
+}
 use io_uring::{
     opcode::{AsyncCancel, Read},
     types::{Fd, SubmitArgs, Timespec},


### PR DESCRIPTION
Use `squeue::Entry128` and `cqueue::Entry32` behind the feature gate. It could be enabled on Ubuntu 22.04 but not Ubuntu 20.04

Closes #191 

And thanks advice and requests from @oxalica