### PR TITLE
feat(driver,windows): add win32 event support

### DIFF
--- a/compio-driver/src/iocp/op.rs
+++ b/compio-driver/src/iocp/op.rs
@@ -47,7 +47,7 @@ use windows_sys::{
     },
 };
 
-use crate::{op::*, syscall, OpCode, RawFd};
+use crate::{op::*, syscall, OpCode, OpType, RawFd};
 
 #[inline]
 fn winapi_result(transferred: u32) -> Poll<io::Result<usize>> {
@@ -119,8 +119,8 @@ impl<
     F: (FnOnce() -> BufResult<usize, D>) + std::marker::Send + std::marker::Sync + 'static,
 > OpCode for Asyncify<F, D>
 {
-    fn is_overlapped(&self) -> bool {
-        false
+    fn op_type(&self) -> OpType {
+        OpType::Blocking
     }
 
     unsafe fn operate(self: Pin<&mut Self>, _optr: *mut OVERLAPPED) -> Poll<io::Result<usize>> {
@@ -176,8 +176,8 @@ impl OpenFile {
 }
 
 impl OpCode for OpenFile {
-    fn is_overlapped(&self) -> bool {
-        false
+    fn op_type(&self) -> OpType {
+        OpType::Blocking
     }
 
     unsafe fn operate(mut self: Pin<&mut Self>, _optr: *mut OVERLAPPED) -> Poll<io::Result<usize>> {
@@ -200,8 +200,8 @@ impl OpCode for OpenFile {
 }
 
 impl OpCode for CloseFile {
-    fn is_overlapped(&self) -> bool {
-        false
+    fn op_type(&self) -> OpType {
+        OpType::Blocking
     }
 
     unsafe fn operate(self: Pin<&mut Self>, _optr: *mut OVERLAPPED) -> Poll<io::Result<usize>> {
@@ -293,8 +293,8 @@ impl FileStat {
 }
 
 impl OpCode for FileStat {
-    fn is_overlapped(&self) -> bool {
-        false
+    fn op_type(&self) -> OpType {
+        OpType::Blocking
     }
 
     unsafe fn operate(mut self: Pin<&mut Self>, _optr: *mut OVERLAPPED) -> Poll<io::Result<usize>> {
@@ -378,8 +378,8 @@ impl PathStat {
 }
 
 impl OpCode for PathStat {
-    fn is_overlapped(&self) -> bool {
-        false
+    fn op_type(&self) -> OpType {
+        OpType::Blocking
     }
 
     unsafe fn operate(mut self: Pin<&mut Self>, optr: *mut OVERLAPPED) -> Poll<io::Result<usize>> {
@@ -473,8 +473,8 @@ impl<T: IoBuf> OpCode for WriteAt<T> {
 }
 
 impl OpCode for Sync {
-    fn is_overlapped(&self) -> bool {
-        false
+    fn op_type(&self) -> OpType {
+        OpType::Blocking
     }
 
     unsafe fn operate(self: Pin<&mut Self>, _optr: *mut OVERLAPPED) -> Poll<io::Result<usize>> {
@@ -483,8 +483,8 @@ impl OpCode for Sync {
 }
 
 impl OpCode for ShutdownSocket {
-    fn is_overlapped(&self) -> bool {
-        false
+    fn op_type(&self) -> OpType {
+        OpType::Blocking
     }
 
     unsafe fn operate(self: Pin<&mut Self>, _optr: *mut OVERLAPPED) -> Poll<io::Result<usize>> {
@@ -498,8 +498,8 @@ impl OpCode for ShutdownSocket {
 }
 
 impl OpCode for CloseSocket {
-    fn is_overlapped(&self) -> bool {
-        false
+    fn op_type(&self) -> OpType {
+        OpType::Blocking
     }
 
     unsafe fn operate(self: Pin<&mut Self>, _optr: *mut OVERLAPPED) -> Poll<io::Result<usize>> {

--- a/compio-fs/src/stdio/windows.rs
+++ b/compio-fs/src/stdio/windows.rs
@@ -9,7 +9,7 @@ use std::{
 use compio_buf::{BufResult, IntoInner, IoBuf, IoBufMut};
 use compio_driver::{
     op::{BufResultExt, Recv, Send},
-    AsRawFd, OpCode, RawFd,
+    AsRawFd, OpCode, OpType, RawFd,
 };
 use compio_io::{AsyncRead, AsyncWrite};
 use compio_runtime::Runtime;
@@ -30,8 +30,8 @@ impl<R: Read, B: IoBufMut> StdRead<R, B> {
 }
 
 impl<R: Read, B: IoBufMut> OpCode for StdRead<R, B> {
-    fn is_overlapped(&self) -> bool {
-        false
+    fn op_type(&self) -> OpType {
+        OpType::Blocking
     }
 
     unsafe fn operate(self: Pin<&mut Self>, _optr: *mut OVERLAPPED) -> Poll<io::Result<usize>> {
@@ -79,8 +79,8 @@ impl<W: Write, B: IoBuf> StdWrite<W, B> {
 }
 
 impl<W: Write, B: IoBuf> OpCode for StdWrite<W, B> {
-    fn is_overlapped(&self) -> bool {
-        false
+    fn op_type(&self) -> OpType {
+        OpType::Blocking
     }
 
     unsafe fn operate(self: Pin<&mut Self>, _optr: *mut OVERLAPPED) -> Poll<io::Result<usize>> {

--- a/compio-runtime/tests/event.rs
+++ b/compio-runtime/tests/event.rs
@@ -12,3 +12,53 @@ fn event_handle() {
         task.await;
     })
 }
+
+#[test]
+#[cfg(windows)]
+fn win32_event() {
+    use std::{
+        os::windows::io::{AsRawHandle, FromRawHandle, OwnedHandle},
+        pin::Pin,
+        ptr::null,
+        task::Poll,
+    };
+
+    use compio_driver::{syscall, OpCode, OpType};
+    use windows_sys::Win32::System::{
+        Threading::{CreateEventW, SetEvent},
+        IO::OVERLAPPED,
+    };
+
+    struct WaitEvent {
+        event: OwnedHandle,
+    }
+
+    impl OpCode for WaitEvent {
+        fn op_type(&self) -> OpType {
+            OpType::Event(self.event.as_raw_handle())
+        }
+
+        unsafe fn operate(
+            self: Pin<&mut Self>,
+            _optr: *mut OVERLAPPED,
+        ) -> Poll<std::io::Result<usize>> {
+            Poll::Ready(Ok(0))
+        }
+    }
+
+    compio_runtime::Runtime::new().unwrap().block_on(async {
+        let event = syscall!(BOOL, CreateEventW(null(), 0, 0, null())).unwrap();
+        let event = unsafe { OwnedHandle::from_raw_handle(event as _) };
+
+        let event_raw = event.as_raw_handle() as _;
+
+        let wait = compio_runtime::Runtime::current().submit(WaitEvent { event });
+
+        let task = compio_runtime::spawn_blocking(move || {
+            unsafe { SetEvent(event_raw) };
+        });
+
+        wait.await.0.unwrap();
+        task.await;
+    })
+}


### PR DESCRIPTION
This PR adds Win32 event support for IOCP driver. Win32 event is kind of foundamental syncronize object. It could be, e.g., an event handle, an input console handle, a pipe handle, or a mutex handle.

Win32 event could not be polled by IOCP, but IOCP could be waited as a usual event on Windows 10+. `MsgWaitForMultipleObjectsEx` is used here to wait them all, and reserves possibility for APC routines and window messages. If there are more than 62 events to be waited, the remain events will be waited in seperate threads.

In this PR, stdio is also refactored to use the new feature. To make the code simpler, the console code page is forced to UTF8.

This PR is a prediction of the planned `compio-process`. We need the feature to wait for the process handle.