### PR TITLE
feat(process): compio-process

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ members = [
     "compio-io",
     "compio-tls",
     "compio-log",
+    "compio-process",
 ]
 resolver = "2"
 
@@ -34,6 +35,7 @@ compio-signal = { path = "./compio-signal", version = "0.2.0" }
 compio-dispatcher = { path = "./compio-dispatcher", version = "0.2.0" }
 compio-log = { path = "./compio-log", version = "0.1.0" }
 compio-tls = { path = "./compio-tls", version = "0.2.0", default-features = false }
+compio-process = { path = "./compio-process", version = "0.1.0" }
 
 flume = "0.11.0"
 cfg-if = "1.0.0"

--- a/compio-driver/src/iocp/cp/mod.rs
+++ b/compio-driver/src/iocp/cp/mod.rs
@@ -22,9 +22,9 @@ use compio_buf::arrayvec::ArrayVec;
 use compio_log::*;
 use windows_sys::Win32::{
     Foundation::{
-        RtlNtStatusToDosError, ERROR_BAD_COMMAND, ERROR_HANDLE_EOF, ERROR_IO_INCOMPLETE,
-        ERROR_NO_DATA, FACILITY_NTWIN32, INVALID_HANDLE_VALUE, NTSTATUS, STATUS_PENDING,
-        STATUS_SUCCESS,
+        RtlNtStatusToDosError, ERROR_BAD_COMMAND, ERROR_BROKEN_PIPE, ERROR_HANDLE_EOF,
+        ERROR_IO_INCOMPLETE, ERROR_NO_DATA, ERROR_PIPE_CONNECTED, ERROR_PIPE_NOT_CONNECTED,
+        FACILITY_NTWIN32, INVALID_HANDLE_VALUE, NTSTATUS, STATUS_PENDING, STATUS_SUCCESS,
     },
     Storage::FileSystem::SetFileCompletionNotificationModes,
     System::{
@@ -173,7 +173,12 @@ impl CompletionPort {
             } else {
                 let error = unsafe { RtlNtStatusToDosError(overlapped.base.Internal as _) };
                 match error {
-                    ERROR_IO_INCOMPLETE | ERROR_HANDLE_EOF | ERROR_NO_DATA => Ok(0),
+                    ERROR_IO_INCOMPLETE
+                    | ERROR_HANDLE_EOF
+                    | ERROR_BROKEN_PIPE
+                    | ERROR_PIPE_CONNECTED
+                    | ERROR_PIPE_NOT_CONNECTED
+                    | ERROR_NO_DATA => Ok(0),
                     _ => Err(io::Error::from_raw_os_error(error as _)),
                 }
             };

--- a/compio-driver/src/iocp/mod.rs
+++ b/compio-driver/src/iocp/mod.rs
@@ -97,6 +97,24 @@ impl AsRawFd for OwnedSocket {
     }
 }
 
+impl AsRawFd for std::process::ChildStdin {
+    fn as_raw_fd(&self) -> RawFd {
+        self.as_raw_handle() as _
+    }
+}
+
+impl AsRawFd for std::process::ChildStdout {
+    fn as_raw_fd(&self) -> RawFd {
+        self.as_raw_handle() as _
+    }
+}
+
+impl AsRawFd for std::process::ChildStderr {
+    fn as_raw_fd(&self) -> RawFd {
+        self.as_raw_handle() as _
+    }
+}
+
 impl From<OwnedHandle> for OwnedFd {
     fn from(value: OwnedHandle) -> Self {
         Self::File(value)
@@ -105,6 +123,24 @@ impl From<OwnedHandle> for OwnedFd {
 
 impl From<std::fs::File> for OwnedFd {
     fn from(value: std::fs::File) -> Self {
+        Self::File(OwnedHandle::from(value))
+    }
+}
+
+impl From<std::process::ChildStdin> for OwnedFd {
+    fn from(value: std::process::ChildStdin) -> Self {
+        Self::File(OwnedHandle::from(value))
+    }
+}
+
+impl From<std::process::ChildStdout> for OwnedFd {
+    fn from(value: std::process::ChildStdout) -> Self {
+        Self::File(OwnedHandle::from(value))
+    }
+}
+
+impl From<std::process::ChildStderr> for OwnedFd {
+    fn from(value: std::process::ChildStderr) -> Self {
         Self::File(OwnedHandle::from(value))
     }
 }

--- a/compio-driver/src/iocp/op.rs
+++ b/compio-driver/src/iocp/op.rs
@@ -19,8 +19,9 @@ use windows_sys::{
     core::GUID,
     Win32::{
         Foundation::{
-            CloseHandle, GetLastError, ERROR_HANDLE_EOF, ERROR_IO_INCOMPLETE, ERROR_IO_PENDING,
-            ERROR_NOT_FOUND, ERROR_NO_DATA, ERROR_PIPE_CONNECTED,
+            CloseHandle, GetLastError, ERROR_BROKEN_PIPE, ERROR_HANDLE_EOF, ERROR_IO_INCOMPLETE,
+            ERROR_IO_PENDING, ERROR_NOT_FOUND, ERROR_NO_DATA, ERROR_PIPE_CONNECTED,
+            ERROR_PIPE_NOT_CONNECTED,
         },
         Networking::WinSock::{
             closesocket, setsockopt, shutdown, socklen_t, WSAIoctl, WSARecv, WSARecvFrom, WSASend,
@@ -45,9 +46,12 @@ fn winapi_result(transferred: u32) -> Poll<io::Result<usize>> {
     assert_ne!(error, 0);
     match error {
         ERROR_IO_PENDING => Poll::Pending,
-        ERROR_IO_INCOMPLETE | ERROR_HANDLE_EOF | ERROR_PIPE_CONNECTED | ERROR_NO_DATA => {
-            Poll::Ready(Ok(transferred as _))
-        }
+        ERROR_IO_INCOMPLETE
+        | ERROR_HANDLE_EOF
+        | ERROR_BROKEN_PIPE
+        | ERROR_PIPE_CONNECTED
+        | ERROR_PIPE_NOT_CONNECTED
+        | ERROR_NO_DATA => Poll::Ready(Ok(transferred as _)),
         _ => Poll::Ready(Err(io::Error::from_raw_os_error(error as _))),
     }
 }

--- a/compio-driver/src/iour/op.rs
+++ b/compio-driver/src/iour/op.rs
@@ -555,3 +555,15 @@ impl<T: IoVectoredBuf, S> IntoInner for SendToVectored<T, S> {
         self.buffer
     }
 }
+
+impl<S: AsRawFd> OpCode for PollOnce<S> {
+    fn create_entry(self: Pin<&mut Self>) -> OpEntry {
+        let flags = match self.interest {
+            Interest::Readable => libc::POLLIN,
+            Interest::Writable => libc::POLLOUT,
+        };
+        opcode::PollAdd::new(Fd(self.fd.as_raw_fd()), flags as _)
+            .build()
+            .into()
+    }
+}

--- a/compio-driver/src/op.rs
+++ b/compio-driver/src/op.rs
@@ -16,8 +16,8 @@ pub use crate::sys::op::{
 };
 #[cfg(unix)]
 pub use crate::sys::op::{
-    CreateDir, CreateSocket, FileStat, HardLink, OpenFile, PathStat, ReadVectoredAt, Rename,
-    Symlink, Unlink, WriteVectoredAt,
+    CreateDir, CreateSocket, FileStat, HardLink, Interest, OpenFile, PathStat, PollOnce,
+    ReadVectoredAt, Rename, Symlink, Unlink, WriteVectoredAt,
 };
 use crate::{
     sys::{sockaddr_storage, socklen_t},

--- a/compio-driver/src/poll/mod.rs
+++ b/compio-driver/src/poll/mod.rs
@@ -17,7 +17,7 @@ use crossbeam_queue::SegQueue;
 pub(crate) use libc::{sockaddr_storage, socklen_t};
 use polling::{Event, Events, PollMode, Poller};
 
-use crate::{syscall, AsyncifyPool, Entry, Key, OutEntries, ProactorBuilder};
+use crate::{op::Interest, syscall, AsyncifyPool, Entry, Key, OutEntries, ProactorBuilder};
 
 pub(crate) mod op;
 
@@ -82,15 +82,6 @@ pub struct WaitArg {
     pub fd: RawFd,
     /// The interest to be registered.
     pub interest: Interest,
-}
-
-/// The interest of the operation
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum Interest {
-    /// Represents a read operation.
-    Readable,
-    /// Represents a write operation.
-    Writable,
 }
 
 #[derive(Debug, Default)]

--- a/compio-driver/src/unix/op.rs
+++ b/compio-driver/src/unix/op.rs
@@ -369,3 +369,25 @@ impl<T: IoVectoredBuf, S> IntoInner for SendVectored<T, S> {
         self.buffer
     }
 }
+
+/// The interest to poll a file descriptor.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Interest {
+    /// Represents a read operation.
+    Readable,
+    /// Represents a write operation.
+    Writable,
+}
+
+/// Poll a file descriptor for specified [`Interest`].
+pub struct PollOnce<S> {
+    pub(crate) fd: SharedFd<S>,
+    pub(crate) interest: Interest,
+}
+
+impl<S> PollOnce<S> {
+    /// Create [`PollOnce`].
+    pub fn new(fd: SharedFd<S>, interest: Interest) -> Self {
+        Self { fd, interest }
+    }
+}

--- a/compio-fs/src/named_pipe.rs
+++ b/compio-fs/src/named_pipe.rs
@@ -168,8 +168,8 @@ impl NamedPipeServer {
     ///
     /// // Write fails with an OS-specific error after client has been
     /// // disconnected.
-    /// let e = client.write("ping").await.0.unwrap_err();
-    /// assert_eq!(e.raw_os_error(), Some(ERROR_PIPE_NOT_CONNECTED as i32));
+    /// let e = client.write("ping").await.0.unwrap();
+    /// assert_eq!(e, 0);
     /// # })
     /// ```
     pub fn disconnect(&self) -> io::Result<()> {

--- a/compio-process/Cargo.toml
+++ b/compio-process/Cargo.toml
@@ -1,0 +1,36 @@
+[package]
+name = "compio-process"
+version = "0.1.0"
+description = "Processes for compio"
+categories = ["asynchronous"]
+keywords = ["async", "process"]
+edition = { workspace = true }
+authors = { workspace = true }
+readme = { workspace = true }
+license = { workspace = true }
+repository = { workspace = true }
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
+
+[dependencies]
+compio-buf = { workspace = true }
+compio-driver = { workspace = true }
+compio-io = { workspace = true }
+compio-runtime = { workspace = true }
+
+cfg-if = { workspace = true }
+futures-util = { workspace = true }
+
+[target.'cfg(windows)'.dependencies]
+windows-sys = { workspace = true }
+
+[dev-dependencies]
+compio-macros = { workspace = true }
+
+[features]
+default = []
+
+linux_pidfd = []
+nightly = ["linux_pidfd"]

--- a/compio-process/src/lib.rs
+++ b/compio-process/src/lib.rs
@@ -1,0 +1,465 @@
+//! Process library for compio. It is an extension to [`std::process`].
+
+#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+#![cfg_attr(
+    all(feature = "linux_pidfd", target_os = "linux"),
+    feature(linux_pidfd)
+)]
+#![warn(missing_docs)]
+
+cfg_if::cfg_if! {
+    if #[cfg(windows)] {
+        #[path = "windows.rs"]
+        mod sys;
+    } else if #[cfg(target_os = "linux")] {
+        #[path = "linux.rs"]
+        mod sys;
+    } else {
+        #[path = "unix.rs"]
+        mod sys;
+    }
+}
+
+#[cfg(unix)]
+use std::os::unix::process::CommandExt;
+#[cfg(windows)]
+use std::os::windows::process::CommandExt;
+use std::{ffi::OsStr, io, path::Path, process};
+
+use compio_buf::{BufResult, IntoInner};
+use compio_io::AsyncReadExt;
+use compio_runtime::Attacher;
+use futures_util::future::Either;
+
+/// A process builder, providing fine-grained control
+/// over how a new process should be spawned.
+///
+/// A default configuration can be
+/// generated using `Command::new(program)`, where `program` gives a path to the
+/// program to be executed. Additional builder methods allow the configuration
+/// to be changed (for example, by adding arguments) prior to spawning:
+///
+/// ```
+/// use compio_process::Command;
+///
+/// # compio_runtime::Runtime::new().unwrap().block_on(async move {
+/// let output = if cfg!(windows) {
+///     Command::new("cmd")
+///         .args(["/C", "echo hello"])
+///         .output()
+///         .await
+///         .expect("failed to execute process")
+/// } else {
+///     Command::new("sh")
+///         .args(["-c", "echo hello"])
+///         .output()
+///         .await
+///         .expect("failed to execute process")
+/// };
+///
+/// let hello = output.stdout;
+/// # })
+/// ```
+///
+/// `Command` can be reused to spawn multiple processes. The builder methods
+/// change the command without needing to immediately spawn the process.
+///
+/// ```no_run
+/// use compio_process::Command;
+///
+/// # compio_runtime::Runtime::new().unwrap().block_on(async move {
+/// let mut echo_hello = Command::new("sh");
+/// echo_hello.arg("-c").arg("echo hello");
+/// let hello_1 = echo_hello
+///     .output()
+///     .await
+///     .expect("failed to execute process");
+/// let hello_2 = echo_hello
+///     .output()
+///     .await
+///     .expect("failed to execute process");
+/// # })
+/// ```
+///
+/// Similarly, you can call builder methods after spawning a process and then
+/// spawn a new process with the modified settings.
+///
+/// ```no_run
+/// use compio_process::Command;
+///
+/// # compio_runtime::Runtime::new().unwrap().block_on(async move {
+/// let mut list_dir = Command::new("ls");
+///
+/// // Execute `ls` in the current directory of the program.
+/// list_dir.status().await.expect("process failed to execute");
+///
+/// println!();
+///
+/// // Change `ls` to execute in the root directory.
+/// list_dir.current_dir("/");
+///
+/// // And then execute `ls` again but in the root directory.
+/// list_dir.status().await.expect("process failed to execute");
+/// # })
+/// ```
+///
+/// See [`std::process::Command`] for detailed documents.
+#[derive(Debug)]
+pub struct Command(process::Command);
+
+impl Command {
+    /// Create [`Command`].
+    pub fn new(program: impl AsRef<OsStr>) -> Self {
+        Self(process::Command::new(program))
+    }
+
+    /// Adds an argument to pass to the program.
+    pub fn arg(&mut self, arg: impl AsRef<OsStr>) -> &mut Self {
+        self.0.arg(arg);
+        self
+    }
+
+    /// Adds multiple arguments to pass to the program.
+    pub fn args<I, S>(&mut self, args: I) -> &mut Self
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<OsStr>,
+    {
+        self.0.args(args);
+        self
+    }
+
+    /// Inserts or updates an explicit environment variable mapping.
+    pub fn env<K, V>(&mut self, key: K, val: V) -> &mut Self
+    where
+        K: AsRef<OsStr>,
+        V: AsRef<OsStr>,
+    {
+        self.0.env(key, val);
+        self
+    }
+
+    /// Inserts or updates multiple explicit environment variable mappings.
+    pub fn envs<I, K, V>(&mut self, vars: I) -> &mut Self
+    where
+        I: IntoIterator<Item = (K, V)>,
+        K: AsRef<OsStr>,
+        V: AsRef<OsStr>,
+    {
+        self.0.envs(vars);
+        self
+    }
+
+    /// Removes an explicitly set environment variable and prevents inheriting
+    /// it from a parent process.
+    pub fn env_remove(&mut self, key: impl AsRef<OsStr>) -> &mut Self {
+        self.0.env_remove(key);
+        self
+    }
+
+    /// Clears all explicitly set environment variables and prevents inheriting
+    /// any parent process environment variables.
+    pub fn env_clear(&mut self) -> &mut Self {
+        self.0.env_clear();
+        self
+    }
+
+    /// Sets the working directory for the child process.
+    pub fn current_dir(&mut self, dir: impl AsRef<Path>) -> &mut Self {
+        self.0.current_dir(dir);
+        self
+    }
+
+    /// Configuration for the child process’s standard input (stdin) handle.
+    pub fn stdin(&mut self, cfg: impl Into<process::Stdio>) -> &mut Self {
+        self.0.stdin(cfg);
+        self
+    }
+
+    /// Configuration for the child process’s standard output (stdout) handle.
+    pub fn stdout(&mut self, cfg: impl Into<process::Stdio>) -> &mut Self {
+        self.0.stdout(cfg);
+        self
+    }
+
+    /// Configuration for the child process’s standard error (stderr) handle.
+    pub fn stderr(&mut self, cfg: impl Into<process::Stdio>) -> &mut Self {
+        self.0.stderr(cfg);
+        self
+    }
+
+    /// Returns the path to the program.
+    pub fn get_program(&self) -> &OsStr {
+        self.0.get_program()
+    }
+
+    /// Returns an iterator of the arguments that will be passed to the program.
+    pub fn get_args(&self) -> process::CommandArgs {
+        self.0.get_args()
+    }
+
+    /// Returns an iterator of the environment variables explicitly set for the
+    /// child process.
+    pub fn get_envs(&self) -> process::CommandEnvs {
+        self.0.get_envs()
+    }
+
+    /// Returns the working directory for the child process.
+    pub fn get_current_dir(&self) -> Option<&Path> {
+        self.0.get_current_dir()
+    }
+
+    /// Executes the command as a child process, returning a handle to it.
+    pub fn spawn(&mut self) -> io::Result<Child> {
+        #[cfg(all(target_os = "linux", feature = "linux_pidfd"))]
+        {
+            use std::os::linux::process::CommandExt;
+            self.0.create_pidfd(true);
+        }
+        let mut child = self.0.spawn()?;
+        let stdin = if let Some(stdin) = child.stdin.take() {
+            Some(ChildStdin::new(stdin)?)
+        } else {
+            None
+        };
+        let stdout = if let Some(stdout) = child.stdout.take() {
+            Some(ChildStdout::new(stdout)?)
+        } else {
+            None
+        };
+        let stderr = if let Some(stderr) = child.stderr.take() {
+            Some(ChildStderr::new(stderr)?)
+        } else {
+            None
+        };
+        Ok(Child {
+            child,
+            stdin,
+            stdout,
+            stderr,
+        })
+    }
+
+    /// Executes a command as a child process, waiting for it to finish and
+    /// collecting its status. The output of child stdout and child stderr will
+    /// be ignored.
+    pub async fn status(&mut self) -> io::Result<process::ExitStatus> {
+        let child = self.spawn()?;
+        child.wait().await
+    }
+
+    /// Executes the command as a child process, waiting for it to finish and
+    /// collecting all of its output.
+    pub async fn output(&mut self) -> io::Result<process::Output> {
+        let child = self.spawn()?;
+        child.wait_with_output().await
+    }
+}
+
+#[cfg(windows)]
+impl Command {
+    /// Sets the [process creation flags][1] to be passed to `CreateProcess`.
+    ///
+    /// These will always be ORed with `CREATE_UNICODE_ENVIRONMENT`.
+    ///
+    /// [1]: https://docs.microsoft.com/en-us/windows/win32/procthread/process-creation-flags
+    pub fn creation_flags(&mut self, flags: u32) -> &mut Self {
+        self.0.creation_flags(flags);
+        self
+    }
+
+    /// Append literal text to the command line without any quoting or escaping.
+    pub fn raw_arg(&mut self, text_to_append_as_is: impl AsRef<OsStr>) -> &mut Self {
+        self.0.raw_arg(text_to_append_as_is);
+        self
+    }
+}
+
+#[cfg(unix)]
+impl Command {
+    /// Sets the child process’s user ID. This translates to a `setuid`` call in
+    /// the child process. Failure in the `setuid` call will cause the spawn to
+    /// fail.
+    pub fn uid(&mut self, id: u32) -> &mut Self {
+        self.0.uid(id);
+        self
+    }
+
+    /// Similar to `uid`, but sets the group ID of the child process. This has
+    /// the same semantics as the `uid` field.
+    pub fn gid(&mut self, id: u32) -> &mut Self {
+        self.0.gid(id);
+        self
+    }
+
+    /// Schedules a closure to be run just before the `exec` function is
+    /// invoked.
+    ///
+    /// # Safety
+    ///
+    /// See [`CommandExt::pre_exec`].
+    pub unsafe fn pre_exec(
+        &mut self,
+        f: impl FnMut() -> io::Result<()> + Send + Sync + 'static,
+    ) -> &mut Self {
+        self.0.pre_exec(f);
+        self
+    }
+
+    /// `exec` the command without `fork`.
+    pub fn exec(&mut self) -> io::Error {
+        self.0.exec()
+    }
+
+    /// Set the first process argument, `argv[0]`, to something other than the
+    /// default executable path.
+    pub fn arg0(&mut self, arg: impl AsRef<OsStr>) -> &mut Self {
+        self.0.arg0(arg);
+        self
+    }
+
+    /// Sets the process group ID (PGID) of the child process.
+    pub fn process_group(&mut self, pgroup: i32) -> &mut Self {
+        self.0.process_group(pgroup);
+        self
+    }
+}
+
+/// Representation of a running or exited child process.
+///
+/// This structure is used to represent and manage child processes. A child
+/// process is created via the [`Command`] struct, which configures the
+/// spawning process and can itself be constructed using a builder-style
+/// interface.
+///
+/// There is no implementation of [`Drop`] for child processes,
+/// so if you do not ensure the `Child` has exited then it will continue to
+/// run, even after the `Child` handle to the child process has gone out of
+/// scope.
+///
+/// Calling [`Child::wait`] (or other functions that wrap around it) will make
+/// the parent process wait until the child has actually exited before
+/// continuing.
+///
+/// See [`std::process::Child`] for detailed documents.
+pub struct Child {
+    child: process::Child,
+    /// The handle for writing to the child’s standard input (stdin).
+    pub stdin: Option<ChildStdin>,
+    /// The handle for reading from the child’s standard output (stdout).
+    pub stdout: Option<ChildStdout>,
+    /// The handle for reading from the child’s standard error (stderr).
+    pub stderr: Option<ChildStderr>,
+}
+
+impl Child {
+    /// Forces the child process to exit. If the child has already exited,
+    /// `Ok(())`` is returned.
+    pub fn kill(&mut self) -> io::Result<()> {
+        self.child.kill()
+    }
+
+    /// Returns the OS-assigned process identifier associated with this child.
+    pub fn id(&self) -> u32 {
+        self.child.id()
+    }
+
+    /// Waits for the child to exit completely, returning the status that it
+    /// exited with. This function will consume the child. To get the output,
+    /// either take `stdout` and `stderr` out before calling it, or call
+    /// [`Child::wait_with_output`].
+    pub async fn wait(self) -> io::Result<process::ExitStatus> {
+        sys::child_wait(self.child).await
+    }
+
+    /// Simultaneously waits for the child to exit and collect all remaining
+    /// output on the stdout/stderr handles, returning an Output instance.
+    pub async fn wait_with_output(mut self) -> io::Result<process::Output> {
+        let status = sys::child_wait(self.child);
+        let stdout = if let Some(stdout) = &mut self.stdout {
+            Either::Left(stdout.read_to_end(vec![]))
+        } else {
+            Either::Right(std::future::ready(BufResult(Ok(0), vec![])))
+        };
+        let stderr = if let Some(stderr) = &mut self.stderr {
+            Either::Left(stderr.read_to_end(vec![]))
+        } else {
+            Either::Right(std::future::ready(BufResult(Ok(0), vec![])))
+        };
+        let (status, BufResult(out_res, stdout), BufResult(err_res, stderr)) =
+            futures_util::join!(status, stdout, stderr);
+        let status = status?;
+        out_res?;
+        err_res?;
+        Ok(process::Output {
+            status,
+            stdout,
+            stderr,
+        })
+    }
+}
+
+/// A handle to a child process's standard output (stdout). See
+/// [`std::process::ChildStdout`].
+pub struct ChildStdout(Attacher<process::ChildStdout>);
+
+impl ChildStdout {
+    fn new(stdout: process::ChildStdout) -> io::Result<Self> {
+        Attacher::new(stdout).map(Self)
+    }
+}
+
+impl From<ChildStdout> for process::Stdio {
+    fn from(value: ChildStdout) -> Self {
+        Self::from(
+            value
+                .0
+                .into_inner()
+                .try_unwrap()
+                .expect("the handle is being used"),
+        )
+    }
+}
+
+/// A handle to a child process's stderr. See [`std::process::ChildStderr`].
+pub struct ChildStderr(Attacher<process::ChildStderr>);
+
+impl ChildStderr {
+    fn new(stderr: process::ChildStderr) -> io::Result<Self> {
+        Attacher::new(stderr).map(Self)
+    }
+}
+
+impl From<ChildStderr> for process::Stdio {
+    fn from(value: ChildStderr) -> Self {
+        Self::from(
+            value
+                .0
+                .into_inner()
+                .try_unwrap()
+                .expect("the handle is being used"),
+        )
+    }
+}
+
+/// A handle to a child process's standard input (stdin). See
+/// [`std::process::ChildStdin`].
+pub struct ChildStdin(Attacher<process::ChildStdin>);
+
+impl ChildStdin {
+    fn new(stdin: process::ChildStdin) -> io::Result<Self> {
+        Attacher::new(stdin).map(Self)
+    }
+}
+
+impl From<ChildStdin> for process::Stdio {
+    fn from(value: ChildStdin) -> Self {
+        Self::from(
+            value
+                .0
+                .into_inner()
+                .try_unwrap()
+                .expect("the handle is being used"),
+        )
+    }
+}

--- a/compio-process/src/lib.rs
+++ b/compio-process/src/lib.rs
@@ -387,7 +387,7 @@ impl Child {
             Either::Right(std::future::ready(BufResult(Ok(0), vec![])))
         };
         let (status, BufResult(out_res, stdout), BufResult(err_res, stderr)) =
-            futures_util::join!(status, stdout, stderr);
+            futures_util::future::join3(status, stdout, stderr).await;
         let status = status?;
         out_res?;
         err_res?;

--- a/compio-process/src/linux.rs
+++ b/compio-process/src/linux.rs
@@ -1,0 +1,32 @@
+use std::{io, process};
+
+use compio_driver::{
+    op::{Interest, PollOnce},
+    SharedFd,
+};
+
+pub async fn child_wait(mut child: process::Child) -> io::Result<process::ExitStatus> {
+    #[cfg(feature = "linux_pidfd")]
+    let fd = {
+        use std::os::linux::process::ChildExt;
+
+        use compio_driver::AsRawFd;
+
+        child.pidfd().ok().map(|fd| fd.as_raw_fd())
+    };
+    #[cfg(not(feature = "linux_pidfd"))]
+    let fd = None::<compio_driver::RawFd>;
+    if let Some(fd) = fd {
+        // pidfd won't be closed, and the child has not been reaped.
+        let fd = SharedFd::new(fd);
+        let op = PollOnce::new(fd, Interest::Readable);
+        compio_runtime::submit(op).await.0?;
+        child.wait()
+    } else {
+        unix::child_wait(child).await
+    }
+}
+
+// For trait impls and fallback.
+#[path = "unix.rs"]
+mod unix;

--- a/compio-process/src/unix.rs
+++ b/compio-process/src/unix.rs
@@ -1,0 +1,84 @@
+use std::{io, panic::resume_unwind, process};
+
+use compio_buf::{BufResult, IntoInner, IoBuf, IoBufMut};
+use compio_driver::{
+    op::{BufResultExt, Recv, Send},
+    AsRawFd, RawFd, SharedFd, ToSharedFd,
+};
+use compio_io::{AsyncRead, AsyncWrite};
+
+use crate::{ChildStderr, ChildStdin, ChildStdout};
+
+pub async fn child_wait(mut child: process::Child) -> io::Result<process::ExitStatus> {
+    compio_runtime::spawn_blocking(move || child.wait())
+        .await
+        .unwrap_or_else(|e| resume_unwind(e))
+}
+
+impl AsRawFd for ChildStdout {
+    fn as_raw_fd(&self) -> RawFd {
+        self.0.as_raw_fd()
+    }
+}
+
+impl ToSharedFd<process::ChildStdout> for ChildStdout {
+    fn to_shared_fd(&self) -> SharedFd<process::ChildStdout> {
+        self.0.to_shared_fd()
+    }
+}
+
+impl AsyncRead for ChildStdout {
+    async fn read<B: IoBufMut>(&mut self, buffer: B) -> BufResult<usize, B> {
+        let fd = self.to_shared_fd();
+        let op = Recv::new(fd, buffer);
+        compio_runtime::submit(op).await.into_inner().map_advanced()
+    }
+}
+
+impl AsRawFd for ChildStderr {
+    fn as_raw_fd(&self) -> RawFd {
+        self.0.as_raw_fd()
+    }
+}
+
+impl ToSharedFd<process::ChildStderr> for ChildStderr {
+    fn to_shared_fd(&self) -> SharedFd<process::ChildStderr> {
+        self.0.to_shared_fd()
+    }
+}
+
+impl AsyncRead for ChildStderr {
+    async fn read<B: IoBufMut>(&mut self, buffer: B) -> BufResult<usize, B> {
+        let fd = self.to_shared_fd();
+        let op = Recv::new(fd, buffer);
+        compio_runtime::submit(op).await.into_inner().map_advanced()
+    }
+}
+
+impl AsRawFd for ChildStdin {
+    fn as_raw_fd(&self) -> RawFd {
+        self.0.as_raw_fd()
+    }
+}
+
+impl ToSharedFd<process::ChildStdin> for ChildStdin {
+    fn to_shared_fd(&self) -> SharedFd<process::ChildStdin> {
+        self.0.to_shared_fd()
+    }
+}
+
+impl AsyncWrite for ChildStdin {
+    async fn write<T: IoBuf>(&mut self, buffer: T) -> BufResult<usize, T> {
+        let fd = self.to_shared_fd();
+        let op = Send::new(fd, buffer);
+        compio_runtime::submit(op).await.into_inner()
+    }
+
+    async fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+
+    async fn shutdown(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}

--- a/compio-process/src/windows.rs
+++ b/compio-process/src/windows.rs
@@ -1,0 +1,116 @@
+use std::{
+    io,
+    os::windows::{io::AsRawHandle, process::ExitStatusExt},
+    pin::Pin,
+    process,
+    task::Poll,
+};
+
+use compio_buf::{BufResult, IntoInner, IoBuf, IoBufMut};
+use compio_driver::{
+    op::{BufResultExt, Recv, Send},
+    syscall, AsRawFd, OpCode, OpType, RawFd, SharedFd, ToSharedFd,
+};
+use compio_io::{AsyncRead, AsyncWrite};
+use windows_sys::Win32::System::{Threading::GetExitCodeProcess, IO::OVERLAPPED};
+
+use crate::{ChildStderr, ChildStdin, ChildStdout};
+
+struct WaitProcess {
+    child: process::Child,
+}
+
+impl WaitProcess {
+    pub fn new(child: process::Child) -> Self {
+        Self { child }
+    }
+}
+
+impl OpCode for WaitProcess {
+    fn op_type(&self) -> OpType {
+        OpType::Event(self.child.as_raw_handle() as _)
+    }
+
+    unsafe fn operate(self: Pin<&mut Self>, _optr: *mut OVERLAPPED) -> Poll<io::Result<usize>> {
+        let mut code = 0;
+        syscall!(
+            BOOL,
+            GetExitCodeProcess(self.child.as_raw_handle() as _, &mut code)
+        )?;
+        Poll::Ready(Ok(code as _))
+    }
+}
+
+pub async fn child_wait(child: process::Child) -> io::Result<process::ExitStatus> {
+    let op = WaitProcess::new(child);
+    let code = compio_runtime::submit(op).await.0?;
+    Ok(process::ExitStatus::from_raw(code as _))
+}
+
+impl AsRawFd for ChildStdout {
+    fn as_raw_fd(&self) -> RawFd {
+        self.0.as_raw_fd()
+    }
+}
+
+impl ToSharedFd<process::ChildStdout> for ChildStdout {
+    fn to_shared_fd(&self) -> SharedFd<process::ChildStdout> {
+        self.0.to_shared_fd()
+    }
+}
+
+impl AsyncRead for ChildStdout {
+    async fn read<B: IoBufMut>(&mut self, buffer: B) -> BufResult<usize, B> {
+        let fd = self.to_shared_fd();
+        let op = Recv::new(fd, buffer);
+        compio_runtime::submit(op).await.into_inner().map_advanced()
+    }
+}
+
+impl AsRawFd for ChildStderr {
+    fn as_raw_fd(&self) -> RawFd {
+        self.0.as_raw_fd()
+    }
+}
+
+impl ToSharedFd<process::ChildStderr> for ChildStderr {
+    fn to_shared_fd(&self) -> SharedFd<process::ChildStderr> {
+        self.0.to_shared_fd()
+    }
+}
+
+impl AsyncRead for ChildStderr {
+    async fn read<B: IoBufMut>(&mut self, buffer: B) -> BufResult<usize, B> {
+        let fd = self.to_shared_fd();
+        let op = Recv::new(fd, buffer);
+        compio_runtime::submit(op).await.into_inner().map_advanced()
+    }
+}
+
+impl AsRawFd for ChildStdin {
+    fn as_raw_fd(&self) -> RawFd {
+        self.0.as_raw_fd()
+    }
+}
+
+impl ToSharedFd<process::ChildStdin> for ChildStdin {
+    fn to_shared_fd(&self) -> SharedFd<process::ChildStdin> {
+        self.0.to_shared_fd()
+    }
+}
+
+impl AsyncWrite for ChildStdin {
+    async fn write<T: IoBuf>(&mut self, buffer: T) -> BufResult<usize, T> {
+        let fd = self.to_shared_fd();
+        let op = Send::new(fd, buffer);
+        compio_runtime::submit(op).await.into_inner()
+    }
+
+    async fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+
+    async fn shutdown(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}

--- a/compio-process/tests/process.rs
+++ b/compio-process/tests/process.rs
@@ -1,0 +1,65 @@
+use std::process::Stdio;
+
+use compio_process::Command;
+
+#[compio_macros::test]
+async fn exit_code() {
+    let mut cmd;
+
+    if cfg!(windows) {
+        cmd = Command::new("cmd");
+        cmd.arg("/c");
+    } else {
+        cmd = Command::new("sh");
+        cmd.arg("-c");
+    }
+
+    let child = cmd.arg("exit 2").spawn().unwrap();
+
+    let id = child.id();
+    assert!(id > 0);
+
+    let status = child.wait().await.unwrap();
+    assert_eq!(status.code(), Some(2));
+}
+
+#[compio_macros::test]
+async fn echo() {
+    let mut cmd;
+
+    if cfg!(windows) {
+        cmd = Command::new("cmd");
+        cmd.arg("/c");
+    } else {
+        cmd = Command::new("sh");
+        cmd.arg("-c");
+    }
+
+    let child = cmd
+        .arg("echo hello world")
+        .stdout(Stdio::piped())
+        .spawn()
+        .unwrap();
+
+    let id = child.id();
+    assert!(id > 0);
+
+    let output = child.wait_with_output().await.unwrap();
+    assert!(output.status.success());
+
+    let out = String::from_utf8(output.stdout).unwrap();
+    assert_eq!(out.trim(), "hello world");
+}
+
+#[cfg(unix)]
+#[compio_macros::test]
+async fn arg0() {
+    let mut cmd = Command::new("sh");
+    cmd.arg0("test_string")
+        .arg("-c")
+        .arg("echo $0")
+        .stdout(Stdio::piped());
+
+    let output = cmd.output().await.unwrap();
+    assert_eq!(output.stdout, b"test_string\n");
+}

--- a/compio-process/tests/process.rs
+++ b/compio-process/tests/process.rs
@@ -38,6 +38,7 @@ async fn echo() {
     let child = cmd
         .arg("echo hello world")
         .stdout(Stdio::piped())
+        .unwrap()
         .spawn()
         .unwrap();
 
@@ -58,7 +59,8 @@ async fn arg0() {
     cmd.arg0("test_string")
         .arg("-c")
         .arg("echo $0")
-        .stdout(Stdio::piped());
+        .stdout(Stdio::piped())
+        .unwrap();
 
     let output = cmd.output().await.unwrap();
     assert_eq!(output.stdout, b"test_string\n");

--- a/compio-runtime/src/attacher.rs
+++ b/compio-runtime/src/attacher.rs
@@ -30,6 +30,15 @@ impl<S> Attacher<S> {
             source: SharedFd::new(source),
         }
     }
+
+    /// Create [`Attacher`] without trying to attach the source.
+    ///
+    /// # Safety
+    ///
+    /// See [`Attacher::new_unchecked`].
+    pub unsafe fn from_shared_fd_unchecked(source: SharedFd<S>) -> Self {
+        Self { source }
+    }
 }
 
 impl<S: AsRawFd> Attacher<S> {

--- a/compio/Cargo.toml
+++ b/compio/Cargo.toml
@@ -41,6 +41,7 @@ compio-signal = { workspace = true, optional = true }
 compio-dispatcher = { workspace = true, optional = true }
 compio-log = { workspace = true }
 compio-tls = { workspace = true, optional = true }
+compio-process = { workspace = true, optional = true }
 
 # Shared dev dependencies for all platforms
 [dev-dependencies]
@@ -92,7 +93,16 @@ dispatcher = ["dep:compio-dispatcher", "runtime"]
 tls = ["dep:compio-tls"]
 native-tls = ["tls", "compio-tls/native-tls"]
 rustls = ["tls", "compio-tls/rustls"]
-all = ["time", "macros", "signal", "dispatcher", "native-tls", "rustls"]
+process = ["dep:compio-process"]
+all = [
+    "time",
+    "macros",
+    "signal",
+    "dispatcher",
+    "native-tls",
+    "rustls",
+    "process",
+]
 
 arrayvec = ["compio-buf/arrayvec"]
 bumpalo = ["compio-buf/bumpalo"]
@@ -104,6 +114,7 @@ enable_log = ["compio-log/enable_log"]
 # Nightly features
 allocator_api = ["compio-buf/allocator_api", "compio-io?/allocator_api"]
 lazy_cell = ["compio-signal?/lazy_cell"]
+linux_pidfd = ["compio-process?/linux_pidfd"]
 once_cell_try = ["compio-driver/once_cell_try", "compio-signal?/once_cell_try"]
 read_buf = [
     "compio-buf/read_buf",
@@ -116,6 +127,7 @@ windows_by_handle = ["compio-fs?/windows_by_handle"]
 nightly = [
     "allocator_api",
     "lazy_cell",
+    "linux_pidfd",
     "once_cell_try",
     "read_buf",
     "try_trait_v2",

--- a/compio/src/lib.rs
+++ b/compio/src/lib.rs
@@ -38,6 +38,9 @@ pub use compio_dispatcher as dispatcher;
 pub use compio_io as io;
 #[cfg(feature = "macros")]
 pub use compio_macros::*;
+#[cfg(feature = "process")]
+#[doc(inline)]
+pub use compio_process as process;
 #[cfg(feature = "signal")]
 #[doc(inline)]
 pub use compio_signal as signal;


### PR DESCRIPTION
This PR adds a new crate, `compio-process`.

* Windows: driver is modified to accept APC routines. This is required for anonymous pipes to child process.
* Linux: tries to create a pidfd. If failed, fallback to `spawn_blocking`.