### PR TITLE
fix(unix,iour): musl libc compatibility

### DIFF
--- a/compio-driver/src/iour/op.rs
+++ b/compio-driver/src/iour/op.rs
@@ -298,7 +298,6 @@ impl RecvFromHeader {
     }
 
     pub fn create_entry(&mut self, slices: &mut [IoSliceMut]) -> OpEntry {
-        self.msg = unsafe { std::mem::zeroed::<libc::msghdr>() };
         self.msg.msg_name = &mut self.addr as *mut _ as _;
         self.msg.msg_namelen = std::mem::size_of_val(&self.addr) as _;
         self.msg.msg_iov = slices.as_mut_ptr() as _;
@@ -402,7 +401,6 @@ impl SendToHeader {
     }
 
     pub fn create_entry(&mut self, slices: &mut [IoSlice]) -> OpEntry {
-        self.msg = unsafe { std::mem::zeroed::<libc::msghdr>() };
         self.msg.msg_name = self.addr.as_ptr() as _;
         self.msg.msg_namelen = self.addr.len();
         self.msg.msg_iov = slices.as_mut_ptr() as _;

--- a/compio-driver/src/iour/op.rs
+++ b/compio-driver/src/iour/op.rs
@@ -55,7 +55,7 @@ impl OpCode for CloseFile {
 /// Get metadata of an opened file.
 pub struct FileStat {
     pub(crate) fd: RawFd,
-    pub(crate) stat: libc::statx,
+    pub(crate) stat: Statx,
 }
 
 impl FileStat {
@@ -93,7 +93,7 @@ impl IntoInner for FileStat {
 /// Get metadata from path.
 pub struct PathStat {
     pub(crate) path: CString,
-    pub(crate) stat: libc::statx,
+    pub(crate) stat: Statx,
     pub(crate) follow_symlink: bool,
 }
 
@@ -298,15 +298,11 @@ impl RecvFromHeader {
     }
 
     pub fn create_entry(&mut self, slices: &mut [IoSliceMut]) -> OpEntry {
-        self.msg = libc::msghdr {
-            msg_name: &mut self.addr as *mut _ as _,
-            msg_namelen: std::mem::size_of_val(&self.addr) as _,
-            msg_iov: slices.as_mut_ptr() as _,
-            msg_iovlen: slices.len() as _,
-            msg_control: std::ptr::null_mut(),
-            msg_controllen: 0,
-            msg_flags: 0,
-        };
+        self.msg = unsafe { std::mem::zeroed::<libc::msghdr>() };
+        self.msg.msg_name = &mut self.addr as *mut _ as _;
+        self.msg.msg_namelen = std::mem::size_of_val(&self.addr) as _;
+        self.msg.msg_iov = slices.as_mut_ptr() as _;
+        self.msg.msg_iovlen = slices.len() as _;
         opcode::RecvMsg::new(Fd(self.fd), &mut self.msg)
             .build()
             .into()
@@ -406,15 +402,11 @@ impl SendToHeader {
     }
 
     pub fn create_entry(&mut self, slices: &mut [IoSlice]) -> OpEntry {
-        self.msg = libc::msghdr {
-            msg_name: self.addr.as_ptr() as _,
-            msg_namelen: self.addr.len(),
-            msg_iov: slices.as_mut_ptr() as _,
-            msg_iovlen: slices.len() as _,
-            msg_control: std::ptr::null_mut(),
-            msg_controllen: 0,
-            msg_flags: 0,
-        };
+        self.msg = unsafe { std::mem::zeroed::<libc::msghdr>() };
+        self.msg.msg_name = self.addr.as_ptr() as _;
+        self.msg.msg_namelen = self.addr.len();
+        self.msg.msg_iov = slices.as_mut_ptr() as _;
+        self.msg.msg_iovlen = slices.len() as _;
         opcode::SendMsg::new(Fd(self.fd), &self.msg).build().into()
     }
 }

--- a/compio-driver/src/unix/op.rs
+++ b/compio-driver/src/unix/op.rs
@@ -22,8 +22,51 @@ impl OpenFile {
     }
 }
 
+#[cfg(all(
+    any(target_os = "linux", target_os = "android"),
+    not(target_env = "musl")
+))]
+pub type Statx = libc::statx;
+
+#[cfg(all(any(target_os = "linux", target_os = "android"), target_env = "musl"))]
+#[repr(C)]
+pub struct StatxTimestamp {
+    pub tv_sec: i64,
+    pub tv_nsec: u32,
+    pub __statx_timestamp_pad1: [i32; 1],
+}
+
+#[cfg(all(any(target_os = "linux", target_os = "android"), target_env = "musl"))]
+#[repr(C)]
+pub struct Statx {
+    pub stx_mask: u32,
+    pub stx_blksize: u32,
+    pub stx_attributes: u64,
+    pub stx_nlink: u32,
+    pub stx_uid: u32,
+    pub stx_gid: u32,
+    pub stx_mode: u16,
+    __statx_pad1: [u16; 1],
+    pub stx_ino: u64,
+    pub stx_size: u64,
+    pub stx_blocks: u64,
+    pub stx_attributes_mask: u64,
+    pub stx_atime: StatxTimestamp,
+    pub stx_btime: StatxTimestamp,
+    pub stx_ctime: StatxTimestamp,
+    pub stx_mtime: StatxTimestamp,
+    pub stx_rdev_major: u32,
+    pub stx_rdev_minor: u32,
+    pub stx_dev_major: u32,
+    pub stx_dev_minor: u32,
+    pub stx_mnt_id: u64,
+    pub stx_dio_mem_align: u32,
+    pub stx_dio_offset_align: u32,
+    __statx_pad3: [u64; 12],
+}
+
 #[cfg(any(target_os = "linux", target_os = "android"))]
-pub(crate) const fn statx_to_stat(statx: libc::statx) -> libc::stat {
+pub(crate) const fn statx_to_stat(statx: Statx) -> libc::stat {
     let mut stat: libc::stat = unsafe { std::mem::zeroed() };
     stat.st_dev = libc::makedev(statx.stx_dev_major, statx.stx_dev_minor);
     stat.st_ino = statx.stx_ino;


### PR DESCRIPTION
The libc crate does not provide statx on musl, and msghdr contains private padding fields :(

See also: https://github.com/DataDog/glommio/pull/590

---

Interestingly I'm getting one test failure on my machine:

```
---- cancel_before_poll stdout ----
thread 'cancel_before_poll' panicked at compio-driver/tests/file.rs:72:24:
index out of bounds: the len is 0 but the index is 0
```