### PR TITLE
feat(driver): move future state into RawOp

### DIFF
--- a/compio-driver/Cargo.toml
+++ b/compio-driver/Cargo.toml
@@ -36,7 +36,6 @@ compio-log = { workspace = true }
 cfg-if = { workspace = true }
 crossbeam-channel = { workspace = true }
 futures-util = { workspace = true }
-slab = { workspace = true }
 socket2 = { workspace = true }
 
 # Windows specific dependencies

--- a/compio-driver/src/fd.rs
+++ b/compio-driver/src/fd.rs
@@ -95,7 +95,7 @@ impl<T> SharedFd<T> {
 impl<T> Drop for SharedFd<T> {
     fn drop(&mut self) {
         // It's OK to wake multiple times.
-        if Arc::strong_count(&self.0) == 2 {
+        if Arc::strong_count(&self.0) == 2 && self.0.waits.load(Ordering::Acquire) {
             self.0.waker.wake()
         }
     }

--- a/compio-driver/src/fusion/mod.rs
+++ b/compio-driver/src/fusion/mod.rs
@@ -16,7 +16,7 @@ pub use iour::{OpCode as IourOpCode, OpEntry};
 pub use poll::{Decision, OpCode as PollOpCode};
 use slab::Slab;
 
-pub(crate) use crate::unix::RawOp;
+pub(crate) use crate::RawOp;
 use crate::{OutEntries, ProactorBuilder};
 
 mod driver_type {

--- a/compio-driver/src/fusion/mod.rs
+++ b/compio-driver/src/fusion/mod.rs
@@ -14,10 +14,8 @@ pub use driver_type::DriverType;
 pub(crate) use iour::{sockaddr_storage, socklen_t};
 pub use iour::{OpCode as IourOpCode, OpEntry};
 pub use poll::{Decision, OpCode as PollOpCode};
-use slab::Slab;
 
-pub(crate) use crate::RawOp;
-use crate::{OutEntries, ProactorBuilder};
+use crate::{Key, OutEntries, ProactorBuilder};
 
 mod driver_type {
     use std::sync::atomic::{AtomicU8, Ordering};
@@ -136,10 +134,10 @@ impl Driver {
         }
     }
 
-    pub fn create_op<T: OpCode + 'static>(&self, user_data: usize, op: T) -> RawOp {
+    pub fn create_op<T: OpCode + 'static>(&self, op: T) -> Key<T> {
         match &self.fuse {
-            FuseDriver::Poll(driver) => driver.create_op(user_data, op),
-            FuseDriver::IoUring(driver) => driver.create_op(user_data, op),
+            FuseDriver::Poll(driver) => driver.create_op(op),
+            FuseDriver::IoUring(driver) => driver.create_op(op),
         }
     }
 
@@ -150,17 +148,17 @@ impl Driver {
         }
     }
 
-    pub fn cancel(&mut self, user_data: usize, registry: &mut Slab<RawOp>) {
+    pub fn cancel<T>(&mut self, op: Key<T>) {
         match &mut self.fuse {
-            FuseDriver::Poll(driver) => driver.cancel(user_data, registry),
-            FuseDriver::IoUring(driver) => driver.cancel(user_data, registry),
+            FuseDriver::Poll(driver) => driver.cancel(op),
+            FuseDriver::IoUring(driver) => driver.cancel(op),
         }
     }
 
-    pub fn push(&mut self, user_data: usize, op: &mut RawOp) -> Poll<io::Result<usize>> {
+    pub fn push<T: OpCode + 'static>(&mut self, op: &mut Key<T>) -> Poll<io::Result<usize>> {
         match &mut self.fuse {
-            FuseDriver::Poll(driver) => driver.push(user_data, op),
-            FuseDriver::IoUring(driver) => driver.push(user_data, op),
+            FuseDriver::Poll(driver) => driver.push(op),
+            FuseDriver::IoUring(driver) => driver.push(op),
         }
     }
 

--- a/compio-driver/src/iocp/cp/global.rs
+++ b/compio-driver/src/iocp/cp/global.rs
@@ -29,15 +29,11 @@ impl GlobalPort {
         self.port.attach(fd)
     }
 
-    pub fn post<T: ?Sized>(
-        &self,
-        res: io::Result<usize>,
-        optr: *mut Overlapped<T>,
-    ) -> io::Result<()> {
+    pub fn post(&self, res: io::Result<usize>, optr: *mut Overlapped) -> io::Result<()> {
         self.port.post(res, optr)
     }
 
-    pub fn post_raw<T: ?Sized>(&self, optr: *const Overlapped<T>) -> io::Result<()> {
+    pub fn post_raw(&self, optr: *const Overlapped) -> io::Result<()> {
         self.port.post_raw(optr)
     }
 }
@@ -62,7 +58,7 @@ fn iocp_start() -> io::Result<()> {
         loop {
             for entry in port.port.poll_raw(None)? {
                 // Any thin pointer is OK because we don't use the type of opcode.
-                let overlapped_ptr: *mut Overlapped<()> = entry.lpOverlapped.cast();
+                let overlapped_ptr: *mut Overlapped = entry.lpOverlapped.cast();
                 let overlapped = unsafe { &*overlapped_ptr };
                 if let Err(_e) = syscall!(
                     BOOL,
@@ -135,15 +131,11 @@ impl PortHandle {
         Self { port }
     }
 
-    pub fn post<T: ?Sized>(
-        &self,
-        res: io::Result<usize>,
-        optr: *mut Overlapped<T>,
-    ) -> io::Result<()> {
+    pub fn post(&self, res: io::Result<usize>, optr: *mut Overlapped) -> io::Result<()> {
         self.port.post(res, optr)
     }
 
-    pub fn post_raw<T: ?Sized>(&self, optr: *const Overlapped<T>) -> io::Result<()> {
+    pub fn post_raw(&self, optr: *const Overlapped) -> io::Result<()> {
         self.port.post_raw(optr)
     }
 }

--- a/compio-driver/src/iocp/cp/multi.rs
+++ b/compio-driver/src/iocp/cp/multi.rs
@@ -48,15 +48,11 @@ impl PortHandle {
         Self { port }
     }
 
-    pub fn post<T: ?Sized>(
-        &self,
-        res: io::Result<usize>,
-        optr: *mut Overlapped<T>,
-    ) -> io::Result<()> {
+    pub fn post(&self, res: io::Result<usize>, optr: *mut Overlapped) -> io::Result<()> {
         self.port.post(res, optr)
     }
 
-    pub fn post_raw<T: ?Sized>(&self, optr: *const Overlapped<T>) -> io::Result<()> {
+    pub fn post_raw(&self, optr: *const Overlapped) -> io::Result<()> {
         self.port.post_raw(optr)
     }
 }

--- a/compio-driver/src/iocp/mod.rs
+++ b/compio-driver/src/iocp/mod.rs
@@ -1,7 +1,6 @@
 use std::{
     collections::{HashMap, HashSet},
     io,
-    mem::ManuallyDrop,
     os::{
         raw::c_void,
         windows::{
@@ -12,11 +11,10 @@ use std::{
     pin::Pin,
     ptr::{null, NonNull},
     sync::Arc,
-    task::{Poll, Waker},
+    task::Poll,
     time::Duration,
 };
 
-use compio_buf::BufResult;
 use compio_log::{instrument, trace};
 use slab::Slab;
 use windows_sys::Win32::{
@@ -31,7 +29,7 @@ use windows_sys::Win32::{
     },
 };
 
-use crate::{syscall, AsyncifyPool, Entry, OutEntries, ProactorBuilder, PushEntry};
+use crate::{syscall, AsyncifyPool, Entry, OutEntries, ProactorBuilder, RawOp};
 
 pub(crate) mod op;
 
@@ -431,89 +429,3 @@ impl<T> Overlapped<T> {
 // SAFETY: neither field of `OVERLAPPED` is used
 unsafe impl Send for Overlapped<()> {}
 unsafe impl Sync for Overlapped<()> {}
-
-pub(crate) struct RawOp {
-    op: NonNull<Overlapped<dyn OpCode>>,
-    // The two flags here are manual reference counting. The driver holds the strong ref until it
-    // completes; the runtime holds the strong ref until the future is dropped.
-    cancelled: bool,
-    result: PushEntry<Option<Waker>, io::Result<usize>>,
-}
-
-impl RawOp {
-    pub(crate) fn new(driver: RawFd, user_data: usize, op: impl OpCode + 'static) -> Self {
-        let op = Overlapped::new(driver, user_data, op);
-        let op = Box::new(op) as Box<Overlapped<dyn OpCode>>;
-        Self {
-            op: unsafe { NonNull::new_unchecked(Box::into_raw(op)) },
-            cancelled: false,
-            result: PushEntry::Pending(None),
-        }
-    }
-
-    pub fn as_op_pin(&mut self) -> Pin<&mut dyn OpCode> {
-        unsafe { Pin::new_unchecked(&mut self.op.as_mut().op) }
-    }
-
-    pub fn as_mut_ptr(&mut self) -> *mut Overlapped<dyn OpCode> {
-        self.op.as_ptr()
-    }
-
-    pub fn set_cancelled(&mut self) -> bool {
-        self.cancelled = true;
-        self.has_result()
-    }
-
-    pub fn set_result(&mut self, res: io::Result<usize>) -> bool {
-        if let PushEntry::Pending(Some(w)) =
-            std::mem::replace(&mut self.result, PushEntry::Ready(res))
-        {
-            w.wake();
-        }
-        self.cancelled
-    }
-
-    pub fn has_result(&self) -> bool {
-        self.result.is_ready()
-    }
-
-    pub fn set_waker(&mut self, waker: Waker) {
-        if let PushEntry::Pending(w) = &mut self.result {
-            *w = Some(waker)
-        }
-    }
-
-    /// # Safety
-    /// The caller should ensure the correct type.
-    ///
-    /// # Panics
-    /// This function will panic if the result has not been set.
-    pub unsafe fn into_inner<T: OpCode>(self) -> BufResult<usize, T> {
-        let mut this = ManuallyDrop::new(self);
-        let overlapped: Box<Overlapped<T>> = Box::from_raw(this.op.cast().as_ptr());
-        BufResult(
-            std::mem::replace(&mut this.result, PushEntry::Pending(None))
-                .take_ready()
-                .unwrap(),
-            overlapped.op,
-        )
-    }
-
-    fn operate_blocking(&mut self) -> io::Result<usize> {
-        let optr = self.as_mut_ptr();
-        let op = self.as_op_pin();
-        let res = unsafe { op.operate(optr.cast()) };
-        match res {
-            Poll::Pending => unreachable!("this operation is not overlapped"),
-            Poll::Ready(res) => res,
-        }
-    }
-}
-
-impl Drop for RawOp {
-    fn drop(&mut self) {
-        if self.has_result() {
-            let _ = unsafe { Box::from_raw(self.op.as_ptr()) };
-        }
-    }
-}

--- a/compio-driver/src/iocp/mod.rs
+++ b/compio-driver/src/iocp/mod.rs
@@ -249,7 +249,7 @@ impl Driver {
         Ok(self
             .pool
             .dispatch(move || {
-                let op = unsafe { Key::upcast(user_data) };
+                let mut op = unsafe { Key::<dyn OpCode>::new_unchecked(user_data) };
                 let optr = op.as_mut_ptr();
                 let res = op.operate_blocking();
                 port.post(res, optr).ok();
@@ -369,7 +369,7 @@ impl WinThreadpollWait {
             WAIT_TIMEOUT => Err(io::Error::from_raw_os_error(ERROR_TIMEOUT as _)),
             _ => Err(io::Error::from_raw_os_error(result as _)),
         };
-        let op = unsafe { Key::upcast(context.user_data) };
+        let mut op = unsafe { Key::<dyn OpCode>::new_unchecked(context.user_data) };
         let res = if res.is_err() {
             res
         } else {

--- a/compio-driver/src/iour/mod.rs
+++ b/compio-driver/src/iour/mod.rs
@@ -234,7 +234,7 @@ impl Driver {
         let is_ok = self
             .pool
             .dispatch(move || {
-                let op = unsafe { Key::upcast(user_data) };
+                let mut op = unsafe { Key::<dyn OpCode>::new_unchecked(user_data) };
                 let op_pin = op.as_op_pin();
                 let res = op_pin.call_blocking();
                 completed.push(Entry::new(user_data, res));

--- a/compio-driver/src/iour/mod.rs
+++ b/compio-driver/src/iour/mod.rs
@@ -1,7 +1,7 @@
 #[cfg_attr(all(doc, docsrs), doc(cfg(all())))]
 #[allow(unused_imports)]
 pub use std::os::fd::{AsRawFd, OwnedFd, RawFd};
-use std::{io, os::fd::FromRawFd, pin::Pin, ptr::NonNull, sync::Arc, task::Poll, time::Duration};
+use std::{io, os::fd::FromRawFd, pin::Pin, sync::Arc, task::Poll, time::Duration};
 
 use compio_log::{instrument, trace, warn};
 use crossbeam_queue::SegQueue;
@@ -25,12 +25,10 @@ use io_uring::{
     IoUring,
 };
 pub(crate) use libc::{sockaddr_storage, socklen_t};
-use slab::Slab;
 
-use crate::{syscall, AsyncifyPool, Entry, OutEntries, ProactorBuilder};
+use crate::{syscall, AsyncifyPool, Entry, Key, OutEntries, ProactorBuilder};
 
 pub(crate) mod op;
-pub(crate) use crate::RawOp;
 
 /// The created entry of [`OpCode`].
 pub enum OpEntry {
@@ -159,16 +157,16 @@ impl Driver {
         has_entry
     }
 
-    pub fn create_op<T: crate::sys::OpCode + 'static>(&self, user_data: usize, op: T) -> RawOp {
-        RawOp::new(self.as_raw_fd(), user_data, op)
+    pub fn create_op<T: crate::sys::OpCode + 'static>(&self, op: T) -> Key<T> {
+        Key::new(self.as_raw_fd(), op)
     }
 
     pub fn attach(&mut self, _fd: RawFd) -> io::Result<()> {
         Ok(())
     }
 
-    pub fn cancel(&mut self, user_data: usize, _registry: &mut Slab<RawOp>) {
-        instrument!(compio_log::Level::TRACE, "cancel", user_data);
+    pub fn cancel<T>(&mut self, op: Key<T>) {
+        instrument!(compio_log::Level::TRACE, "cancel", ?op);
         trace!("cancel RawOp");
         unsafe {
             #[allow(clippy::useless_conversion)]
@@ -176,7 +174,7 @@ impl Driver {
                 .inner
                 .submission()
                 .push(
-                    &AsyncCancel::new(user_data as _)
+                    &AsyncCancel::new(op.user_data() as _)
                         .build()
                         .user_data(Self::CANCEL)
                         .into(),
@@ -204,8 +202,9 @@ impl Driver {
         }
     }
 
-    pub fn push(&mut self, user_data: usize, op: &mut RawOp) -> Poll<io::Result<usize>> {
-        instrument!(compio_log::Level::TRACE, "push", user_data);
+    pub fn push<T: OpCode + 'static>(&mut self, op: &mut Key<T>) -> Poll<io::Result<usize>> {
+        instrument!(compio_log::Level::TRACE, "push", ?op);
+        let user_data = op.user_data();
         let op_pin = op.as_op_pin();
         trace!("push RawOp");
         match op_pin.create_entry() {
@@ -220,7 +219,7 @@ impl Driver {
                 Poll::Pending
             }
             OpEntry::Blocking => {
-                if self.push_blocking(user_data, op)? {
+                if self.push_blocking(user_data)? {
                     Poll::Pending
                 } else {
                     Poll::Ready(Err(io::Error::from_raw_os_error(libc::EBUSY)))
@@ -229,20 +228,13 @@ impl Driver {
         }
     }
 
-    fn push_blocking(&mut self, user_data: usize, op: &mut RawOp) -> io::Result<bool> {
-        // Safety: the RawOp is not released before the operation returns.
-        struct SendWrapper<T>(T);
-        unsafe impl<T> Send for SendWrapper<T> {}
-
-        let op = SendWrapper(NonNull::from(op));
+    fn push_blocking(&mut self, user_data: usize) -> io::Result<bool> {
         let handle = self.handle()?;
         let completed = self.pool_completed.clone();
         let is_ok = self
             .pool
             .dispatch(move || {
-                #[allow(clippy::redundant_locals)]
-                let mut op = op;
-                let op = unsafe { op.0.as_mut() };
+                let op = unsafe { Key::upcast(user_data) };
                 let op_pin = op.as_op_pin();
                 let res = op_pin.call_blocking();
                 completed.push(Entry::new(user_data, res));

--- a/compio-driver/src/iour/mod.rs
+++ b/compio-driver/src/iour/mod.rs
@@ -202,7 +202,10 @@ impl Driver {
         }
     }
 
-    pub fn push<T: OpCode + 'static>(&mut self, op: &mut Key<T>) -> Poll<io::Result<usize>> {
+    pub fn push<T: crate::sys::OpCode + 'static>(
+        &mut self,
+        op: &mut Key<T>,
+    ) -> Poll<io::Result<usize>> {
         instrument!(compio_log::Level::TRACE, "push", ?op);
         let user_data = op.user_data();
         let op_pin = op.as_op_pin();
@@ -234,7 +237,7 @@ impl Driver {
         let is_ok = self
             .pool
             .dispatch(move || {
-                let mut op = unsafe { Key::<dyn OpCode>::new_unchecked(user_data) };
+                let mut op = unsafe { Key::<dyn crate::sys::OpCode>::new_unchecked(user_data) };
                 let op_pin = op.as_op_pin();
                 let res = op_pin.call_blocking();
                 completed.push(Entry::new(user_data, res));

--- a/compio-driver/src/key.rs
+++ b/compio-driver/src/key.rs
@@ -70,7 +70,7 @@ const unsafe fn opcode_dyn_mut(ptr: *mut (), metadata: usize) -> *mut RawOp<dyn 
 #[derive(PartialEq, Eq, Hash)]
 pub struct Key<T: ?Sized> {
     user_data: *mut (),
-    _p: PhantomData<Box<T>>,
+    _p: PhantomData<Box<RawOp<T>>>,
 }
 
 impl<T: ?Sized> Unpin for Key<T> {}

--- a/compio-driver/src/key.rs
+++ b/compio-driver/src/key.rs
@@ -33,7 +33,7 @@ union OpCodePtrRepr {
 #[repr(C)]
 #[derive(Clone, Copy)]
 struct OpCodePtrComponents {
-    data_pointer: *const (),
+    data_pointer: *mut (),
     metadata: usize,
 }
 
@@ -49,7 +49,7 @@ fn opcode_metadata<T: OpCode + 'static>() -> usize {
     }
 }
 
-const unsafe fn opcode_dyn_mut(ptr: *const (), metadata: usize) -> *mut RawOp<dyn OpCode> {
+const unsafe fn opcode_dyn_mut(ptr: *mut (), metadata: usize) -> *mut RawOp<dyn OpCode> {
     OpCodePtrRepr {
         components: OpCodePtrComponents {
             data_pointer: ptr,

--- a/compio-driver/src/key.rs
+++ b/compio-driver/src/key.rs
@@ -1,19 +1,110 @@
+use std::{
+    io,
+    marker::PhantomData,
+    ops::{Deref, DerefMut},
+    pin::Pin,
+    task::Waker,
+};
+
+use compio_buf::BufResult;
+
+use crate::{OpCode, Overlapped, PushEntry, RawFd};
+
+#[repr(C)]
+pub struct RawOp<T: ?Sized> {
+    header: Overlapped,
+    // The two flags here are manual reference counting. The driver holds the strong ref until it
+    // completes; the runtime holds the strong ref until the future is dropped.
+    cancelled: bool,
+    upcast_fn: unsafe fn(usize) -> *mut RawOp<dyn OpCode>,
+    result: PushEntry<Option<Waker>, io::Result<usize>>,
+    op: T,
+}
+
+impl<T: ?Sized> RawOp<T> {
+    pub fn as_op_pin(&mut self) -> Pin<&mut T> {
+        unsafe { Pin::new_unchecked(&mut self.op) }
+    }
+
+    #[cfg(windows)]
+    pub fn as_mut_ptr(&mut self) -> *mut Overlapped {
+        &mut self.header
+    }
+
+    pub fn set_cancelled(&mut self) -> bool {
+        self.cancelled = true;
+        self.has_result()
+    }
+
+    pub fn set_result(&mut self, res: io::Result<usize>) -> bool {
+        if let PushEntry::Pending(Some(w)) =
+            std::mem::replace(&mut self.result, PushEntry::Ready(res))
+        {
+            w.wake();
+        }
+        self.cancelled
+    }
+
+    pub fn has_result(&self) -> bool {
+        self.result.is_ready()
+    }
+
+    pub fn set_waker(&mut self, waker: Waker) {
+        if let PushEntry::Pending(w) = &mut self.result {
+            *w = Some(waker)
+        }
+    }
+
+    pub fn into_inner(self) -> BufResult<usize, T>
+    where
+        T: Sized,
+    {
+        BufResult(self.result.take_ready().unwrap(), self.op)
+    }
+}
+
+#[cfg(windows)]
+impl<T: OpCode + ?Sized> RawOp<T> {
+    pub fn operate_blocking(&mut self) -> io::Result<usize> {
+        use std::task::Poll;
+
+        let optr = self.as_mut_ptr();
+        let op = self.as_op_pin();
+        let res = unsafe { op.operate(optr.cast()) };
+        match res {
+            Poll::Pending => unreachable!("this operation is not overlapped"),
+            Poll::Ready(res) => res,
+        }
+    }
+}
+
+unsafe fn upcast<T: OpCode>(user_data: usize) -> *mut RawOp<dyn OpCode> {
+    user_data as *mut RawOp<T> as *mut RawOp<dyn OpCode>
+}
+
 /// A typed wrapper for key of Ops submitted into driver
 #[derive(PartialEq, Eq, Hash)]
 pub struct Key<T> {
     user_data: usize,
-    _p: std::marker::PhantomData<fn(T)>,
+    _p: PhantomData<Box<T>>,
 }
 
 impl<T> Unpin for Key<T> {}
 
-impl<T> Clone for Key<T> {
-    fn clone(&self) -> Self {
-        *self
+impl<T: OpCode + 'static> Key<T> {
+    /// Create [`RawOp`] and get the [`Key`] to it.
+    pub fn new(driver: RawFd, op: T) -> Self {
+        let header = Overlapped::new(driver);
+        let raw_op = Box::new(RawOp {
+            header,
+            cancelled: false,
+            upcast_fn: upcast::<T>,
+            result: PushEntry::Pending(None),
+            op,
+        });
+        unsafe { Self::new_unchecked(Box::into_raw(raw_op) as _) }
     }
 }
-
-impl<T> Copy for Key<T> {}
 
 impl<T> Key<T> {
     /// Create a new `Key` with the given user data.
@@ -22,19 +113,48 @@ impl<T> Key<T> {
     ///
     /// Caller needs to ensure that `T` does correspond to `user_data` in driver
     /// this `Key` is created with.
-    pub unsafe fn new(user_data: usize) -> Self {
+    pub unsafe fn new_unchecked(user_data: usize) -> Self {
         Self {
             user_data,
-            _p: std::marker::PhantomData,
+            _p: PhantomData,
         }
+    }
+
+    /// Get the unique user-defined data.
+    pub const fn user_data(&self) -> usize {
+        self.user_data
+    }
+
+    /// Get the inner result if it is completed.
+    pub fn into_inner(self) -> BufResult<usize, T> {
+        unsafe { Box::from_raw(self.user_data as *mut RawOp<T>) }.into_inner()
     }
 }
 
-impl<T> std::ops::Deref for Key<T> {
-    type Target = usize;
+impl Key<()> {
+    pub(crate) unsafe fn drop_in_place(user_data: usize) {
+        let op = &*(user_data as *const RawOp<()>);
+        let ptr = (op.upcast_fn)(user_data);
+        let _ = Box::from_raw(ptr);
+    }
+
+    pub(crate) unsafe fn upcast<'a>(user_data: usize) -> &'a mut RawOp<dyn OpCode> {
+        let op = &*(user_data as *const RawOp<()>);
+        &mut *(op.upcast_fn)(user_data)
+    }
+}
+
+impl<T> Deref for Key<T> {
+    type Target = RawOp<T>;
 
     fn deref(&self) -> &Self::Target {
-        &self.user_data
+        unsafe { &*(self.user_data as *const RawOp<T>) }
+    }
+}
+
+impl<T> DerefMut for Key<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        unsafe { &mut *(self.user_data as *mut RawOp<T>) }
     }
 }
 

--- a/compio-driver/src/key.rs
+++ b/compio-driver/src/key.rs
@@ -5,11 +5,11 @@ use compio_buf::BufResult;
 use crate::{OpCode, Overlapped, PushEntry, RawFd};
 
 /// An operation with other needed information. It should be allocated on the
-/// stack. The pointer to this struct is used as user_data, and on Windows, it
-/// is used as the pointer to OVERLAPPED.
+/// heap. The pointer to this struct is used as `user_data`, and on Windows, it
+/// is used as the pointer to `OVERLAPPED`.
 ///
-/// Convert any user_data to *const RawOp<()> is valid. Then it could be
-/// converted to *mut RawOp<dyn OpCode> with upcast_fn.
+/// Convert any `user_data` to `*const RawOp<()>` is valid. Then it could be
+/// converted to `*mut RawOp<dyn OpCode>` with `upcast_fn`.
 #[repr(C)]
 pub(crate) struct RawOp<T: ?Sized> {
     header: Overlapped,

--- a/compio-driver/src/lib.rs
+++ b/compio-driver/src/lib.rs
@@ -32,6 +32,8 @@ pub mod op;
 #[cfg(unix)]
 #[cfg_attr(docsrs, doc(cfg(all())))]
 mod unix;
+#[cfg(unix)]
+use unix::Overlapped;
 
 mod asyncify;
 pub use asyncify::*;
@@ -383,6 +385,7 @@ impl RawOp {
         unsafe { Pin::new_unchecked(&mut self.op.as_mut().op) }
     }
 
+    #[cfg(windows)]
     pub fn as_mut_ptr(&mut self) -> *mut Overlapped<dyn OpCode> {
         self.op.as_ptr()
     }
@@ -427,6 +430,7 @@ impl RawOp {
         )
     }
 
+    #[cfg(windows)]
     fn operate_blocking(&mut self) -> io::Result<usize> {
         let optr = self.as_mut_ptr();
         let op = self.as_op_pin();

--- a/compio-driver/src/poll/mod.rs
+++ b/compio-driver/src/poll/mod.rs
@@ -239,7 +239,7 @@ impl Driver {
         let completed = self.pool_completed.clone();
         self.pool
             .dispatch(move || {
-                let op = unsafe { Key::upcast(user_data) };
+                let mut op = unsafe { Key::<dyn OpCode>::new_unchecked(user_data) };
                 let op_pin = op.as_op_pin();
                 let res = match op_pin.on_event(&event) {
                     Poll::Pending => unreachable!("this operation is not non-blocking"),
@@ -277,7 +277,7 @@ impl Driver {
                 if self.cancelled.remove(&user_data) {
                     entries.extend(Some(entry_cancelled(user_data)));
                 } else {
-                    let op = Key::upcast(user_data);
+                    let mut op = Key::<dyn OpCode>::new_unchecked(user_data);
                     let op = op.as_op_pin();
                     let res = match op.on_event(&event) {
                         Poll::Pending => {

--- a/compio-driver/src/unix/mod.rs
+++ b/compio-driver/src/unix/mod.rs
@@ -9,73 +9,13 @@ use compio_buf::BufResult;
 
 use crate::{OpCode, PushEntry};
 
-pub(crate) struct RawOp {
-    op: NonNull<dyn OpCode>,
-    // The two flags here are manual reference counting. The driver holds the strong ref until it
-    // completes; the runtime holds the strong ref until the future is dropped.
-    cancelled: bool,
-    result: PushEntry<Option<Waker>, io::Result<usize>>,
+#[repr(transparent)]
+pub(crate) struct Overlapped<T: ?Sized> {
+    pub op: T,
 }
 
-impl RawOp {
-    pub(crate) fn new(_user_data: usize, op: impl OpCode + 'static) -> Self {
-        let op = Box::new(op);
-        Self {
-            op: unsafe { NonNull::new_unchecked(Box::into_raw(op as Box<dyn OpCode>)) },
-            cancelled: false,
-            result: PushEntry::Pending(None),
-        }
-    }
-
-    pub fn as_pin(&mut self) -> Pin<&mut dyn OpCode> {
-        unsafe { Pin::new_unchecked(self.op.as_mut()) }
-    }
-
-    pub fn set_cancelled(&mut self) -> bool {
-        self.cancelled = true;
-        self.has_result()
-    }
-
-    pub fn set_result(&mut self, res: io::Result<usize>) -> bool {
-        if let PushEntry::Pending(Some(w)) =
-            std::mem::replace(&mut self.result, PushEntry::Ready(res))
-        {
-            w.wake();
-        }
-        self.cancelled
-    }
-
-    pub fn has_result(&self) -> bool {
-        self.result.is_ready()
-    }
-
-    pub fn set_waker(&mut self, waker: Waker) {
-        if let PushEntry::Pending(w) = &mut self.result {
-            *w = Some(waker)
-        }
-    }
-
-    /// # Safety
-    /// The caller should ensure the correct type.
-    ///
-    /// # Panics
-    /// This function will panic if the result has not been set.
-    pub unsafe fn into_inner<T: OpCode>(self) -> BufResult<usize, T> {
-        let mut this = ManuallyDrop::new(self);
-        let op = *Box::from_raw(this.op.cast().as_ptr());
-        BufResult(
-            std::mem::replace(&mut this.result, PushEntry::Pending(None))
-                .take_ready()
-                .unwrap(),
-            op,
-        )
-    }
-}
-
-impl Drop for RawOp {
-    fn drop(&mut self) {
-        if self.has_result() {
-            let _ = unsafe { Box::from_raw(self.op.as_ptr()) };
-        }
+impl<T> Overlapped<T> {
+    pub(crate) fn new(_driver: RawFd, _user_data: usize, op: T) -> Self {
+        Self { op }
     }
 }

--- a/compio-driver/src/unix/mod.rs
+++ b/compio-driver/src/unix/mod.rs
@@ -3,12 +3,9 @@
 
 pub(crate) mod op;
 
-use std::{io, mem::ManuallyDrop, pin::Pin, ptr::NonNull, task::Waker};
+use crate::RawFd;
 
-use compio_buf::BufResult;
-
-use crate::{OpCode, PushEntry};
-
+/// The overlapped struct for unix needn't contain extra fields.
 #[repr(transparent)]
 pub(crate) struct Overlapped<T: ?Sized> {
     pub op: T,

--- a/compio-driver/src/unix/mod.rs
+++ b/compio-driver/src/unix/mod.rs
@@ -6,13 +6,10 @@ pub(crate) mod op;
 use crate::RawFd;
 
 /// The overlapped struct for unix needn't contain extra fields.
-#[repr(transparent)]
-pub(crate) struct Overlapped<T: ?Sized> {
-    pub op: T,
-}
+pub(crate) struct Overlapped;
 
-impl<T> Overlapped<T> {
-    pub(crate) fn new(_driver: RawFd, _user_data: usize, op: T) -> Self {
-        Self { op }
+impl Overlapped {
+    pub fn new(_driver: RawFd) -> Self {
+        Self
     }
 }

--- a/compio-driver/tests/file.rs
+++ b/compio-driver/tests/file.rs
@@ -53,7 +53,7 @@ fn push_and_wait<O: OpCode + 'static>(driver: &mut Proactor, op: O) -> BufResult
                 driver.poll(None, &mut entries).unwrap();
             }
             assert_eq!(entries[0], *user_data);
-            driver.pop(user_data)
+            driver.pop(user_data).unwrap()
         }
     }
 }

--- a/compio-runtime/src/runtime/mod.rs
+++ b/compio-runtime/src/runtime/mod.rs
@@ -7,7 +7,7 @@ use std::{
     panic::AssertUnwindSafe,
     rc::{Rc, Weak},
     sync::Arc,
-    task::{Context, Poll, Waker},
+    task::{Context, Poll},
     time::Duration,
 };
 
@@ -31,17 +31,6 @@ use crate::runtime::time::{TimerFuture, TimerRuntime};
 use crate::{runtime::op::OpFuture, BufResult};
 
 pub type JoinHandle<T> = Task<Result<T, Box<dyn Any + Send>>>;
-
-pub(crate) enum FutureState {
-    Active(Option<Waker>),
-    Completed,
-}
-
-impl Default for FutureState {
-    fn default() -> Self {
-        Self::Active(None)
-    }
-}
 
 pub(crate) struct RuntimeInner {
     driver: RefCell<Proactor>,

--- a/compio-runtime/src/runtime/op.rs
+++ b/compio-runtime/src/runtime/op.rs
@@ -1,63 +1,45 @@
 use std::{
-    collections::HashMap,
     future::Future,
     pin::Pin,
-    task::{Context, Poll, Waker},
+    task::{Context, Poll},
 };
 
 use compio_buf::BufResult;
 use compio_driver::{Key, OpCode};
 
-use crate::runtime::{FutureState, Runtime};
-
-#[derive(Default)]
-pub(crate) struct OpRuntime {
-    ops: HashMap<usize, FutureState>,
-}
-
-impl OpRuntime {
-    pub fn update_waker(&mut self, key: usize, waker: Waker) {
-        *self.ops.entry(key).or_default() = FutureState::Active(Some(waker));
-    }
-
-    pub fn wake(&mut self, key: usize) {
-        let state = self.ops.entry(key).or_default();
-        let old_state = std::mem::replace(state, FutureState::Completed);
-        if let FutureState::Active(Some(waker)) = old_state {
-            waker.wake();
-        }
-    }
-
-    // Returns whether the op is completed.
-    pub fn cancel(&mut self, key: usize) -> bool {
-        let state = self.ops.remove(&key);
-        state
-            .map(|state| matches!(state, FutureState::Completed))
-            .unwrap_or(true)
-    }
-}
+use crate::runtime::Runtime;
 
 #[derive(Debug)]
 pub struct OpFuture<T> {
     user_data: Key<T>,
+    completed: bool,
 }
 
 impl<T> OpFuture<T> {
     pub fn new(user_data: Key<T>) -> Self {
-        Self { user_data }
+        Self {
+            user_data,
+            completed: false,
+        }
     }
 }
 
 impl<T: OpCode> Future for OpFuture<T> {
     type Output = BufResult<usize, T>;
 
-    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        Runtime::current().inner().poll_task(cx, self.user_data)
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let res = Runtime::current().inner().poll_task(cx, self.user_data);
+        if res.is_ready() {
+            self.completed = true;
+        }
+        res
     }
 }
 
 impl<T> Drop for OpFuture<T> {
     fn drop(&mut self) {
-        Runtime::current().inner().cancel_op(self.user_data)
+        if !self.completed {
+            Runtime::current().inner().cancel_op(self.user_data)
+        }
     }
 }

--- a/compio-runtime/src/runtime/time.rs
+++ b/compio-runtime/src/runtime/time.rs
@@ -9,7 +9,18 @@ use std::{
 
 use slab::Slab;
 
-use crate::runtime::{FutureState, Runtime};
+use crate::runtime::Runtime;
+
+pub(crate) enum FutureState {
+    Active(Option<Waker>),
+    Completed,
+}
+
+impl Default for FutureState {
+    fn default() -> Self {
+        Self::Active(None)
+    }
+}
 
 #[derive(Debug)]
 struct TimerEntry {

--- a/compio-runtime/src/runtime/time.rs
+++ b/compio-runtime/src/runtime/time.rs
@@ -104,6 +104,9 @@ impl TimerRuntime {
     }
 
     pub fn wake(&mut self) {
+        if self.wheel.is_empty() {
+            return;
+        }
         let elapsed = self.time.elapsed();
         while let Some(entry) = self.wheel.pop() {
             if entry.0.delay <= elapsed {

--- a/compio/examples/driver.rs
+++ b/compio/examples/driver.rs
@@ -54,7 +54,7 @@ fn push_and_wait<O: OpCode + 'static>(driver: &mut Proactor, op: O) -> (usize, O
                 driver.poll(None, &mut entries).unwrap();
             }
             assert_eq!(entries[0], *user_data);
-            driver.pop(user_data).unwrap()
+            driver.pop(user_data).unwrap().unwrap()
         }
     }
 }

--- a/compio/examples/driver.rs
+++ b/compio/examples/driver.rs
@@ -53,8 +53,8 @@ fn push_and_wait<O: OpCode + 'static>(driver: &mut Proactor, op: O) -> (usize, O
             while entries.is_empty() {
                 driver.poll(None, &mut entries).unwrap();
             }
-            assert_eq!(entries[0], *user_data);
-            driver.pop(user_data).unwrap().unwrap()
+            assert_eq!(entries[0], user_data.user_data());
+            driver.pop(user_data).take_ready().unwrap().unwrap()
         }
     }
 }


### PR DESCRIPTION
In this way, no need the `OpRuntime`, and the HashMap could be removed.