### PR TITLE
feat(driver): reduce eventfd IO

### DIFF
--- a/compio-runtime/Cargo.toml
+++ b/compio-runtime/Cargo.toml
@@ -39,6 +39,7 @@ criterion = { workspace = true, optional = true }
 crossbeam-queue = { workspace = true }
 futures-util = { workspace = true }
 once_cell = { workspace = true }
+send_wrapper = "0.6.0"
 slab = { workspace = true, optional = true }
 smallvec = "1.11.1"
 socket2 = { workspace = true }

--- a/compio-runtime/src/runtime/mod.rs
+++ b/compio-runtime/src/runtime/mod.rs
@@ -90,8 +90,11 @@ impl RuntimeInner {
     }
 
     pub fn run(&self) {
+        use std::ops::Deref;
+
+        let local_runnables = self.local_runnables.deref().deref();
         loop {
-            let next_task = self.local_runnables.borrow_mut().pop_front();
+            let next_task = local_runnables.borrow_mut().pop_front();
             let has_local_task = next_task.is_some();
             if let Some(task) = next_task {
                 task.run();

--- a/compio-runtime/src/runtime/mod.rs
+++ b/compio-runtime/src/runtime/mod.rs
@@ -60,6 +60,8 @@ impl RuntimeInner {
         Ok(Self {
             driver: RefCell::new(builder.proactor_builder.build()?),
             poll: builder.poll,
+            // Arc to send to another thread, but only in current thread will the inner be accessed.
+            #[allow(clippy::arc_with_non_send_sync)]
             local_runnables: Arc::new(RefCell::new(VecDeque::new())),
             sync_runnables: Arc::new(SegQueue::new()),
             op_runtime: RefCell::default(),

--- a/compio-runtime/src/runtime/mod.rs
+++ b/compio-runtime/src/runtime/mod.rs
@@ -48,7 +48,7 @@ impl Default for FutureState {
 
 pub(crate) struct RuntimeInner {
     driver: RefCell<Proactor>,
-    local_runnables: SendWrapper<Arc<RefCell<VecDeque<Runnable>>>>,
+    local_runnables: Arc<SendWrapper<RefCell<VecDeque<Runnable>>>>,
     sync_runnables: Arc<SegQueue<Runnable>>,
     op_runtime: RefCell<OpRuntime>,
     #[cfg(feature = "time")]
@@ -59,9 +59,7 @@ impl RuntimeInner {
     pub fn new(builder: &ProactorBuilder) -> io::Result<Self> {
         Ok(Self {
             driver: RefCell::new(builder.build()?),
-            // Arc to send to another thread, but only in current thread will the inner be accessed.
-            #[allow(clippy::arc_with_non_send_sync)]
-            local_runnables: SendWrapper::new(Arc::new(RefCell::new(VecDeque::new()))),
+            local_runnables: Arc::new(SendWrapper::new(RefCell::new(VecDeque::new()))),
             sync_runnables: Arc::new(SegQueue::new()),
             op_runtime: RefCell::default(),
             #[cfg(feature = "time")]

--- a/compio-runtime/src/runtime/mod.rs
+++ b/compio-runtime/src/runtime/mod.rs
@@ -100,17 +100,16 @@ impl RuntimeInner {
     pub fn run(&self) {
         loop {
             let next_task = self.local_runnables.borrow_mut().pop_front();
+            let has_local_task = next_task.is_some();
             if let Some(task) = next_task {
                 task.run();
-            } else {
-                break;
             }
-        }
-        loop {
             let next_task = self.sync_runnables.pop();
+            let has_sync_task = next_task.is_some();
             if let Some(task) = next_task {
                 task.run();
-            } else {
+            }
+            if !has_local_task && !has_sync_task {
                 break;
             }
         }

--- a/compio-runtime/src/runtime/time.rs
+++ b/compio-runtime/src/runtime/time.rs
@@ -82,8 +82,8 @@ impl TimerRuntime {
     }
 
     pub fn min_timeout(&self) -> Option<Duration> {
-        let elapsed = self.time.elapsed();
         self.wheel.peek().map(|entry| {
+            let elapsed = self.time.elapsed();
             if entry.0.delay > elapsed {
                 entry.0.delay - elapsed
             } else {

--- a/compio-runtime/tests/custom_loop.rs
+++ b/compio-runtime/tests/custom_loop.rs
@@ -25,7 +25,7 @@ fn cf_run_loop() {
 
     impl CFRunLoopRuntime {
         pub fn new() -> Self {
-            let runtime = Runtime::new().unwrap();
+            let runtime = Runtime::builder().enable_poll(true).build().unwrap();
 
             extern "C" fn callback(
                 _fdref: CFFileDescriptorRef,
@@ -120,7 +120,7 @@ fn message_queue() {
     impl MQRuntime {
         pub fn new() -> Self {
             Self {
-                runtime: Runtime::new().unwrap(),
+                runtime: Runtime::builder().enable_poll(true).build().unwrap(),
             }
         }
 

--- a/compio-runtime/tests/custom_loop.rs
+++ b/compio-runtime/tests/custom_loop.rs
@@ -52,11 +52,6 @@ fn cf_run_loop() {
             }
             .detach();
             loop {
-                self.runtime.run();
-                if let Some(result) = result.take() {
-                    break result;
-                }
-
                 self.runtime.poll_with(Some(Duration::ZERO));
 
                 self.runtime.run();
@@ -139,11 +134,6 @@ fn message_queue() {
             }
             .detach();
             loop {
-                self.runtime.run();
-                if let Some(result) = result.take() {
-                    break result;
-                }
-
                 self.runtime.poll_with(Some(Duration::ZERO));
 
                 self.runtime.run();
@@ -242,11 +232,6 @@ fn glib_context() {
             }
             .detach();
             loop {
-                self.runtime.run();
-                if let Some(result) = result.take() {
-                    break result;
-                }
-
                 self.runtime.poll_with(Some(Duration::ZERO));
 
                 self.runtime.run();

--- a/compio-runtime/tests/custom_loop.rs
+++ b/compio-runtime/tests/custom_loop.rs
@@ -212,7 +212,7 @@ fn glib_context() {
 
     impl GLibRuntime {
         pub fn new() -> Self {
-            let runtime = Runtime::new().unwrap();
+            let runtime = Runtime::builder().enable_poll(true).build().unwrap();
             let ctx = MainContext::default();
 
             unix_fd_add_local(runtime.as_raw_fd(), IOCondition::IN, |_fd, _cond| {

--- a/compio-runtime/tests/custom_loop.rs
+++ b/compio-runtime/tests/custom_loop.rs
@@ -14,7 +14,7 @@ fn cf_run_loop() {
     use core_foundation::{
         base::TCFType,
         filedescriptor::{kCFFileDescriptorReadCallBack, CFFileDescriptor, CFFileDescriptorRef},
-        runloop::{kCFRunLoopDefaultMode, CFRunLoop, CFRunLoopRef},
+        runloop::{kCFRunLoopDefaultMode, CFRunLoop, CFRunLoopRef, CFRunLoopStop},
         string::CFStringRef,
     };
 
@@ -77,8 +77,12 @@ fn cf_run_loop() {
 
         let event = Event::new();
         let handle = Arc::new(Mutex::new(Some(event.handle())));
+        let run_loop = CFRunLoop::get_current();
         let block = StackBlock::new(move || {
             handle.lock().unwrap().take().unwrap().notify();
+            unsafe {
+                CFRunLoopStop(run_loop.as_concrete_TypeRef());
+            }
         });
         extern "C" {
             fn CFRunLoopPerformBlock(rl: CFRunLoopRef, mode: CFStringRef, block: &Block<dyn Fn()>);


### PR DESCRIPTION
Each call to `Waker::wake` writes to the eventfd, which is too annoying. This PR provides a faster path. When the waker is on the same thread, no need to write to the eventfd.

The `enable_poll` switch of proactor builder provides compatibility to custom event loops, which may poll the io-uring fd in other frameworks. When the switch is enabled, the fast path is disabled.