### PR TITLE
feat(poll): AIO support on FreeBSD

### DIFF
--- a/compio-driver/src/fusion/op.rs
+++ b/compio-driver/src/fusion/op.rs
@@ -72,9 +72,8 @@ macro_rules! op {
 
             fn on_event(
                 self: std::pin::Pin<&mut Self>,
-                event: &polling::Event,
             ) -> std::task::Poll<std::io::Result<usize>> {
-                unsafe { self.map_unchecked_mut(|x| x.inner.poll() ) }.on_event(event)
+                unsafe { self.map_unchecked_mut(|x| x.inner.poll() ) }.on_event()
             }
         }
 

--- a/compio-driver/src/op.rs
+++ b/compio-driver/src/op.rs
@@ -113,6 +113,8 @@ pub struct ReadAt<T: IoBufMut> {
     pub(crate) fd: RawFd,
     pub(crate) offset: u64,
     pub(crate) buffer: T,
+    #[cfg(target_os = "freebsd")]
+    pub(crate) aiocb: libc::aiocb,
     _p: PhantomPinned,
 }
 
@@ -123,6 +125,8 @@ impl<T: IoBufMut> ReadAt<T> {
             fd,
             offset,
             buffer,
+            #[cfg(target_os = "freebsd")]
+            aiocb: unsafe { std::mem::zeroed() },
             _p: PhantomPinned,
         }
     }
@@ -142,6 +146,8 @@ pub struct WriteAt<T: IoBuf> {
     pub(crate) fd: RawFd,
     pub(crate) offset: u64,
     pub(crate) buffer: T,
+    #[cfg(target_os = "freebsd")]
+    pub(crate) aiocb: libc::aiocb,
     _p: PhantomPinned,
 }
 
@@ -152,6 +158,8 @@ impl<T: IoBuf> WriteAt<T> {
             fd,
             offset,
             buffer,
+            #[cfg(target_os = "freebsd")]
+            aiocb: unsafe { std::mem::zeroed() },
             _p: PhantomPinned,
         }
     }
@@ -170,6 +178,8 @@ pub struct Sync {
     pub(crate) fd: RawFd,
     #[allow(dead_code)]
     pub(crate) datasync: bool,
+    #[cfg(target_os = "freebsd")]
+    pub(crate) aiocb: libc::aiocb,
 }
 
 impl Sync {
@@ -177,7 +187,12 @@ impl Sync {
     ///
     /// If `datasync` is `true`, the file metadata may not be synchronized.
     pub fn new(fd: RawFd, datasync: bool) -> Self {
-        Self { fd, datasync }
+        Self {
+            fd,
+            datasync,
+            #[cfg(target_os = "freebsd")]
+            aiocb: unsafe { std::mem::zeroed() },
+        }
     }
 }
 

--- a/compio-driver/src/unix/op.rs
+++ b/compio-driver/src/unix/op.rs
@@ -90,6 +90,8 @@ pub struct ReadVectoredAt<T: IoVectoredBufMut> {
     pub(crate) offset: u64,
     pub(crate) buffer: T,
     pub(crate) slices: Vec<IoSliceMut>,
+    #[cfg(target_os = "freebsd")]
+    pub(crate) aiocb: libc::aiocb,
     _p: PhantomPinned,
 }
 
@@ -101,6 +103,8 @@ impl<T: IoVectoredBufMut> ReadVectoredAt<T> {
             offset,
             buffer,
             slices: vec![],
+            #[cfg(target_os = "freebsd")]
+            aiocb: unsafe { std::mem::zeroed() },
             _p: PhantomPinned,
         }
     }
@@ -120,6 +124,8 @@ pub struct WriteVectoredAt<T: IoVectoredBuf> {
     pub(crate) offset: u64,
     pub(crate) buffer: T,
     pub(crate) slices: Vec<IoSlice>,
+    #[cfg(target_os = "freebsd")]
+    pub(crate) aiocb: libc::aiocb,
     _p: PhantomPinned,
 }
 
@@ -131,6 +137,8 @@ impl<T: IoVectoredBuf> WriteVectoredAt<T> {
             offset,
             buffer,
             slices: vec![],
+            #[cfg(target_os = "freebsd")]
+            aiocb: unsafe { std::mem::zeroed() },
             _p: PhantomPinned,
         }
     }

--- a/compio/tests/runtime.rs
+++ b/compio/tests/runtime.rs
@@ -131,7 +131,7 @@ async fn too_many_submissions() {
     let tempfile = tempfile();
 
     let mut file = File::create(tempfile.path()).await.unwrap();
-    for _ in 0..600 {
+    for _ in 0..100 {
         poll_once(async {
             file.write_at("hello world", 0).await.0.unwrap();
         })


### PR DESCRIPTION
We can use AIO on FreeBSD because it is able to notify kqueue.