### PR TITLE
refactor(driver): add SharedFd & OwnedFd and require them in operations

### DIFF
--- a/compio-driver/Cargo.toml
+++ b/compio-driver/Cargo.toml
@@ -35,6 +35,7 @@ compio-log = { workspace = true }
 # Utils
 cfg-if = { workspace = true }
 crossbeam-channel = { workspace = true }
+futures-util = { workspace = true }
 slab = { workspace = true }
 socket2 = { workspace = true }
 

--- a/compio-driver/src/fd.rs
+++ b/compio-driver/src/fd.rs
@@ -1,0 +1,136 @@
+use std::{
+    future::{poll_fn, ready, Future},
+    mem::ManuallyDrop,
+    panic::RefUnwindSafe,
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    },
+    task::Poll,
+};
+
+use futures_util::{future::Either, task::AtomicWaker};
+
+use crate::{AsRawFd, OwnedFd, RawFd};
+
+#[derive(Debug)]
+struct Inner {
+    fd: OwnedFd,
+    waits: AtomicUsize,
+    waker: AtomicWaker,
+}
+
+impl RefUnwindSafe for Inner {}
+
+/// A shared fd. It is passed to the operations to make sure the fd won't be
+/// closed before the operations complete.
+#[derive(Debug, Clone)]
+pub struct SharedFd(Arc<Inner>);
+
+impl SharedFd {
+    /// Create the shared fd from an owned fd.
+    pub fn new(fd: impl Into<OwnedFd>) -> Self {
+        Self(Arc::new(Inner {
+            fd: fd.into(),
+            waits: AtomicUsize::new(0),
+            waker: AtomicWaker::new(),
+        }))
+    }
+
+    /// Try to take the inner owned fd.
+    pub fn try_owned(self) -> Result<OwnedFd, Self> {
+        let this = ManuallyDrop::new(self);
+        if let Some(fd) = Self::try_owned_inner(&this) {
+            Ok(fd)
+        } else {
+            Err(ManuallyDrop::into_inner(this))
+        }
+    }
+
+    fn try_owned_inner(this: &ManuallyDrop<Self>) -> Option<OwnedFd> {
+        // SAFETY: see ManuallyDrop::take
+        let ptr = ManuallyDrop::new(unsafe { std::ptr::read(&this.0) });
+        // The ptr is duplicated without increasing the strong count, should forget.
+        match Arc::try_unwrap(ManuallyDrop::into_inner(ptr)) {
+            Ok(inner) => Some(inner.fd),
+            Err(ptr) => {
+                std::mem::forget(ptr);
+                None
+            }
+        }
+    }
+
+    /// Wait and take the inner owned fd.
+    pub fn take(self) -> impl Future<Output = Option<OwnedFd>> {
+        if self.0.waits.fetch_add(1, Ordering::AcqRel) == 0 {
+            let this = ManuallyDrop::new(self);
+            Either::Left(async move {
+                poll_fn(|cx| {
+                    if let Some(fd) = Self::try_owned_inner(&this) {
+                        return Poll::Ready(Some(fd));
+                    }
+
+                    this.0.waker.register(cx.waker());
+
+                    if let Some(fd) = Self::try_owned_inner(&this) {
+                        Poll::Ready(Some(fd))
+                    } else {
+                        Poll::Pending
+                    }
+                })
+                .await
+            })
+        } else {
+            Either::Right(ready(None))
+        }
+    }
+}
+
+impl Drop for SharedFd {
+    fn drop(&mut self) {
+        // It's OK to wake multiple times.
+        if Arc::strong_count(&self.0) == 2 {
+            self.0.waker.wake()
+        }
+    }
+}
+
+#[cfg(windows)]
+#[doc(hidden)]
+impl SharedFd {
+    pub unsafe fn to_file(&self) -> ManuallyDrop<std::fs::File> {
+        use std::os::windows::io::FromRawHandle;
+
+        ManuallyDrop::new(std::fs::File::from_raw_handle(self.as_raw_fd() as _))
+    }
+
+    pub unsafe fn to_socket(&self) -> ManuallyDrop<socket2::Socket> {
+        use std::os::windows::io::FromRawSocket;
+
+        ManuallyDrop::new(socket2::Socket::from_raw_socket(self.as_raw_fd() as _))
+    }
+}
+
+impl AsRawFd for SharedFd {
+    fn as_raw_fd(&self) -> RawFd {
+        self.0.fd.as_raw_fd()
+    }
+}
+
+impl From<OwnedFd> for SharedFd {
+    fn from(value: OwnedFd) -> Self {
+        Self::new(value)
+    }
+}
+
+/// Get a clone of [`SharedFd`].
+pub trait ToSharedFd {
+    /// Return a cloned [`SharedFd`].
+    fn to_shared_fd(&self) -> SharedFd;
+}
+
+impl ToSharedFd for SharedFd {
+    fn to_shared_fd(&self) -> SharedFd {
+        self.clone()
+    }
+}

--- a/compio-driver/src/fd.rs
+++ b/compio-driver/src/fd.rs
@@ -111,6 +111,22 @@ impl SharedFd {
     }
 }
 
+#[cfg(unix)]
+#[doc(hidden)]
+impl SharedFd {
+    pub unsafe fn to_file(&self) -> ManuallyDrop<std::fs::File> {
+        use std::os::fd::FromRawFd;
+
+        ManuallyDrop::new(std::fs::File::from_raw_fd(self.as_raw_fd() as _))
+    }
+
+    pub unsafe fn to_socket(&self) -> ManuallyDrop<socket2::Socket> {
+        use std::os::fd::FromRawFd;
+
+        ManuallyDrop::new(socket2::Socket::from_raw_fd(self.as_raw_fd() as _))
+    }
+}
+
 impl AsRawFd for SharedFd {
     fn as_raw_fd(&self) -> RawFd {
         self.0.fd.as_raw_fd()

--- a/compio-driver/src/fusion/mod.rs
+++ b/compio-driver/src/fusion/mod.rs
@@ -7,7 +7,7 @@ mod iour;
 pub(crate) mod op;
 
 #[cfg_attr(all(doc, docsrs), doc(cfg(all())))]
-pub use std::os::fd::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
+pub use std::os::fd::{AsRawFd, OwnedFd, RawFd};
 use std::{io, task::Poll, time::Duration};
 
 pub use driver_type::DriverType;

--- a/compio-driver/src/fusion/op.rs
+++ b/compio-driver/src/fusion/op.rs
@@ -5,6 +5,7 @@ use socket2::SockAddr;
 
 use super::*;
 pub use crate::unix::op::*;
+use crate::SharedFd;
 
 macro_rules! op {
     (<$($ty:ident: $trait:ident),* $(,)?> $name:ident( $($arg:ident: $arg_t:ident),* $(,)? )) => {
@@ -91,9 +92,9 @@ mod iour { pub use crate::sys::iour::{op::*, OpCode}; }
 #[rustfmt::skip]
 mod poll { pub use crate::sys::poll::{op::*, OpCode}; }
 
-op!(<T: IoBufMut> RecvFrom(fd: RawFd, buffer: T));
-op!(<T: IoBuf> SendTo(fd: RawFd, buffer: T, addr: SockAddr));
-op!(<T: IoVectoredBufMut> RecvFromVectored(fd: RawFd, buffer: T));
-op!(<T: IoVectoredBuf> SendToVectored(fd: RawFd, buffer: T, addr: SockAddr));
-op!(<> FileStat(fd: RawFd));
+op!(<T: IoBufMut> RecvFrom(fd: SharedFd, buffer: T));
+op!(<T: IoBuf> SendTo(fd: SharedFd, buffer: T, addr: SockAddr));
+op!(<T: IoVectoredBufMut> RecvFromVectored(fd: SharedFd, buffer: T));
+op!(<T: IoVectoredBuf> SendToVectored(fd: SharedFd, buffer: T, addr: SockAddr));
+op!(<> FileStat(fd: SharedFd));
 op!(<> PathStat(path: CString, follow_symlink: bool));

--- a/compio-driver/src/iocp/cp/global.rs
+++ b/compio-driver/src/iocp/cp/global.rs
@@ -74,7 +74,7 @@ fn iocp_start() -> io::Result<()> {
                     )
                 ) {
                     error!(
-                        "fail to dispatch entry ({}, {}, {:p}) to driver {:p}: {:?}",
+                        "fail to dispatch entry ({}, {}, {:p}) to driver {:x}: {:?}",
                         entry.dwNumberOfBytesTransferred,
                         entry.lpCompletionKey,
                         entry.lpOverlapped,

--- a/compio-driver/src/iocp/cp/mod.rs
+++ b/compio-driver/src/iocp/cp/mod.rs
@@ -158,7 +158,7 @@ impl CompletionPort {
                         )
                     ) {
                         error!(
-                            "fail to repost entry ({}, {}, {:p}) to driver {:p}: {:?}",
+                            "fail to repost entry ({}, {}, {:p}) to driver {:x}: {:?}",
                             entry.dwNumberOfBytesTransferred,
                             entry.lpCompletionKey,
                             entry.lpOverlapped,

--- a/compio-driver/src/iocp/cp/multi.rs
+++ b/compio-driver/src/iocp/cp/multi.rs
@@ -28,7 +28,7 @@ impl Port {
     }
 
     pub fn poll(&self, timeout: Option<Duration>) -> io::Result<impl Iterator<Item = Entry> + '_> {
-        let current_id = self.as_raw_handle();
+        let current_id = self.as_raw_handle() as _;
         self.port.poll(timeout, Some(current_id))
     }
 }

--- a/compio-driver/src/iour/mod.rs
+++ b/compio-driver/src/iour/mod.rs
@@ -1,7 +1,7 @@
 #[cfg_attr(all(doc, docsrs), doc(cfg(all())))]
 #[allow(unused_imports)]
-pub use std::os::fd::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
-use std::{io, os::fd::OwnedFd, pin::Pin, ptr::NonNull, sync::Arc, task::Poll, time::Duration};
+pub use std::os::fd::{AsRawFd, OwnedFd, RawFd};
+use std::{io, os::fd::FromRawFd, pin::Pin, ptr::NonNull, sync::Arc, task::Poll, time::Duration};
 
 use compio_log::{instrument, trace, warn};
 use crossbeam_queue::SegQueue;

--- a/compio-driver/src/lib.rs
+++ b/compio-driver/src/lib.rs
@@ -29,6 +29,9 @@ mod unix;
 mod asyncify;
 pub use asyncify::*;
 
+mod fd;
+pub use fd::*;
+
 cfg_if::cfg_if! {
     if #[cfg(windows)] {
         #[path = "iocp/mod.rs"]
@@ -111,16 +114,9 @@ macro_rules! impl_raw_fd {
                 self.$inner.as_raw_fd()
             }
         }
-        impl $crate::FromRawFd for $t {
-            unsafe fn from_raw_fd(fd: $crate::RawFd) -> Self {
-                Self {
-                    $inner: $crate::FromRawFd::from_raw_fd(fd),
-                }
-            }
-        }
-        impl $crate::IntoRawFd for $t {
-            fn into_raw_fd(self) -> $crate::RawFd {
-                self.$inner.into_raw_fd()
+        impl $crate::ToSharedFd for $t {
+            fn to_shared_fd(&self) -> $crate::SharedFd {
+                self.$inner.to_shared_fd()
             }
         }
     };

--- a/compio-driver/src/lib.rs
+++ b/compio-driver/src/lib.rs
@@ -114,9 +114,39 @@ macro_rules! impl_raw_fd {
                 self.$inner.as_raw_fd()
             }
         }
+        #[cfg(unix)]
+        impl std::os::fd::FromRawFd for $t {
+            unsafe fn from_raw_fd(fd: $crate::RawFd) -> Self {
+                Self {
+                    $inner: std::os::fd::FromRawFd::from_raw_fd(fd),
+                }
+            }
+        }
         impl $crate::ToSharedFd for $t {
             fn to_shared_fd(&self) -> $crate::SharedFd {
                 self.$inner.to_shared_fd()
+            }
+        }
+    };
+    ($t:ty, $inner:ident,file) => {
+        $crate::impl_raw_fd!($t, $inner);
+        #[cfg(windows)]
+        impl std::os::windows::io::FromRawHandle for $t {
+            unsafe fn from_raw_handle(handle: std::os::windows::io::RawHandle) -> Self {
+                Self {
+                    $inner: std::os::windows::io::FromRawHandle::from_raw_handle(handle),
+                }
+            }
+        }
+    };
+    ($t:ty, $inner:ident,socket) => {
+        $crate::impl_raw_fd!($t, $inner);
+        #[cfg(windows)]
+        impl std::os::windows::io::FromRawSocket for $t {
+            unsafe fn from_raw_socket(sock: std::os::windows::io::RawSocket) -> Self {
+                Self {
+                    $inner: std::os::windows::io::FromRawSocket::from_raw_socket(sock),
+                }
             }
         }
     };

--- a/compio-driver/src/poll/mod.rs
+++ b/compio-driver/src/poll/mod.rs
@@ -1,6 +1,6 @@
 #[cfg_attr(all(doc, docsrs), doc(cfg(all())))]
 #[allow(unused_imports)]
-pub use std::os::fd::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
+pub use std::os::fd::{AsRawFd, OwnedFd, RawFd};
 use std::{
     collections::{HashMap, HashSet, VecDeque},
     io::{self, Read, Write},

--- a/compio-driver/src/poll/op.rs
+++ b/compio-driver/src/poll/op.rs
@@ -102,7 +102,9 @@ impl OpCode for FileStat {
         }
         #[cfg(not(all(target_os = "linux", target_env = "gnu")))]
         {
-            Poll::Ready(Ok(syscall!(libc::fstat(self.fd, &mut self.stat))? as _))
+            Poll::Ready(Ok(
+                syscall!(libc::fstat(self.fd.as_raw_fd(), &mut self.stat))? as _,
+            ))
         }
     }
 }
@@ -283,7 +285,7 @@ impl OpCode for Sync {
             target_os = "netbsd"
         )))]
         {
-            Poll::Ready(Ok(syscall!(libc::fsync(self.fd))? as _))
+            Poll::Ready(Ok(syscall!(libc::fsync(self.fd.as_raw_fd()))? as _))
         }
     }
 }

--- a/compio-driver/src/unix/op.rs
+++ b/compio-driver/src/unix/op.rs
@@ -6,7 +6,7 @@ use compio_buf::{
 use libc::{sockaddr_storage, socklen_t};
 use socket2::SockAddr;
 
-use crate::{op::*, sys::RawFd};
+use crate::{op::*, SharedFd};
 
 /// Open or create a file with flags and mode.
 pub struct OpenFile {
@@ -86,7 +86,7 @@ pub(crate) const fn statx_to_stat(statx: Statx) -> libc::stat {
 
 /// Read a file at specified position into vectored buffer.
 pub struct ReadVectoredAt<T: IoVectoredBufMut> {
-    pub(crate) fd: RawFd,
+    pub(crate) fd: SharedFd,
     pub(crate) offset: u64,
     pub(crate) buffer: T,
     pub(crate) slices: Vec<IoSliceMut>,
@@ -95,7 +95,7 @@ pub struct ReadVectoredAt<T: IoVectoredBufMut> {
 
 impl<T: IoVectoredBufMut> ReadVectoredAt<T> {
     /// Create [`ReadVectoredAt`].
-    pub fn new(fd: RawFd, offset: u64, buffer: T) -> Self {
+    pub fn new(fd: SharedFd, offset: u64, buffer: T) -> Self {
         Self {
             fd,
             offset,
@@ -116,7 +116,7 @@ impl<T: IoVectoredBufMut> IntoInner for ReadVectoredAt<T> {
 
 /// Write a file at specified position from vectored buffer.
 pub struct WriteVectoredAt<T: IoVectoredBuf> {
-    pub(crate) fd: RawFd,
+    pub(crate) fd: SharedFd,
     pub(crate) offset: u64,
     pub(crate) buffer: T,
     pub(crate) slices: Vec<IoSlice>,
@@ -125,7 +125,7 @@ pub struct WriteVectoredAt<T: IoVectoredBuf> {
 
 impl<T: IoVectoredBuf> WriteVectoredAt<T> {
     /// Create [`WriteVectoredAt`]
-    pub fn new(fd: RawFd, offset: u64, buffer: T) -> Self {
+    pub fn new(fd: SharedFd, offset: u64, buffer: T) -> Self {
         Self {
             fd,
             offset,
@@ -239,7 +239,7 @@ impl ShutdownSocket {
 
 /// Accept a connection.
 pub struct Accept {
-    pub(crate) fd: RawFd,
+    pub(crate) fd: SharedFd,
     pub(crate) buffer: sockaddr_storage,
     pub(crate) addr_len: socklen_t,
     _p: PhantomPinned,
@@ -247,7 +247,7 @@ pub struct Accept {
 
 impl Accept {
     /// Create [`Accept`].
-    pub fn new(fd: RawFd) -> Self {
+    pub fn new(fd: SharedFd) -> Self {
         Self {
             fd,
             buffer: unsafe { std::mem::zeroed() },
@@ -264,14 +264,14 @@ impl Accept {
 
 /// Receive data from remote.
 pub struct Recv<T: IoBufMut> {
-    pub(crate) fd: RawFd,
+    pub(crate) fd: SharedFd,
     pub(crate) buffer: T,
     _p: PhantomPinned,
 }
 
 impl<T: IoBufMut> Recv<T> {
     /// Create [`Recv`].
-    pub fn new(fd: RawFd, buffer: T) -> Self {
+    pub fn new(fd: SharedFd, buffer: T) -> Self {
         Self {
             fd,
             buffer,
@@ -290,7 +290,7 @@ impl<T: IoBufMut> IntoInner for Recv<T> {
 
 /// Receive data from remote into vectored buffer.
 pub struct RecvVectored<T: IoVectoredBufMut> {
-    pub(crate) fd: RawFd,
+    pub(crate) fd: SharedFd,
     pub(crate) buffer: T,
     pub(crate) slices: Vec<IoSliceMut>,
     _p: PhantomPinned,
@@ -298,7 +298,7 @@ pub struct RecvVectored<T: IoVectoredBufMut> {
 
 impl<T: IoVectoredBufMut> RecvVectored<T> {
     /// Create [`RecvVectored`].
-    pub fn new(fd: RawFd, buffer: T) -> Self {
+    pub fn new(fd: SharedFd, buffer: T) -> Self {
         Self {
             fd,
             buffer,
@@ -318,14 +318,14 @@ impl<T: IoVectoredBufMut> IntoInner for RecvVectored<T> {
 
 /// Send data to remote.
 pub struct Send<T: IoBuf> {
-    pub(crate) fd: RawFd,
+    pub(crate) fd: SharedFd,
     pub(crate) buffer: T,
     _p: PhantomPinned,
 }
 
 impl<T: IoBuf> Send<T> {
     /// Create [`Send`].
-    pub fn new(fd: RawFd, buffer: T) -> Self {
+    pub fn new(fd: SharedFd, buffer: T) -> Self {
         Self {
             fd,
             buffer,
@@ -344,7 +344,7 @@ impl<T: IoBuf> IntoInner for Send<T> {
 
 /// Send data to remote from vectored buffer.
 pub struct SendVectored<T: IoVectoredBuf> {
-    pub(crate) fd: RawFd,
+    pub(crate) fd: SharedFd,
     pub(crate) buffer: T,
     pub(crate) slices: Vec<IoSlice>,
     _p: PhantomPinned,
@@ -352,7 +352,7 @@ pub struct SendVectored<T: IoVectoredBuf> {
 
 impl<T: IoVectoredBuf> SendVectored<T> {
     /// Create [`SendVectored`].
-    pub fn new(fd: RawFd, buffer: T) -> Self {
+    pub fn new(fd: SharedFd, buffer: T) -> Self {
         Self {
             fd,
             buffer,

--- a/compio-driver/tests/file.rs
+++ b/compio-driver/tests/file.rs
@@ -3,39 +3,45 @@ use std::{io, time::Duration};
 use compio_buf::{arrayvec::ArrayVec, BufResult};
 use compio_driver::{
     op::{Asyncify, CloseFile, ReadAt},
-    OpCode, Proactor, PushEntry, RawFd,
+    AsRawFd, OpCode, OwnedFd, Proactor, PushEntry, SharedFd,
 };
 
 #[cfg(windows)]
-fn open_file_op() -> impl OpCode {
-    use std::os::windows::fs::OpenOptionsExt;
+fn open_file(driver: &mut Proactor) -> OwnedFd {
+    use std::os::windows::{
+        fs::OpenOptionsExt,
+        io::{FromRawHandle, IntoRawHandle, OwnedHandle},
+    };
 
-    use compio_driver::IntoRawFd;
     use windows_sys::Win32::Storage::FileSystem::FILE_FLAG_OVERLAPPED;
 
-    Asyncify::new(|| {
+    let op = Asyncify::new(|| {
         BufResult(
             std::fs::OpenOptions::new()
                 .read(true)
                 .attributes(FILE_FLAG_OVERLAPPED)
                 .open("Cargo.toml")
-                .map(|f| f.into_raw_fd() as usize),
+                .map(|f| f.into_raw_handle() as usize),
             (),
         )
-    })
+    });
+    let (fd, _) = push_and_wait(driver, op).unwrap();
+    OwnedFd::File(unsafe { OwnedHandle::from_raw_handle(fd as _) })
 }
 
 #[cfg(unix)]
-fn open_file_op() -> impl OpCode {
-    use std::ffi::CString;
+fn open_file(driver: &mut Proactor) -> OwnedFd {
+    use std::{ffi::CString, os::fd::io::FromRawFd};
 
     use compio_driver::op::OpenFile;
 
-    OpenFile::new(
+    let op = OpenFile::new(
         CString::new("Cargo.toml").unwrap(),
         libc::O_CLOEXEC | libc::O_RDONLY,
         0o666,
-    )
+    );
+    let (fd, _) = push_and_wait(driver, op).unwrap();
+    unsafe { OwnedFd::from_raw_fd(fd) }
 }
 
 fn push_and_wait<O: OpCode + 'static>(driver: &mut Proactor, op: O) -> BufResult<usize, O> {
@@ -56,19 +62,18 @@ fn push_and_wait<O: OpCode + 'static>(driver: &mut Proactor, op: O) -> BufResult
 fn cancel_before_poll() {
     let mut driver = Proactor::new().unwrap();
 
-    let op = open_file_op();
-    let (fd, _) = push_and_wait(&mut driver, op).unwrap();
-    let fd = fd as RawFd;
-    driver.attach(fd).unwrap();
+    let fd = open_file(&mut driver);
+    let fd = SharedFd::new(fd);
+    driver.attach(fd.as_raw_fd()).unwrap();
 
     driver.cancel(0);
 
-    let op = ReadAt::new(fd, 0, Vec::with_capacity(8));
+    let op = ReadAt::new(fd.clone(), 0, Vec::with_capacity(8));
     let BufResult(res, _) = push_and_wait(&mut driver, op);
 
     assert!(res.is_ok() || res.unwrap_err().kind() == io::ErrorKind::TimedOut);
 
-    let op = CloseFile::new(fd);
+    let op = CloseFile::new(fd.try_owned().unwrap());
     push_and_wait(&mut driver, op).unwrap();
 }
 
@@ -89,15 +94,14 @@ fn register_multiple() {
 
     let mut driver = Proactor::new().unwrap();
 
-    let op = open_file_op();
-    let (fd, _) = push_and_wait(&mut driver, op).unwrap();
-    let fd = fd as RawFd;
-    driver.attach(fd).unwrap();
+    let fd = open_file(&mut driver);
+    let fd = SharedFd::new(fd);
+    driver.attach(fd.as_raw_fd()).unwrap();
 
     let mut need_wait = 0;
 
     for _i in 0..TASK_LEN {
-        match driver.push(ReadAt::new(fd, 0, Vec::with_capacity(1024))) {
+        match driver.push(ReadAt::new(fd.clone(), 0, Vec::with_capacity(1024))) {
             PushEntry::Pending(_) => need_wait += 1,
             PushEntry::Ready(res) => {
                 res.unwrap();
@@ -110,7 +114,12 @@ fn register_multiple() {
         driver.poll(None, &mut entries).unwrap();
     }
 
-    let op = CloseFile::new(fd);
+    // Cancel the entries to drop the ops, and decrease the ref count of fd.
+    for entry in entries {
+        driver.cancel(entry);
+    }
+
+    let op = CloseFile::new(fd.try_owned().unwrap());
     push_and_wait(&mut driver, op).unwrap();
 }
 

--- a/compio-driver/tests/file.rs
+++ b/compio-driver/tests/file.rs
@@ -73,7 +73,7 @@ fn cancel_before_poll() {
 
     assert!(res.is_ok() || res.unwrap_err().kind() == io::ErrorKind::TimedOut);
 
-    let op = CloseFile::new(fd.try_owned().unwrap());
+    let op = CloseFile::new(fd.try_unwrap().unwrap());
     push_and_wait(&mut driver, op).unwrap();
 }
 
@@ -119,7 +119,7 @@ fn register_multiple() {
         driver.cancel(entry);
     }
 
-    let op = CloseFile::new(fd.try_owned().unwrap());
+    let op = CloseFile::new(fd.try_unwrap().unwrap());
     push_and_wait(&mut driver, op).unwrap();
 }
 

--- a/compio-driver/tests/file.rs
+++ b/compio-driver/tests/file.rs
@@ -31,7 +31,7 @@ fn open_file(driver: &mut Proactor) -> OwnedFd {
 
 #[cfg(unix)]
 fn open_file(driver: &mut Proactor) -> OwnedFd {
-    use std::{ffi::CString, os::fd::io::FromRawFd};
+    use std::{ffi::CString, os::fd::FromRawFd};
 
     use compio_driver::op::OpenFile;
 
@@ -41,7 +41,7 @@ fn open_file(driver: &mut Proactor) -> OwnedFd {
         0o666,
     );
     let (fd, _) = push_and_wait(driver, op).unwrap();
-    unsafe { OwnedFd::from_raw_fd(fd) }
+    unsafe { OwnedFd::from_raw_fd(fd as _) }
 }
 
 fn push_and_wait<O: OpCode + 'static>(driver: &mut Proactor, op: O) -> BufResult<usize, O> {

--- a/compio-fs/src/file.rs
+++ b/compio-fs/src/file.rs
@@ -214,4 +214,4 @@ impl AsyncWriteAt for &File {
     }
 }
 
-impl_raw_fd!(File, inner);
+impl_raw_fd!(File, inner, file);

--- a/compio-fs/src/named_pipe.rs
+++ b/compio-fs/src/named_pipe.rs
@@ -974,7 +974,7 @@ impl ServerOptions {
         )?;
 
         Ok(NamedPipeServer {
-            handle: File::new(unsafe { std::fs::File::from_raw_handle(h as _) })?,
+            handle: File::from_std(unsafe { std::fs::File::from_raw_handle(h as _) })?,
         })
     }
 }

--- a/compio-fs/src/named_pipe.rs
+++ b/compio-fs/src/named_pipe.rs
@@ -229,7 +229,7 @@ impl AsyncWrite for &NamedPipeServer {
     }
 }
 
-impl_raw_fd!(NamedPipeServer, handle);
+impl_raw_fd!(NamedPipeServer, handle, file);
 
 /// A [Windows named pipe] client.
 ///
@@ -350,7 +350,7 @@ impl AsyncWrite for &NamedPipeClient {
     }
 }
 
-impl_raw_fd!(NamedPipeClient, handle);
+impl_raw_fd!(NamedPipeClient, handle, file);
 
 /// A builder structure for construct a named pipe with named pipe-specific
 /// options. This is required to use for named pipe servers who wants to modify

--- a/compio-fs/src/named_pipe.rs
+++ b/compio-fs/src/named_pipe.rs
@@ -4,12 +4,12 @@
 
 #[cfg(doc)]
 use std::ptr::null_mut;
-use std::{ffi::OsStr, io, ptr::null};
+use std::{ffi::OsStr, io, os::windows::io::FromRawHandle, ptr::null};
 
 use compio_buf::{BufResult, IoBuf, IoBufMut};
-use compio_driver::{impl_raw_fd, op::ConnectNamedPipe, syscall, AsRawFd, FromRawFd, RawFd};
+use compio_driver::{impl_raw_fd, op::ConnectNamedPipe, syscall, AsRawFd, RawFd, ToSharedFd};
 use compio_io::{AsyncRead, AsyncReadAt, AsyncWrite, AsyncWriteAt};
-use compio_runtime::{impl_try_clone, Runtime};
+use compio_runtime::Runtime;
 use widestring::U16CString;
 use windows_sys::Win32::{
     Storage::FileSystem::{
@@ -86,7 +86,7 @@ use crate::{File, OpenOptions};
 /// ```
 ///
 /// [Windows named pipe]: https://docs.microsoft.com/en-us/windows/win32/ipc/named-pipes
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct NamedPipeServer {
     handle: File,
 }
@@ -141,7 +141,7 @@ impl NamedPipeServer {
     /// # std::io::Result::Ok(()) });
     /// ```
     pub async fn connect(&self) -> io::Result<()> {
-        let op = ConnectNamedPipe::new(self.handle.as_raw_fd());
+        let op = ConnectNamedPipe::new(self.handle.to_shared_fd());
         Runtime::current().submit(op).await.0?;
         Ok(())
     }
@@ -231,8 +231,6 @@ impl AsyncWrite for &NamedPipeServer {
 
 impl_raw_fd!(NamedPipeServer, handle);
 
-impl_try_clone!(NamedPipeServer, handle);
-
 /// A [Windows named pipe] client.
 ///
 /// Constructed using [`ClientOptions::open`].
@@ -272,7 +270,7 @@ impl_try_clone!(NamedPipeServer, handle);
 ///
 /// [`ERROR_PIPE_BUSY`]: https://docs.rs/windows-sys/latest/windows_sys/Win32/Foundation/constant.ERROR_PIPE_BUSY.html
 /// [Windows named pipe]: https://docs.microsoft.com/en-us/windows/win32/ipc/named-pipes
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct NamedPipeClient {
     handle: File,
 }
@@ -353,8 +351,6 @@ impl AsyncWrite for &NamedPipeClient {
 }
 
 impl_raw_fd!(NamedPipeClient, handle);
-
-impl_try_clone!(NamedPipeClient, handle);
 
 /// A builder structure for construct a named pipe with named pipe-specific
 /// options. This is required to use for named pipe servers who wants to modify
@@ -978,7 +974,7 @@ impl ServerOptions {
         )?;
 
         Ok(NamedPipeServer {
-            handle: File::new(unsafe { std::fs::File::from_raw_fd(h as _) })?,
+            handle: File::new(unsafe { std::fs::File::from_raw_handle(h as _) })?,
         })
     }
 }

--- a/compio-fs/src/open_options/unix.rs
+++ b/compio-fs/src/open_options/unix.rs
@@ -1,6 +1,6 @@
-use std::{io, path::Path};
+use std::{io, os::fd::FromRawFd, path::Path};
 
-use compio_driver::{op::OpenFile, FromRawFd, RawFd};
+use compio_driver::{op::OpenFile, RawFd};
 use compio_runtime::Runtime;
 
 use crate::{path_string, File};
@@ -88,6 +88,6 @@ impl OpenOptions {
         let p = path_string(p)?;
         let op = OpenFile::new(p, flags, self.mode);
         let fd = Runtime::current().submit(op).await.0? as RawFd;
-        File::new(unsafe { std::fs::File::from_raw_fd(fd) })
+        File::from_std(unsafe { std::fs::File::from_raw_fd(fd) })
     }
 }

--- a/compio-fs/src/open_options/windows.rs
+++ b/compio-fs/src/open_options/windows.rs
@@ -63,6 +63,6 @@ impl OpenOptions {
         let file = compio_runtime::spawn_blocking(move || opt.open(p))
             .await
             .unwrap_or_else(|e| resume_unwind(e))?;
-        File::new(file)
+        File::from_std(file)
     }
 }

--- a/compio-fs/src/pipe.rs
+++ b/compio-fs/src/pipe.rs
@@ -326,7 +326,7 @@ enum PipeEnd {
 /// ```
 ///
 /// [`ENXIO`]: https://docs.rs/libc/latest/libc/constant.ENXIO.html
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Sender {
     file: File,
 }
@@ -469,7 +469,7 @@ impl FromRawFd for Sender {
 /// ```
 ///
 /// [`read_to_end`]: compio_io::AsyncReadExt::read_to_end
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Receiver {
     file: File,
 }

--- a/compio-fs/src/pipe.rs
+++ b/compio-fs/src/pipe.rs
@@ -1,15 +1,20 @@
 //! Unix pipe types.
 
-use std::{future::Future, io, path::Path};
+use std::{
+    future::Future,
+    io,
+    os::fd::{FromRawFd, IntoRawFd},
+    path::Path,
+};
 
 use compio_buf::{BufResult, IntoInner, IoBuf, IoBufMut, IoVectoredBuf, IoVectoredBufMut};
 use compio_driver::{
     impl_raw_fd,
     op::{BufResultExt, Recv, RecvVectored, Send, SendVectored},
-    syscall, AsRawFd, FromRawFd, IntoRawFd,
+    syscall, AsRawFd, RawFd, ToSharedFd,
 };
 use compio_io::{AsyncRead, AsyncWrite};
-use compio_runtime::{impl_try_clone, Runtime};
+use compio_runtime::Runtime;
 
 use crate::File;
 
@@ -29,8 +34,12 @@ use crate::File;
 /// ```
 pub fn anonymous() -> io::Result<(Receiver, Sender)> {
     let (receiver, sender) = os_pipe::pipe()?;
-    let receiver = Receiver::from_file(unsafe { File::from_raw_fd(receiver.into_raw_fd()) })?;
-    let sender = Sender::from_file(unsafe { File::from_raw_fd(sender.into_raw_fd()) })?;
+    let receiver = Receiver::from_file(File::from_std(unsafe {
+        std::fs::File::from_raw_fd(receiver.into_raw_fd())
+    })?)?;
+    let sender = Sender::from_file(File::from_std(unsafe {
+        std::fs::File::from_raw_fd(sender.into_raw_fd())
+    })?)?;
     Ok((receiver, sender))
 }
 
@@ -359,13 +368,13 @@ impl AsyncWrite for Sender {
 
 impl AsyncWrite for &Sender {
     async fn write<T: IoBuf>(&mut self, buffer: T) -> BufResult<usize, T> {
-        let fd = self.as_raw_fd();
+        let fd = self.to_shared_fd();
         let op = Send::new(fd, buffer);
         Runtime::current().submit(op).await.into_inner()
     }
 
     async fn write_vectored<T: IoVectoredBuf>(&mut self, buffer: T) -> BufResult<usize, T> {
-        let fd = self.as_raw_fd();
+        let fd = self.to_shared_fd();
         let op = SendVectored::new(fd, buffer);
         Runtime::current().submit(op).await.into_inner()
     }
@@ -383,7 +392,13 @@ impl AsyncWrite for &Sender {
 
 impl_raw_fd!(Sender, file);
 
-impl_try_clone!(Sender, file);
+impl FromRawFd for Sender {
+    unsafe fn from_raw_fd(fd: RawFd) -> Self {
+        Self {
+            file: File::from_std(std::fs::File::from_raw_fd(fd)).expect("attach should be Ok"),
+        }
+    }
+}
 
 /// Reading end of a Unix pipe.
 ///
@@ -484,7 +499,7 @@ impl AsyncRead for Receiver {
 
 impl AsyncRead for &Receiver {
     async fn read<B: IoBufMut>(&mut self, buffer: B) -> BufResult<usize, B> {
-        let fd = self.as_raw_fd();
+        let fd = self.to_shared_fd();
         let op = Recv::new(fd, buffer);
         Runtime::current()
             .submit(op)
@@ -494,7 +509,7 @@ impl AsyncRead for &Receiver {
     }
 
     async fn read_vectored<V: IoVectoredBufMut>(&mut self, buffer: V) -> BufResult<usize, V> {
-        let fd = self.as_raw_fd();
+        let fd = self.to_shared_fd();
         let op = RecvVectored::new(fd, buffer);
         Runtime::current()
             .submit(op)
@@ -506,7 +521,13 @@ impl AsyncRead for &Receiver {
 
 impl_raw_fd!(Receiver, file);
 
-impl_try_clone!(Receiver, file);
+impl FromRawFd for Receiver {
+    unsafe fn from_raw_fd(fd: RawFd) -> Self {
+        Self {
+            file: File::from_std(std::fs::File::from_raw_fd(fd)).expect("attach should be Ok"),
+        }
+    }
+}
 
 /// Checks if file is a FIFO
 async fn is_fifo(file: &File) -> io::Result<bool> {

--- a/compio-fs/src/pipe.rs
+++ b/compio-fs/src/pipe.rs
@@ -11,7 +11,7 @@ use compio_buf::{BufResult, IntoInner, IoBuf, IoBufMut, IoVectoredBuf, IoVectore
 use compio_driver::{
     impl_raw_fd,
     op::{BufResultExt, Recv, RecvVectored, Send, SendVectored},
-    syscall, AsRawFd, RawFd, ToSharedFd,
+    syscall, AsRawFd, ToSharedFd,
 };
 use compio_io::{AsyncRead, AsyncWrite};
 use compio_runtime::Runtime;
@@ -390,15 +390,7 @@ impl AsyncWrite for &Sender {
     }
 }
 
-impl_raw_fd!(Sender, file);
-
-impl FromRawFd for Sender {
-    unsafe fn from_raw_fd(fd: RawFd) -> Self {
-        Self {
-            file: File::from_std(std::fs::File::from_raw_fd(fd)).expect("attach should be Ok"),
-        }
-    }
-}
+impl_raw_fd!(Sender, file, file);
 
 /// Reading end of a Unix pipe.
 ///
@@ -519,15 +511,7 @@ impl AsyncRead for &Receiver {
     }
 }
 
-impl_raw_fd!(Receiver, file);
-
-impl FromRawFd for Receiver {
-    unsafe fn from_raw_fd(fd: RawFd) -> Self {
-        Self {
-            file: File::from_std(std::fs::File::from_raw_fd(fd)).expect("attach should be Ok"),
-        }
-    }
-}
+impl_raw_fd!(Receiver, file, file);
 
 /// Checks if file is a FIFO
 async fn is_fifo(file: &File) -> io::Result<bool> {

--- a/compio-fs/src/stdio/unix.rs
+++ b/compio-fs/src/stdio/unix.rs
@@ -11,6 +11,7 @@ use crate::pipe::{Receiver, Sender};
 /// A handle to the standard input stream of a process.
 ///
 /// See [`stdin`].
+#[derive(Debug, Clone)]
 pub struct Stdin(ManuallyDrop<Receiver>);
 
 impl Stdin {
@@ -41,6 +42,7 @@ impl AsRawFd for Stdin {
 /// A handle to the standard output stream of a process.
 ///
 /// See [`stdout`].
+#[derive(Debug, Clone)]
 pub struct Stdout(ManuallyDrop<Sender>);
 
 impl Stdout {
@@ -79,6 +81,7 @@ impl AsRawFd for Stdout {
 /// A handle to the standard output stream of a process.
 ///
 /// See [`stderr`].
+#[derive(Debug, Clone)]
 pub struct Stderr(ManuallyDrop<Sender>);
 
 impl Stderr {

--- a/compio-fs/src/stdio/unix.rs
+++ b/compio-fs/src/stdio/unix.rs
@@ -1,7 +1,7 @@
-use std::{io, mem::ManuallyDrop};
+use std::{io, mem::ManuallyDrop, os::fd::FromRawFd};
 
 use compio_buf::{BufResult, IoBuf, IoBufMut, IoVectoredBuf, IoVectoredBufMut};
-use compio_driver::{AsRawFd, FromRawFd, RawFd};
+use compio_driver::{AsRawFd, RawFd};
 use compio_io::{AsyncRead, AsyncWrite};
 
 #[cfg(doc)]

--- a/compio-net/src/socket.rs
+++ b/compio-net/src/socket.rs
@@ -9,29 +9,35 @@ use compio_driver::{
         Accept, BufResultExt, CloseSocket, Connect, Recv, RecvFrom, RecvFromVectored,
         RecvResultExt, RecvVectored, Send, SendTo, SendToVectored, SendVectored, ShutdownSocket,
     },
-    AsRawFd,
+    SharedFd, ToSharedFd,
 };
-use compio_runtime::{impl_try_clone, Attacher, Runtime};
+use compio_runtime::{Attacher, Runtime};
 use socket2::{Domain, Protocol, SockAddr, Socket as Socket2, Type};
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Socket {
-    socket: Attacher<Socket2>,
+    socket: Attacher<SharedFd>,
 }
 
 impl Socket {
+    pub(crate) fn from_shared_fd(fd: SharedFd) -> io::Result<Self> {
+        Ok(Self {
+            socket: Attacher::new(fd)?,
+        })
+    }
+
     pub fn from_socket2(socket: Socket2) -> io::Result<Self> {
         Ok(Self {
-            socket: Attacher::new(socket)?,
+            socket: Attacher::new(SharedFd::new(socket))?,
         })
     }
 
     pub fn peer_addr(&self) -> io::Result<SockAddr> {
-        self.socket.peer_addr()
+        unsafe { self.socket.to_socket() }.peer_addr()
     }
 
     pub fn local_addr(&self) -> io::Result<SockAddr> {
-        self.socket.local_addr()
+        unsafe { self.socket.to_socket() }.local_addr()
     }
 
     #[cfg(windows)]
@@ -109,20 +115,20 @@ impl Socket {
 
     pub async fn bind(addr: &SockAddr, ty: Type, protocol: Option<Protocol>) -> io::Result<Self> {
         let socket = Self::new(addr.domain(), ty, protocol).await?;
-        socket.socket.bind(addr)?;
+        unsafe { socket.socket.to_socket() }.bind(addr)?;
         Ok(socket)
     }
 
     pub fn listen(&self, backlog: i32) -> io::Result<()> {
-        self.socket.listen(backlog)
+        unsafe { self.socket.to_socket() }.listen(backlog)
     }
 
     pub fn connect(&self, addr: &SockAddr) -> io::Result<()> {
-        self.socket.connect(addr)
+        unsafe { self.socket.to_socket() }.connect(addr)
     }
 
     pub async fn connect_async(&self, addr: &SockAddr) -> io::Result<()> {
-        let op = Connect::new(self.as_raw_fd(), addr.clone());
+        let op = Connect::new(self.to_shared_fd(), addr.clone());
         let BufResult(res, _op) = Runtime::current().submit(op).await;
         #[cfg(windows)]
         {
@@ -157,10 +163,12 @@ impl Socket {
     #[cfg(windows)]
     pub async fn accept(&self) -> io::Result<(Self, SockAddr)> {
         let domain = self.local_addr()?.domain();
-        let ty = self.socket.r#type()?;
-        let protocol = self.socket.protocol()?;
+        // We should allow users sending this accepted socket to a new thread.
+        let this_socket = unsafe { self.socket.to_socket() };
+        let ty = this_socket.r#type()?;
+        let protocol = this_socket.protocol()?;
         let accept_sock = Self::new(domain, ty, protocol).await?;
-        let op = Accept::new(self.as_raw_fd(), accept_sock.as_raw_fd() as _);
+        let op = Accept::new(self.to_shared_fd(), accept_sock.to_shared_fd());
         let BufResult(res, op) = Runtime::current().submit(op).await;
         res?;
         op.update_context()?;
@@ -174,20 +182,27 @@ impl Socket {
         // `close` should be cancelled.
         let this = ManuallyDrop::new(self);
         async move {
-            let op = CloseSocket::new(this.as_raw_fd());
-            Runtime::current().submit(op).await.0?;
+            let fd = ManuallyDrop::into_inner(this)
+                .socket
+                .into_inner()
+                .take()
+                .await;
+            if let Some(fd) = fd {
+                let op = CloseSocket::new(fd);
+                Runtime::current().submit(op).await.0?;
+            }
             Ok(())
         }
     }
 
     pub async fn shutdown(&self) -> io::Result<()> {
-        let op = ShutdownSocket::new(self.as_raw_fd(), std::net::Shutdown::Write);
+        let op = ShutdownSocket::new(self.to_shared_fd(), std::net::Shutdown::Write);
         Runtime::current().submit(op).await.0?;
         Ok(())
     }
 
     pub async fn recv<B: IoBufMut>(&self, buffer: B) -> BufResult<usize, B> {
-        let fd = self.as_raw_fd();
+        let fd = self.to_shared_fd();
         let op = Recv::new(fd, buffer);
         Runtime::current()
             .submit(op)
@@ -197,7 +212,7 @@ impl Socket {
     }
 
     pub async fn recv_vectored<V: IoVectoredBufMut>(&self, buffer: V) -> BufResult<usize, V> {
-        let fd = self.as_raw_fd();
+        let fd = self.to_shared_fd();
         let op = RecvVectored::new(fd, buffer);
         Runtime::current()
             .submit(op)
@@ -207,19 +222,19 @@ impl Socket {
     }
 
     pub async fn send<T: IoBuf>(&self, buffer: T) -> BufResult<usize, T> {
-        let fd = self.as_raw_fd();
+        let fd = self.to_shared_fd();
         let op = Send::new(fd, buffer);
         Runtime::current().submit(op).await.into_inner()
     }
 
     pub async fn send_vectored<T: IoVectoredBuf>(&self, buffer: T) -> BufResult<usize, T> {
-        let fd = self.as_raw_fd();
+        let fd = self.to_shared_fd();
         let op = SendVectored::new(fd, buffer);
         Runtime::current().submit(op).await.into_inner()
     }
 
     pub async fn recv_from<T: IoBufMut>(&self, buffer: T) -> BufResult<(usize, SockAddr), T> {
-        let fd = self.as_raw_fd();
+        let fd = self.to_shared_fd();
         let op = RecvFrom::new(fd, buffer);
         Runtime::current()
             .submit(op)
@@ -233,7 +248,7 @@ impl Socket {
         &self,
         buffer: T,
     ) -> BufResult<(usize, SockAddr), T> {
-        let fd = self.as_raw_fd();
+        let fd = self.to_shared_fd();
         let op = RecvFromVectored::new(fd, buffer);
         Runtime::current()
             .submit(op)
@@ -244,7 +259,7 @@ impl Socket {
     }
 
     pub async fn send_to<T: IoBuf>(&self, buffer: T, addr: &SockAddr) -> BufResult<usize, T> {
-        let fd = self.as_raw_fd();
+        let fd = self.to_shared_fd();
         let op = SendTo::new(fd, buffer, addr.clone());
         Runtime::current().submit(op).await.into_inner()
     }
@@ -254,12 +269,10 @@ impl Socket {
         buffer: T,
         addr: &SockAddr,
     ) -> BufResult<usize, T> {
-        let fd = self.as_raw_fd();
+        let fd = self.to_shared_fd();
         let op = SendToVectored::new(fd, buffer, addr.clone());
         Runtime::current().submit(op).await.into_inner()
     }
 }
 
 impl_raw_fd!(Socket, socket);
-
-impl_try_clone!(Socket, socket);

--- a/compio-net/src/socket.rs
+++ b/compio-net/src/socket.rs
@@ -274,4 +274,4 @@ impl Socket {
     }
 }
 
-impl_raw_fd!(Socket, socket);
+impl_raw_fd!(Socket, socket, socket);

--- a/compio-net/src/tcp.rs
+++ b/compio-net/src/tcp.rs
@@ -109,7 +109,7 @@ impl TcpListener {
     }
 }
 
-impl_raw_fd!(TcpListener, inner);
+impl_raw_fd!(TcpListener, inner, socket);
 
 /// A TCP stream between a local and a remote socket.
 ///
@@ -273,4 +273,4 @@ impl AsyncWrite for &TcpStream {
     }
 }
 
-impl_raw_fd!(TcpStream, inner);
+impl_raw_fd!(TcpStream, inner, socket);

--- a/compio-net/src/tcp.rs
+++ b/compio-net/src/tcp.rs
@@ -3,7 +3,6 @@ use std::{future::Future, io, net::SocketAddr};
 use compio_buf::{BufResult, IoBuf, IoBufMut, IoVectoredBuf, IoVectoredBufMut};
 use compio_driver::impl_raw_fd;
 use compio_io::{AsyncRead, AsyncWrite};
-use compio_runtime::impl_try_clone;
 use socket2::{Protocol, SockAddr, Type};
 
 use crate::{OwnedReadHalf, OwnedWriteHalf, ReadHalf, Socket, ToSocketAddrsAsync, WriteHalf};
@@ -40,7 +39,7 @@ use crate::{OwnedReadHalf, OwnedWriteHalf, ReadHalf, Socket, ToSocketAddrsAsync,
 /// assert_eq!(buf, b"test");
 /// # });
 /// ```
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct TcpListener {
     inner: Socket,
 }
@@ -112,8 +111,6 @@ impl TcpListener {
 
 impl_raw_fd!(TcpListener, inner);
 
-impl_try_clone!(TcpListener, inner);
-
 /// A TCP stream between a local and a remote socket.
 ///
 /// A TCP stream can either be created by connecting to an endpoint, via the
@@ -135,7 +132,7 @@ impl_try_clone!(TcpListener, inner);
 /// stream.write("hello world!").await.unwrap();
 /// # })
 /// ```
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct TcpStream {
     inner: Socket,
 }
@@ -277,5 +274,3 @@ impl AsyncWrite for &TcpStream {
 }
 
 impl_raw_fd!(TcpStream, inner);
-
-impl_try_clone!(TcpStream, inner);

--- a/compio-net/src/udp.rs
+++ b/compio-net/src/udp.rs
@@ -251,4 +251,4 @@ impl UdpSocket {
     }
 }
 
-impl_raw_fd!(UdpSocket, inner);
+impl_raw_fd!(UdpSocket, inner, socket);

--- a/compio-net/src/udp.rs
+++ b/compio-net/src/udp.rs
@@ -2,7 +2,6 @@ use std::{future::Future, io, net::SocketAddr};
 
 use compio_buf::{BufResult, IoBuf, IoBufMut, IoVectoredBuf, IoVectoredBufMut};
 use compio_driver::impl_raw_fd;
-use compio_runtime::impl_try_clone;
 use socket2::{Protocol, SockAddr, Type};
 
 use crate::{Socket, ToSocketAddrsAsync};
@@ -86,7 +85,7 @@ use crate::{Socket, ToSocketAddrsAsync};
 /// assert_eq!(buf, b"hello world");
 /// # });
 /// ```
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct UdpSocket {
     inner: Socket,
 }
@@ -253,5 +252,3 @@ impl UdpSocket {
 }
 
 impl_raw_fd!(UdpSocket, inner);
-
-impl_try_clone!(UdpSocket, inner);

--- a/compio-net/src/unix.rs
+++ b/compio-net/src/unix.rs
@@ -87,7 +87,7 @@ impl UnixListener {
     }
 }
 
-impl_raw_fd!(UnixListener, inner);
+impl_raw_fd!(UnixListener, inner, socket);
 
 /// A Unix stream between two local sockets on Windows & WSL.
 ///
@@ -257,7 +257,7 @@ impl AsyncWrite for &UnixStream {
     }
 }
 
-impl_raw_fd!(UnixStream, inner);
+impl_raw_fd!(UnixStream, inner, socket);
 
 #[cfg(windows)]
 #[inline]

--- a/compio-net/src/unix.rs
+++ b/compio-net/src/unix.rs
@@ -3,7 +3,6 @@ use std::{future::Future, io, path::Path};
 use compio_buf::{BufResult, IoBuf, IoBufMut, IoVectoredBuf, IoVectoredBufMut};
 use compio_driver::impl_raw_fd;
 use compio_io::{AsyncRead, AsyncWrite};
-use compio_runtime::impl_try_clone;
 use socket2::{SockAddr, Type};
 
 use crate::{OwnedReadHalf, OwnedWriteHalf, ReadHalf, Socket, WriteHalf};
@@ -36,7 +35,7 @@ use crate::{OwnedReadHalf, OwnedWriteHalf, ReadHalf, Socket, WriteHalf};
 /// assert_eq!(buf, b"test");
 /// # });
 /// ```
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct UnixListener {
     inner: Socket,
 }
@@ -90,8 +89,6 @@ impl UnixListener {
 
 impl_raw_fd!(UnixListener, inner);
 
-impl_try_clone!(UnixListener, inner);
-
 /// A Unix stream between two local sockets on Windows & WSL.
 ///
 /// A Unix stream can either be created by connecting to an endpoint, via the
@@ -111,7 +108,7 @@ impl_try_clone!(UnixListener, inner);
 /// stream.write("hello world!").await.unwrap();
 /// # })
 /// ```
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct UnixStream {
     inner: Socket,
 }
@@ -305,5 +302,3 @@ fn fix_unix_socket_length(addr: &mut SockAddr) {
         addr.set_length(addr_len as _);
     }
 }
-
-impl_try_clone!(UnixStream, inner);

--- a/compio-runtime/Cargo.toml
+++ b/compio-runtime/Cargo.toml
@@ -66,10 +66,6 @@ glib = "0.19"
 event = ["dep:cfg-if", "compio-buf/arrayvec"]
 time = ["dep:slab"]
 
-# Nightly features
-once_cell_try = []
-nightly = ["once_cell_try"]
-
 [[test]]
 name = "event"
 required-features = ["event"]

--- a/compio-runtime/src/attacher.rs
+++ b/compio-runtime/src/attacher.rs
@@ -1,3 +1,7 @@
+#[cfg(unix)]
+use std::os::fd::{FromRawFd, RawFd};
+#[cfg(windows)]
+use std::os::windows::io::{FromRawHandle, FromRawSocket, RawHandle, RawSocket};
 use std::{
     io,
     ops::{Deref, DerefMut},
@@ -49,6 +53,27 @@ impl<S> IntoInner for Attacher<S> {
 
     fn into_inner(self) -> Self::Inner {
         self.source
+    }
+}
+
+#[cfg(windows)]
+impl<S: FromRawHandle> FromRawHandle for Attacher<S> {
+    unsafe fn from_raw_handle(handle: RawHandle) -> Self {
+        Self::new_unchecked(S::from_raw_handle(handle))
+    }
+}
+
+#[cfg(windows)]
+impl<S: FromRawSocket> FromRawSocket for Attacher<S> {
+    unsafe fn from_raw_socket(sock: RawSocket) -> Self {
+        Self::new_unchecked(S::from_raw_socket(sock))
+    }
+}
+
+#[cfg(unix)]
+impl<S: FromRawFd> FromRawFd for Attacher<S> {
+    unsafe fn from_raw_fd(fd: RawFd) -> Self {
+        Self::new_unchecked(S::from_raw_fd(fd))
     }
 }
 

--- a/compio-runtime/src/lib.rs
+++ b/compio-runtime/src/lib.rs
@@ -8,7 +8,6 @@
 //! assert_eq!(ans, 42);
 //! ```
 
-#![cfg_attr(feature = "once_cell_try", feature(once_cell_try))]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 #![warn(missing_docs)]
 

--- a/compio-runtime/tests/event.rs
+++ b/compio-runtime/tests/event.rs
@@ -37,7 +37,7 @@ fn win32_event() {
 
     impl OpCode for WaitEvent {
         fn op_type(&self) -> OpType {
-            OpType::Event(self.event.as_raw_handle())
+            OpType::Event(self.event.as_raw_handle() as _)
         }
 
         unsafe fn operate(

--- a/compio/Cargo.toml
+++ b/compio/Cargo.toml
@@ -100,11 +100,7 @@ enable_log = ["compio-log/enable_log"]
 # Nightly features
 allocator_api = ["compio-buf/allocator_api", "compio-io?/allocator_api"]
 lazy_cell = ["compio-signal?/lazy_cell"]
-once_cell_try = [
-    "compio-driver/once_cell_try",
-    "compio-runtime?/once_cell_try",
-    "compio-signal?/once_cell_try",
-]
+once_cell_try = ["compio-driver/once_cell_try", "compio-signal?/once_cell_try"]
 read_buf = [
     "compio-buf/read_buf",
     "compio-io?/read_buf",

--- a/compio/examples/driver.rs
+++ b/compio/examples/driver.rs
@@ -32,7 +32,7 @@ fn open_file(driver: &mut Proactor) -> OwnedFd {
 
 #[cfg(unix)]
 fn open_file(driver: &mut Proactor) -> OwnedFd {
-    use std::{ffi::CString, os::fd::io::FromRawFd};
+    use std::{ffi::CString, os::fd::FromRawFd};
 
     use compio_driver::op::OpenFile;
 
@@ -42,7 +42,7 @@ fn open_file(driver: &mut Proactor) -> OwnedFd {
         0o666,
     );
     let (fd, _) = push_and_wait(driver, op);
-    unsafe { OwnedFd::from_raw_fd(fd) }
+    unsafe { OwnedFd::from_raw_fd(fd as _) }
 }
 
 fn push_and_wait<O: OpCode + 'static>(driver: &mut Proactor, op: O) -> (usize, O) {

--- a/compio/examples/driver.rs
+++ b/compio/examples/driver.rs
@@ -75,6 +75,6 @@ fn main() {
     }
     println!("{}", String::from_utf8(buffer).unwrap());
 
-    let op = CloseFile::new(fd.try_owned().unwrap());
+    let op = CloseFile::new(fd.try_unwrap().unwrap());
     push_and_wait(&mut driver, op);
 }

--- a/compio/examples/driver.rs
+++ b/compio/examples/driver.rs
@@ -2,43 +2,47 @@ use compio::{
     buf::{arrayvec::ArrayVec, IntoInner},
     driver::{
         op::{CloseFile, ReadAt},
-        OpCode, Proactor, PushEntry, RawFd,
+        AsRawFd, OpCode, OwnedFd, Proactor, PushEntry, SharedFd,
     },
 };
 
 #[cfg(windows)]
-fn open_file_op() -> impl OpCode {
-    use std::os::windows::fs::OpenOptionsExt;
-
-    use compio::{
-        driver::{op::Asyncify, IntoRawFd},
-        BufResult,
+fn open_file(driver: &mut Proactor) -> OwnedFd {
+    use std::os::windows::{
+        fs::OpenOptionsExt,
+        io::{FromRawHandle, IntoRawHandle, OwnedHandle},
     };
+
+    use compio::{driver::op::Asyncify, BufResult};
     use windows_sys::Win32::Storage::FileSystem::FILE_FLAG_OVERLAPPED;
 
-    Asyncify::new(|| {
+    let op = Asyncify::new(|| {
         BufResult(
             std::fs::OpenOptions::new()
                 .read(true)
                 .attributes(FILE_FLAG_OVERLAPPED)
                 .open("Cargo.toml")
-                .map(|f| f.into_raw_fd() as usize),
+                .map(|f| f.into_raw_handle() as usize),
             (),
         )
-    })
+    });
+    let (fd, _) = push_and_wait(driver, op);
+    OwnedFd::File(unsafe { OwnedHandle::from_raw_handle(fd as _) })
 }
 
 #[cfg(unix)]
-fn open_file_op() -> impl OpCode {
-    use std::ffi::CString;
+fn open_file(driver: &mut Proactor) -> OwnedFd {
+    use std::{ffi::CString, os::fd::io::FromRawFd};
 
-    use compio::driver::op::OpenFile;
+    use compio_driver::op::OpenFile;
 
-    OpenFile::new(
+    let op = OpenFile::new(
         CString::new("Cargo.toml").unwrap(),
         libc::O_CLOEXEC | libc::O_RDONLY,
         0o666,
-    )
+    );
+    let (fd, _) = push_and_wait(driver, op);
+    unsafe { OwnedFd::from_raw_fd(fd) }
 }
 
 fn push_and_wait<O: OpCode + 'static>(driver: &mut Proactor, op: O) -> (usize, O) {
@@ -58,13 +62,11 @@ fn push_and_wait<O: OpCode + 'static>(driver: &mut Proactor, op: O) -> (usize, O
 fn main() {
     let mut driver = Proactor::new().unwrap();
 
-    let op = open_file_op();
-    let (fd, _) = push_and_wait(&mut driver, op);
-    let fd = fd as RawFd;
+    let fd = open_file(&mut driver);
+    let fd = SharedFd::new(fd);
+    driver.attach(fd.as_raw_fd()).unwrap();
 
-    driver.attach(fd).unwrap();
-
-    let op = ReadAt::new(fd, 0, Vec::with_capacity(4096));
+    let op = ReadAt::new(fd.clone(), 0, Vec::with_capacity(4096));
     let (n, op) = push_and_wait(&mut driver, op);
 
     let mut buffer = op.into_inner();
@@ -73,6 +75,6 @@ fn main() {
     }
     println!("{}", String::from_utf8(buffer).unwrap());
 
-    let op = CloseFile::new(fd);
+    let op = CloseFile::new(fd.try_owned().unwrap());
     push_and_wait(&mut driver, op);
 }

--- a/compio/tests/runtime.rs
+++ b/compio/tests/runtime.rs
@@ -7,7 +7,6 @@ use compio::{
     fs::File,
     io::{AsyncReadAt, AsyncReadExt, AsyncWriteAt, AsyncWriteExt},
     net::{TcpListener, TcpStream},
-    runtime::TryClone,
 };
 use tempfile::NamedTempFile;
 
@@ -47,7 +46,7 @@ async fn try_clone() {
     let (tx, (mut rx, _)) =
         futures_util::try_join!(TcpStream::connect(&addr), listener.accept()).unwrap();
 
-    let mut tx = tx.try_clone().unwrap();
+    let mut tx = tx.clone();
     tx.write_all(DATA).await.0.unwrap();
 
     if let Err(e) = std::thread::spawn(move || {


### PR DESCRIPTION
Closes #229 

Most operations require `SharedFd`, while the close operations require `OwnedFd`. `SharedFd` provides some methods to get the inner `OwnedFd`.