### PR TITLE
Add coc-settings to enable rust analyser support by default for coc.nvim

### DIFF
--- a/.vim/coc-settings.json
+++ b/.vim/coc-settings.json
@@ -1,0 +1,4 @@
+{
+    "rust-analyzer.updates.channel": "nightly",
+    "rust-analyzer.cargo.features": ["all", "nightly"]
+}


### PR DESCRIPTION
Add a small coc configuration, so that anyone using coc-rust-analyzer could start work immediately...