### PR TITLE
refactor(driver): generic SharedFd

### DIFF
--- a/compio-driver/src/fd.rs
+++ b/compio-driver/src/fd.rs
@@ -1,12 +1,11 @@
 #[cfg(unix)]
 use std::os::fd::FromRawFd;
 #[cfg(windows)]
-use std::os::windows::io::{
-    FromRawHandle, FromRawSocket, OwnedHandle, OwnedSocket, RawHandle, RawSocket,
-};
+use std::os::windows::io::{FromRawHandle, FromRawSocket, RawHandle, RawSocket};
 use std::{
     future::{poll_fn, Future},
     mem::ManuallyDrop,
+    ops::Deref,
     panic::RefUnwindSafe,
     sync::{
         atomic::{AtomicBool, Ordering},
@@ -17,35 +16,35 @@ use std::{
 
 use futures_util::task::AtomicWaker;
 
-use crate::{AsRawFd, OwnedFd, RawFd};
+use crate::{AsRawFd, RawFd};
 
 #[derive(Debug)]
-struct Inner {
-    fd: OwnedFd,
+struct Inner<T> {
+    fd: T,
     // whether there is a future waiting
     waits: AtomicBool,
     waker: AtomicWaker,
 }
 
-impl RefUnwindSafe for Inner {}
+impl<T> RefUnwindSafe for Inner<T> {}
 
 /// A shared fd. It is passed to the operations to make sure the fd won't be
 /// closed before the operations complete.
-#[derive(Debug, Clone)]
-pub struct SharedFd(Arc<Inner>);
+#[derive(Debug)]
+pub struct SharedFd<T>(Arc<Inner<T>>);
 
-impl SharedFd {
+impl<T> SharedFd<T> {
     /// Create the shared fd from an owned fd.
-    pub fn new(fd: impl Into<OwnedFd>) -> Self {
+    pub fn new(fd: T) -> Self {
         Self(Arc::new(Inner {
-            fd: fd.into(),
+            fd,
             waits: AtomicBool::new(false),
             waker: AtomicWaker::new(),
         }))
     }
 
     /// Try to take the inner owned fd.
-    pub fn try_unwrap(self) -> Result<OwnedFd, Self> {
+    pub fn try_unwrap(self) -> Result<T, Self> {
         let this = ManuallyDrop::new(self);
         if let Some(fd) = unsafe { Self::try_unwrap_inner(&this) } {
             Ok(fd)
@@ -55,7 +54,7 @@ impl SharedFd {
     }
 
     // SAFETY: if `Some` is returned, the method should not be called again.
-    unsafe fn try_unwrap_inner(this: &ManuallyDrop<Self>) -> Option<OwnedFd> {
+    unsafe fn try_unwrap_inner(this: &ManuallyDrop<Self>) -> Option<T> {
         let ptr = ManuallyDrop::new(std::ptr::read(&this.0));
         // The ptr is duplicated without increasing the strong count, should forget.
         match Arc::try_unwrap(ManuallyDrop::into_inner(ptr)) {
@@ -68,7 +67,7 @@ impl SharedFd {
     }
 
     /// Wait and take the inner owned fd.
-    pub fn take(self) -> impl Future<Output = Option<OwnedFd>> {
+    pub fn take(self) -> impl Future<Output = Option<T>> {
         let this = ManuallyDrop::new(self);
         async move {
             if !this.0.waits.swap(true, Ordering::AcqRel) {
@@ -93,7 +92,7 @@ impl SharedFd {
     }
 }
 
-impl Drop for SharedFd {
+impl<T> Drop for SharedFd<T> {
     fn drop(&mut self) {
         // It's OK to wake multiple times.
         if Arc::strong_count(&self.0) == 2 {
@@ -102,71 +101,61 @@ impl Drop for SharedFd {
     }
 }
 
-#[cfg(windows)]
-#[doc(hidden)]
-impl SharedFd {
-    pub unsafe fn to_file(&self) -> ManuallyDrop<std::fs::File> {
-        ManuallyDrop::new(std::fs::File::from_raw_handle(self.as_raw_fd() as _))
-    }
-
-    pub unsafe fn to_socket(&self) -> ManuallyDrop<socket2::Socket> {
-        ManuallyDrop::new(socket2::Socket::from_raw_socket(self.as_raw_fd() as _))
-    }
-}
-
-#[cfg(unix)]
-#[doc(hidden)]
-impl SharedFd {
-    pub unsafe fn to_file(&self) -> ManuallyDrop<std::fs::File> {
-        ManuallyDrop::new(std::fs::File::from_raw_fd(self.as_raw_fd() as _))
-    }
-
-    pub unsafe fn to_socket(&self) -> ManuallyDrop<socket2::Socket> {
-        ManuallyDrop::new(socket2::Socket::from_raw_fd(self.as_raw_fd() as _))
-    }
-}
-
-impl AsRawFd for SharedFd {
+impl<T: AsRawFd> AsRawFd for SharedFd<T> {
     fn as_raw_fd(&self) -> RawFd {
         self.0.fd.as_raw_fd()
     }
 }
 
 #[cfg(windows)]
-impl FromRawHandle for SharedFd {
+impl<T: FromRawHandle> FromRawHandle for SharedFd<T> {
     unsafe fn from_raw_handle(handle: RawHandle) -> Self {
-        Self::new(OwnedFd::File(OwnedHandle::from_raw_handle(handle)))
+        Self::new(T::from_raw_handle(handle))
     }
 }
 
 #[cfg(windows)]
-impl FromRawSocket for SharedFd {
+impl<T: FromRawSocket> FromRawSocket for SharedFd<T> {
     unsafe fn from_raw_socket(sock: RawSocket) -> Self {
-        Self::new(OwnedFd::Socket(OwnedSocket::from_raw_socket(sock)))
+        Self::new(T::from_raw_socket(sock))
     }
 }
 
 #[cfg(unix)]
-impl FromRawFd for SharedFd {
+impl<T: FromRawFd> FromRawFd for SharedFd<T> {
     unsafe fn from_raw_fd(fd: RawFd) -> Self {
-        Self::new(OwnedFd::from_raw_fd(fd))
+        Self::new(T::from_raw_fd(fd))
     }
 }
 
-impl From<OwnedFd> for SharedFd {
-    fn from(value: OwnedFd) -> Self {
+impl<T> From<T> for SharedFd<T> {
+    fn from(value: T) -> Self {
         Self::new(value)
     }
 }
 
-/// Get a clone of [`SharedFd`].
-pub trait ToSharedFd {
-    /// Return a cloned [`SharedFd`].
-    fn to_shared_fd(&self) -> SharedFd;
+impl<T> Clone for SharedFd<T> {
+    fn clone(&self) -> Self {
+        Self(self.0.clone())
+    }
 }
 
-impl ToSharedFd for SharedFd {
-    fn to_shared_fd(&self) -> SharedFd {
+impl<T> Deref for SharedFd<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0.fd
+    }
+}
+
+/// Get a clone of [`SharedFd`].
+pub trait ToSharedFd<T> {
+    /// Return a cloned [`SharedFd`].
+    fn to_shared_fd(&self) -> SharedFd<T>;
+}
+
+impl<T> ToSharedFd<T> for SharedFd<T> {
+    fn to_shared_fd(&self) -> SharedFd<T> {
         self.clone()
     }
 }

--- a/compio-driver/src/fusion/op.rs
+++ b/compio-driver/src/fusion/op.rs
@@ -8,7 +8,7 @@ pub use crate::unix::op::*;
 use crate::SharedFd;
 
 macro_rules! op {
-    (<$($ty:ident: $trait:ident),* $(,)?> $name:ident( $($arg:ident: $arg_t:ident),* $(,)? )) => {
+    (<$($ty:ident: $trait:ident),* $(,)?> $name:ident( $($arg:ident: $arg_t:ty),* $(,)? )) => {
         ::paste::paste!{
             enum [< $name Inner >] <$($ty: $trait),*> {
                 Poll(poll::$name<$($ty),*>),
@@ -92,9 +92,9 @@ mod iour { pub use crate::sys::iour::{op::*, OpCode}; }
 #[rustfmt::skip]
 mod poll { pub use crate::sys::poll::{op::*, OpCode}; }
 
-op!(<T: IoBufMut> RecvFrom(fd: SharedFd, buffer: T));
-op!(<T: IoBuf> SendTo(fd: SharedFd, buffer: T, addr: SockAddr));
-op!(<T: IoVectoredBufMut> RecvFromVectored(fd: SharedFd, buffer: T));
-op!(<T: IoVectoredBuf> SendToVectored(fd: SharedFd, buffer: T, addr: SockAddr));
-op!(<> FileStat(fd: SharedFd));
+op!(<T: IoBufMut, S: AsRawFd> RecvFrom(fd: SharedFd<S>, buffer: T));
+op!(<T: IoBuf, S: AsRawFd> SendTo(fd: SharedFd<S>, buffer: T, addr: SockAddr));
+op!(<T: IoVectoredBufMut, S: AsRawFd> RecvFromVectored(fd: SharedFd<S>, buffer: T));
+op!(<T: IoVectoredBuf, S: AsRawFd> SendToVectored(fd: SharedFd<S>, buffer: T, addr: SockAddr));
+op!(<S: AsRawFd> FileStat(fd: SharedFd<S>));
 op!(<> PathStat(path: CString, follow_symlink: bool));

--- a/compio-driver/src/iocp/mod.rs
+++ b/compio-driver/src/iocp/mod.rs
@@ -70,6 +70,36 @@ impl AsRawFd for OwnedFd {
     }
 }
 
+impl AsRawFd for RawFd {
+    fn as_raw_fd(&self) -> RawFd {
+        *self
+    }
+}
+
+impl AsRawFd for std::fs::File {
+    fn as_raw_fd(&self) -> RawFd {
+        self.as_raw_handle() as _
+    }
+}
+
+impl AsRawFd for OwnedHandle {
+    fn as_raw_fd(&self) -> RawFd {
+        self.as_raw_handle() as _
+    }
+}
+
+impl AsRawFd for socket2::Socket {
+    fn as_raw_fd(&self) -> RawFd {
+        self.as_raw_socket() as _
+    }
+}
+
+impl AsRawFd for OwnedSocket {
+    fn as_raw_fd(&self) -> RawFd {
+        self.as_raw_socket() as _
+    }
+}
+
 impl From<OwnedHandle> for OwnedFd {
     fn from(value: OwnedHandle) -> Self {
         Self::File(value)

--- a/compio-driver/src/lib.rs
+++ b/compio-driver/src/lib.rs
@@ -108,7 +108,7 @@ macro_rules! syscall {
 #[macro_export]
 #[doc(hidden)]
 macro_rules! impl_raw_fd {
-    ($t:ty, $inner:ident) => {
+    ($t:ty, $it:ty, $inner:ident) => {
         impl $crate::AsRawFd for $t {
             fn as_raw_fd(&self) -> $crate::RawFd {
                 self.$inner.as_raw_fd()
@@ -122,14 +122,14 @@ macro_rules! impl_raw_fd {
                 }
             }
         }
-        impl $crate::ToSharedFd for $t {
-            fn to_shared_fd(&self) -> $crate::SharedFd {
+        impl $crate::ToSharedFd<$it> for $t {
+            fn to_shared_fd(&self) -> $crate::SharedFd<$it> {
                 self.$inner.to_shared_fd()
             }
         }
     };
-    ($t:ty, $inner:ident,file) => {
-        $crate::impl_raw_fd!($t, $inner);
+    ($t:ty, $it:ty, $inner:ident,file) => {
+        $crate::impl_raw_fd!($t, $it, $inner);
         #[cfg(windows)]
         impl std::os::windows::io::FromRawHandle for $t {
             unsafe fn from_raw_handle(handle: std::os::windows::io::RawHandle) -> Self {
@@ -139,8 +139,8 @@ macro_rules! impl_raw_fd {
             }
         }
     };
-    ($t:ty, $inner:ident,socket) => {
-        $crate::impl_raw_fd!($t, $inner);
+    ($t:ty, $it:ty, $inner:ident,socket) => {
+        $crate::impl_raw_fd!($t, $it, $inner);
         #[cfg(windows)]
         impl std::os::windows::io::FromRawSocket for $t {
             unsafe fn from_raw_socket(sock: std::os::windows::io::RawSocket) -> Self {

--- a/compio-driver/src/op.rs
+++ b/compio-driver/src/op.rs
@@ -114,16 +114,16 @@ impl CloseFile {
 
 /// Read a file at specified position into specified buffer.
 #[derive(Debug)]
-pub struct ReadAt<T: IoBufMut> {
-    pub(crate) fd: SharedFd,
+pub struct ReadAt<T: IoBufMut, S> {
+    pub(crate) fd: SharedFd<S>,
     pub(crate) offset: u64,
     pub(crate) buffer: T,
     _p: PhantomPinned,
 }
 
-impl<T: IoBufMut> ReadAt<T> {
+impl<T: IoBufMut, S> ReadAt<T, S> {
     /// Create [`ReadAt`].
-    pub fn new(fd: SharedFd, offset: u64, buffer: T) -> Self {
+    pub fn new(fd: SharedFd<S>, offset: u64, buffer: T) -> Self {
         Self {
             fd,
             offset,
@@ -133,7 +133,7 @@ impl<T: IoBufMut> ReadAt<T> {
     }
 }
 
-impl<T: IoBufMut> IntoInner for ReadAt<T> {
+impl<T: IoBufMut, S> IntoInner for ReadAt<T, S> {
     type Inner = T;
 
     fn into_inner(self) -> Self::Inner {
@@ -143,16 +143,16 @@ impl<T: IoBufMut> IntoInner for ReadAt<T> {
 
 /// Write a file at specified position from specified buffer.
 #[derive(Debug)]
-pub struct WriteAt<T: IoBuf> {
-    pub(crate) fd: SharedFd,
+pub struct WriteAt<T: IoBuf, S> {
+    pub(crate) fd: SharedFd<S>,
     pub(crate) offset: u64,
     pub(crate) buffer: T,
     _p: PhantomPinned,
 }
 
-impl<T: IoBuf> WriteAt<T> {
+impl<T: IoBuf, S> WriteAt<T, S> {
     /// Create [`WriteAt`].
-    pub fn new(fd: SharedFd, offset: u64, buffer: T) -> Self {
+    pub fn new(fd: SharedFd<S>, offset: u64, buffer: T) -> Self {
         Self {
             fd,
             offset,
@@ -162,7 +162,7 @@ impl<T: IoBuf> WriteAt<T> {
     }
 }
 
-impl<T: IoBuf> IntoInner for WriteAt<T> {
+impl<T: IoBuf, S> IntoInner for WriteAt<T, S> {
     type Inner = T;
 
     fn into_inner(self) -> Self::Inner {
@@ -171,30 +171,30 @@ impl<T: IoBuf> IntoInner for WriteAt<T> {
 }
 
 /// Sync data to the disk.
-pub struct Sync {
-    pub(crate) fd: SharedFd,
+pub struct Sync<S> {
+    pub(crate) fd: SharedFd<S>,
     #[allow(dead_code)]
     pub(crate) datasync: bool,
 }
 
-impl Sync {
+impl<S> Sync<S> {
     /// Create [`Sync`].
     ///
     /// If `datasync` is `true`, the file metadata may not be synchronized.
-    pub fn new(fd: SharedFd, datasync: bool) -> Self {
+    pub fn new(fd: SharedFd<S>, datasync: bool) -> Self {
         Self { fd, datasync }
     }
 }
 
 /// Shutdown a socket.
-pub struct ShutdownSocket {
-    pub(crate) fd: SharedFd,
+pub struct ShutdownSocket<S> {
+    pub(crate) fd: SharedFd<S>,
     pub(crate) how: Shutdown,
 }
 
-impl ShutdownSocket {
+impl<S> ShutdownSocket<S> {
     /// Create [`ShutdownSocket`].
-    pub fn new(fd: SharedFd, how: Shutdown) -> Self {
+    pub fn new(fd: SharedFd<S>, how: Shutdown) -> Self {
         Self { fd, how }
     }
 }
@@ -214,14 +214,14 @@ impl CloseSocket {
 }
 
 /// Connect to a remote address.
-pub struct Connect {
-    pub(crate) fd: SharedFd,
+pub struct Connect<S> {
+    pub(crate) fd: SharedFd<S>,
     pub(crate) addr: SockAddr,
 }
 
-impl Connect {
+impl<S> Connect<S> {
     /// Create [`Connect`]. `fd` should be bound.
-    pub fn new(fd: SharedFd, addr: SockAddr) -> Self {
+    pub fn new(fd: SharedFd<S>, addr: SockAddr) -> Self {
         Self { fd, addr }
     }
 }

--- a/compio-driver/src/unix/op.rs
+++ b/compio-driver/src/unix/op.rs
@@ -85,17 +85,17 @@ pub(crate) const fn statx_to_stat(statx: Statx) -> libc::stat {
 }
 
 /// Read a file at specified position into vectored buffer.
-pub struct ReadVectoredAt<T: IoVectoredBufMut> {
-    pub(crate) fd: SharedFd,
+pub struct ReadVectoredAt<T: IoVectoredBufMut, S> {
+    pub(crate) fd: SharedFd<S>,
     pub(crate) offset: u64,
     pub(crate) buffer: T,
     pub(crate) slices: Vec<IoSliceMut>,
     _p: PhantomPinned,
 }
 
-impl<T: IoVectoredBufMut> ReadVectoredAt<T> {
+impl<T: IoVectoredBufMut, S> ReadVectoredAt<T, S> {
     /// Create [`ReadVectoredAt`].
-    pub fn new(fd: SharedFd, offset: u64, buffer: T) -> Self {
+    pub fn new(fd: SharedFd<S>, offset: u64, buffer: T) -> Self {
         Self {
             fd,
             offset,
@@ -106,7 +106,7 @@ impl<T: IoVectoredBufMut> ReadVectoredAt<T> {
     }
 }
 
-impl<T: IoVectoredBufMut> IntoInner for ReadVectoredAt<T> {
+impl<T: IoVectoredBufMut, S> IntoInner for ReadVectoredAt<T, S> {
     type Inner = T;
 
     fn into_inner(self) -> Self::Inner {
@@ -115,17 +115,17 @@ impl<T: IoVectoredBufMut> IntoInner for ReadVectoredAt<T> {
 }
 
 /// Write a file at specified position from vectored buffer.
-pub struct WriteVectoredAt<T: IoVectoredBuf> {
-    pub(crate) fd: SharedFd,
+pub struct WriteVectoredAt<T: IoVectoredBuf, S> {
+    pub(crate) fd: SharedFd<S>,
     pub(crate) offset: u64,
     pub(crate) buffer: T,
     pub(crate) slices: Vec<IoSlice>,
     _p: PhantomPinned,
 }
 
-impl<T: IoVectoredBuf> WriteVectoredAt<T> {
+impl<T: IoVectoredBuf, S> WriteVectoredAt<T, S> {
     /// Create [`WriteVectoredAt`]
-    pub fn new(fd: SharedFd, offset: u64, buffer: T) -> Self {
+    pub fn new(fd: SharedFd<S>, offset: u64, buffer: T) -> Self {
         Self {
             fd,
             offset,
@@ -136,7 +136,7 @@ impl<T: IoVectoredBuf> WriteVectoredAt<T> {
     }
 }
 
-impl<T: IoVectoredBuf> IntoInner for WriteVectoredAt<T> {
+impl<T: IoVectoredBuf, S> IntoInner for WriteVectoredAt<T, S> {
     type Inner = T;
 
     fn into_inner(self) -> Self::Inner {
@@ -227,7 +227,7 @@ impl CreateSocket {
     }
 }
 
-impl ShutdownSocket {
+impl<S> ShutdownSocket<S> {
     pub(crate) fn how(&self) -> i32 {
         match self.how {
             Shutdown::Write => libc::SHUT_WR,
@@ -238,16 +238,16 @@ impl ShutdownSocket {
 }
 
 /// Accept a connection.
-pub struct Accept {
-    pub(crate) fd: SharedFd,
+pub struct Accept<S> {
+    pub(crate) fd: SharedFd<S>,
     pub(crate) buffer: sockaddr_storage,
     pub(crate) addr_len: socklen_t,
     _p: PhantomPinned,
 }
 
-impl Accept {
+impl<S> Accept<S> {
     /// Create [`Accept`].
-    pub fn new(fd: SharedFd) -> Self {
+    pub fn new(fd: SharedFd<S>) -> Self {
         Self {
             fd,
             buffer: unsafe { std::mem::zeroed() },
@@ -263,15 +263,15 @@ impl Accept {
 }
 
 /// Receive data from remote.
-pub struct Recv<T: IoBufMut> {
-    pub(crate) fd: SharedFd,
+pub struct Recv<T: IoBufMut, S> {
+    pub(crate) fd: SharedFd<S>,
     pub(crate) buffer: T,
     _p: PhantomPinned,
 }
 
-impl<T: IoBufMut> Recv<T> {
+impl<T: IoBufMut, S> Recv<T, S> {
     /// Create [`Recv`].
-    pub fn new(fd: SharedFd, buffer: T) -> Self {
+    pub fn new(fd: SharedFd<S>, buffer: T) -> Self {
         Self {
             fd,
             buffer,
@@ -280,7 +280,7 @@ impl<T: IoBufMut> Recv<T> {
     }
 }
 
-impl<T: IoBufMut> IntoInner for Recv<T> {
+impl<T: IoBufMut, S> IntoInner for Recv<T, S> {
     type Inner = T;
 
     fn into_inner(self) -> Self::Inner {
@@ -289,16 +289,16 @@ impl<T: IoBufMut> IntoInner for Recv<T> {
 }
 
 /// Receive data from remote into vectored buffer.
-pub struct RecvVectored<T: IoVectoredBufMut> {
-    pub(crate) fd: SharedFd,
+pub struct RecvVectored<T: IoVectoredBufMut, S> {
+    pub(crate) fd: SharedFd<S>,
     pub(crate) buffer: T,
     pub(crate) slices: Vec<IoSliceMut>,
     _p: PhantomPinned,
 }
 
-impl<T: IoVectoredBufMut> RecvVectored<T> {
+impl<T: IoVectoredBufMut, S> RecvVectored<T, S> {
     /// Create [`RecvVectored`].
-    pub fn new(fd: SharedFd, buffer: T) -> Self {
+    pub fn new(fd: SharedFd<S>, buffer: T) -> Self {
         Self {
             fd,
             buffer,
@@ -308,7 +308,7 @@ impl<T: IoVectoredBufMut> RecvVectored<T> {
     }
 }
 
-impl<T: IoVectoredBufMut> IntoInner for RecvVectored<T> {
+impl<T: IoVectoredBufMut, S> IntoInner for RecvVectored<T, S> {
     type Inner = T;
 
     fn into_inner(self) -> Self::Inner {
@@ -317,15 +317,15 @@ impl<T: IoVectoredBufMut> IntoInner for RecvVectored<T> {
 }
 
 /// Send data to remote.
-pub struct Send<T: IoBuf> {
-    pub(crate) fd: SharedFd,
+pub struct Send<T: IoBuf, S> {
+    pub(crate) fd: SharedFd<S>,
     pub(crate) buffer: T,
     _p: PhantomPinned,
 }
 
-impl<T: IoBuf> Send<T> {
+impl<T: IoBuf, S> Send<T, S> {
     /// Create [`Send`].
-    pub fn new(fd: SharedFd, buffer: T) -> Self {
+    pub fn new(fd: SharedFd<S>, buffer: T) -> Self {
         Self {
             fd,
             buffer,
@@ -334,7 +334,7 @@ impl<T: IoBuf> Send<T> {
     }
 }
 
-impl<T: IoBuf> IntoInner for Send<T> {
+impl<T: IoBuf, S> IntoInner for Send<T, S> {
     type Inner = T;
 
     fn into_inner(self) -> Self::Inner {
@@ -343,16 +343,16 @@ impl<T: IoBuf> IntoInner for Send<T> {
 }
 
 /// Send data to remote from vectored buffer.
-pub struct SendVectored<T: IoVectoredBuf> {
-    pub(crate) fd: SharedFd,
+pub struct SendVectored<T: IoVectoredBuf, S> {
+    pub(crate) fd: SharedFd<S>,
     pub(crate) buffer: T,
     pub(crate) slices: Vec<IoSlice>,
     _p: PhantomPinned,
 }
 
-impl<T: IoVectoredBuf> SendVectored<T> {
+impl<T: IoVectoredBuf, S> SendVectored<T, S> {
     /// Create [`SendVectored`].
-    pub fn new(fd: SharedFd, buffer: T) -> Self {
+    pub fn new(fd: SharedFd<S>, buffer: T) -> Self {
         Self {
             fd,
             buffer,
@@ -362,7 +362,7 @@ impl<T: IoVectoredBuf> SendVectored<T> {
     }
 }
 
-impl<T: IoVectoredBuf> IntoInner for SendVectored<T> {
+impl<T: IoVectoredBuf, S> IntoInner for SendVectored<T, S> {
     type Inner = T;
 
     fn into_inner(self) -> Self::Inner {

--- a/compio-fs/src/named_pipe.rs
+++ b/compio-fs/src/named_pipe.rs
@@ -229,7 +229,7 @@ impl AsyncWrite for &NamedPipeServer {
     }
 }
 
-impl_raw_fd!(NamedPipeServer, handle, file);
+impl_raw_fd!(NamedPipeServer, std::fs::File, handle, file);
 
 /// A [Windows named pipe] client.
 ///
@@ -350,7 +350,7 @@ impl AsyncWrite for &NamedPipeClient {
     }
 }
 
-impl_raw_fd!(NamedPipeClient, handle, file);
+impl_raw_fd!(NamedPipeClient, std::fs::File, handle, file);
 
 /// A builder structure for construct a named pipe with named pipe-specific
 /// options. This is required to use for named pipe servers who wants to modify

--- a/compio-fs/src/pipe.rs
+++ b/compio-fs/src/pipe.rs
@@ -390,7 +390,7 @@ impl AsyncWrite for &Sender {
     }
 }
 
-impl_raw_fd!(Sender, file, file);
+impl_raw_fd!(Sender, std::fs::File, file, file);
 
 /// Reading end of a Unix pipe.
 ///
@@ -511,7 +511,7 @@ impl AsyncRead for &Receiver {
     }
 }
 
-impl_raw_fd!(Receiver, file, file);
+impl_raw_fd!(Receiver, std::fs::File, file, file);
 
 /// Checks if file is a FIFO
 async fn is_fifo(file: &File) -> io::Result<bool> {

--- a/compio-net/src/tcp.rs
+++ b/compio-net/src/tcp.rs
@@ -109,7 +109,7 @@ impl TcpListener {
     }
 }
 
-impl_raw_fd!(TcpListener, inner, socket);
+impl_raw_fd!(TcpListener, socket2::Socket, inner, socket);
 
 /// A TCP stream between a local and a remote socket.
 ///
@@ -273,4 +273,4 @@ impl AsyncWrite for &TcpStream {
     }
 }
 
-impl_raw_fd!(TcpStream, inner, socket);
+impl_raw_fd!(TcpStream, socket2::Socket, inner, socket);

--- a/compio-net/src/udp.rs
+++ b/compio-net/src/udp.rs
@@ -251,4 +251,4 @@ impl UdpSocket {
     }
 }
 
-impl_raw_fd!(UdpSocket, inner, socket);
+impl_raw_fd!(UdpSocket, socket2::Socket, inner, socket);

--- a/compio-net/src/unix.rs
+++ b/compio-net/src/unix.rs
@@ -87,7 +87,7 @@ impl UnixListener {
     }
 }
 
-impl_raw_fd!(UnixListener, inner, socket);
+impl_raw_fd!(UnixListener, socket2::Socket, inner, socket);
 
 /// A Unix stream between two local sockets on Windows & WSL.
 ///
@@ -257,7 +257,7 @@ impl AsyncWrite for &UnixStream {
     }
 }
 
-impl_raw_fd!(UnixStream, inner, socket);
+impl_raw_fd!(UnixStream, socket2::Socket, inner, socket);
 
 #[cfg(windows)]
 #[inline]


### PR DESCRIPTION
A SharedFd is generic to hold the original handle type. An OwnedFd is type-erased to support close operations. This PR is the basis of #224 , and will be convenient for AsyncFd in the future.