### PR TITLE
perf(net): rewrite net bench and optimize

### DIFF
--- a/compio-buf/src/lib.rs
+++ b/compio-buf/src/lib.rs
@@ -44,35 +44,17 @@ pub trait IntoInner {
 #[cfg(not(feature = "allocator_api"))]
 #[macro_export]
 #[doc(hidden)]
-macro_rules! vec_alloc {
-    ($t:ty, $a:ident) => {
-        Vec<$t>
+macro_rules! t_alloc {
+    ($b:tt, $t:ty, $a:ident) => {
+        $b<$t>
     };
 }
 
 #[cfg(feature = "allocator_api")]
 #[macro_export]
 #[doc(hidden)]
-macro_rules! vec_alloc {
-    ($t:ty, $a:ident) => {
-        Vec<$t, $a>
-    };
-}
-
-#[cfg(feature = "allocator_api")]
-#[macro_export]
-#[doc(hidden)]
-macro_rules! box_alloc {
-    ($t:ty, $a:ident) => {
-        Box<$t, $a>
-    };
-}
-
-#[cfg(not(feature = "allocator_api"))]
-#[macro_export]
-#[doc(hidden)]
-macro_rules! box_alloc {
-    ($t:ty, $a:ident) => {
-        Box<$t>
+macro_rules! t_alloc {
+    ($b:tt, $t:ty, $a:ident) => {
+        $b<$t, $a>
     };
 }

--- a/compio-dispatcher/src/lib.rs
+++ b/compio-dispatcher/src/lib.rs
@@ -56,11 +56,10 @@ impl Dispatcher {
                             .build()
                             .expect("cannot create compio runtime")
                             .block_on(async move {
-                                let rt = Runtime::current();
                                 while let Ok(f) = receiver.recv_async().await {
                                     let fut = (f)();
                                     if builder.concurrent {
-                                        rt.spawn(fut).detach()
+                                        compio_runtime::spawn(fut).detach()
                                     } else {
                                         fut.await
                                     }

--- a/compio-driver/src/iour/mod.rs
+++ b/compio-driver/src/iour/mod.rs
@@ -135,8 +135,11 @@ impl Driver {
     }
 
     fn poll_entries(&mut self, entries: &mut impl Extend<Entry>) -> bool {
-        while let Some(entry) = self.pool_completed.pop() {
-            entries.extend(Some(entry));
+        // Cheaper than pop.
+        if !self.pool_completed.is_empty() {
+            while let Some(entry) = self.pool_completed.pop() {
+                entries.extend(Some(entry));
+            }
         }
 
         let mut cqueue = self.inner.completion();

--- a/compio-fs/src/metadata/unix.rs
+++ b/compio-fs/src/metadata/unix.rs
@@ -8,14 +8,13 @@ use std::{
 
 use compio_buf::{BufResult, IntoInner};
 use compio_driver::{op::PathStat, syscall};
-use compio_runtime::Runtime;
 
 use crate::path_string;
 
 async fn metadata_impl(path: impl AsRef<Path>, follow_symlink: bool) -> io::Result<Metadata> {
     let path = path_string(path)?;
     let op = PathStat::new(path, follow_symlink);
-    let BufResult(res, op) = Runtime::current().submit(op).await;
+    let BufResult(res, op) = compio_runtime::submit(op).await;
     res.map(|_| Metadata::from_stat(op.into_inner()))
 }
 

--- a/compio-fs/src/named_pipe.rs
+++ b/compio-fs/src/named_pipe.rs
@@ -9,7 +9,6 @@ use std::{ffi::OsStr, io, os::windows::io::FromRawHandle, ptr::null};
 use compio_buf::{BufResult, IoBuf, IoBufMut};
 use compio_driver::{impl_raw_fd, op::ConnectNamedPipe, syscall, AsRawFd, RawFd, ToSharedFd};
 use compio_io::{AsyncRead, AsyncReadAt, AsyncWrite, AsyncWriteAt};
-use compio_runtime::Runtime;
 use widestring::U16CString;
 use windows_sys::Win32::{
     Storage::FileSystem::{
@@ -142,7 +141,7 @@ impl NamedPipeServer {
     /// ```
     pub async fn connect(&self) -> io::Result<()> {
         let op = ConnectNamedPipe::new(self.handle.to_shared_fd());
-        Runtime::current().submit(op).await.0?;
+        compio_runtime::submit(op).await.0?;
         Ok(())
     }
 

--- a/compio-fs/src/open_options/unix.rs
+++ b/compio-fs/src/open_options/unix.rs
@@ -1,7 +1,6 @@
 use std::{io, os::fd::FromRawFd, path::Path};
 
 use compio_driver::{op::OpenFile, RawFd};
-use compio_runtime::Runtime;
 
 use crate::{path_string, File};
 
@@ -87,7 +86,7 @@ impl OpenOptions {
             | (self.custom_flags as libc::c_int & !libc::O_ACCMODE);
         let p = path_string(p)?;
         let op = OpenFile::new(p, flags, self.mode);
-        let fd = Runtime::current().submit(op).await.0? as RawFd;
+        let fd = compio_runtime::submit(op).await.0? as RawFd;
         File::from_std(unsafe { std::fs::File::from_raw_fd(fd) })
     }
 }

--- a/compio-fs/src/pipe.rs
+++ b/compio-fs/src/pipe.rs
@@ -14,7 +14,6 @@ use compio_driver::{
     syscall, AsRawFd, ToSharedFd,
 };
 use compio_io::{AsyncRead, AsyncWrite};
-use compio_runtime::Runtime;
 
 use crate::File;
 
@@ -370,13 +369,13 @@ impl AsyncWrite for &Sender {
     async fn write<T: IoBuf>(&mut self, buffer: T) -> BufResult<usize, T> {
         let fd = self.to_shared_fd();
         let op = Send::new(fd, buffer);
-        Runtime::current().submit(op).await.into_inner()
+        compio_runtime::submit(op).await.into_inner()
     }
 
     async fn write_vectored<T: IoVectoredBuf>(&mut self, buffer: T) -> BufResult<usize, T> {
         let fd = self.to_shared_fd();
         let op = SendVectored::new(fd, buffer);
-        Runtime::current().submit(op).await.into_inner()
+        compio_runtime::submit(op).await.into_inner()
     }
 
     #[inline]
@@ -493,21 +492,13 @@ impl AsyncRead for &Receiver {
     async fn read<B: IoBufMut>(&mut self, buffer: B) -> BufResult<usize, B> {
         let fd = self.to_shared_fd();
         let op = Recv::new(fd, buffer);
-        Runtime::current()
-            .submit(op)
-            .await
-            .into_inner()
-            .map_advanced()
+        compio_runtime::submit(op).await.into_inner().map_advanced()
     }
 
     async fn read_vectored<V: IoVectoredBufMut>(&mut self, buffer: V) -> BufResult<usize, V> {
         let fd = self.to_shared_fd();
         let op = RecvVectored::new(fd, buffer);
-        Runtime::current()
-            .submit(op)
-            .await
-            .into_inner()
-            .map_advanced()
+        compio_runtime::submit(op).await.into_inner().map_advanced()
     }
 }
 

--- a/compio-fs/src/utils/unix.rs
+++ b/compio-fs/src/utils/unix.rs
@@ -1,14 +1,13 @@
 use std::{io, path::Path};
 
 use compio_driver::op::{CreateDir, HardLink, Rename, Symlink, Unlink};
-use compio_runtime::Runtime;
 
 use crate::path_string;
 
 async fn unlink(path: impl AsRef<Path>, dir: bool) -> io::Result<()> {
     let path = path_string(path)?;
     let op = Unlink::new(path, dir);
-    Runtime::current().submit(op).await.0?;
+    compio_runtime::submit(op).await.0?;
     Ok(())
 }
 
@@ -24,7 +23,7 @@ pub async fn rename(from: impl AsRef<Path>, to: impl AsRef<Path>) -> io::Result<
     let from = path_string(from)?;
     let to = path_string(to)?;
     let op = Rename::new(from, to);
-    Runtime::current().submit(op).await.0?;
+    compio_runtime::submit(op).await.0?;
     Ok(())
 }
 
@@ -32,7 +31,7 @@ pub async fn symlink(original: impl AsRef<Path>, link: impl AsRef<Path>) -> io::
     let original = path_string(original)?;
     let link = path_string(link)?;
     let op = Symlink::new(original, link);
-    Runtime::current().submit(op).await.0?;
+    compio_runtime::submit(op).await.0?;
     Ok(())
 }
 
@@ -40,7 +39,7 @@ pub async fn hard_link(original: impl AsRef<Path>, link: impl AsRef<Path>) -> io
     let original = path_string(original)?;
     let link = path_string(link)?;
     let op = HardLink::new(original, link);
-    Runtime::current().submit(op).await.0?;
+    compio_runtime::submit(op).await.0?;
     Ok(())
 }
 
@@ -60,7 +59,7 @@ impl DirBuilder {
     pub async fn create(&self, path: &Path) -> io::Result<()> {
         let path = path_string(path)?;
         let op = CreateDir::new(path, self.mode as _);
-        Runtime::current().submit(op).await.0?;
+        compio_runtime::submit(op).await.0?;
         Ok(())
     }
 }

--- a/compio-io/src/read/ext.rs
+++ b/compio-io/src/read/ext.rs
@@ -1,7 +1,7 @@
 #[cfg(feature = "allocator_api")]
 use std::alloc::Allocator;
 
-use compio_buf::{vec_alloc, BufResult, IntoInner, IoBuf, IoBufMut, IoVectoredBufMut};
+use compio_buf::{t_alloc, BufResult, IntoInner, IoBuf, IoBufMut, IoVectoredBufMut};
 
 use crate::{util::Take, AsyncRead, AsyncReadAt, IoResult};
 
@@ -183,8 +183,8 @@ pub trait AsyncReadExt: AsyncRead {
     /// Read all bytes until underlying reader reaches `EOF`.
     async fn read_to_end<#[cfg(feature = "allocator_api")] A: Allocator + 'static>(
         &mut self,
-        mut buf: vec_alloc!(u8, A),
-    ) -> BufResult<usize, vec_alloc!(u8, A)> {
+        mut buf: t_alloc!(Vec, u8, A),
+    ) -> BufResult<usize, t_alloc!(Vec, u8, A)> {
         loop_read_to_end!(buf, total: usize, loop self.read(buf.slice(total..)))
     }
 
@@ -268,9 +268,9 @@ pub trait AsyncReadAtExt: AsyncReadAt {
     /// [`read_at()`]: AsyncReadAt::read_at
     async fn read_to_end_at<#[cfg(feature = "allocator_api")] A: Allocator + 'static>(
         &self,
-        mut buffer: vec_alloc!(u8, A),
+        mut buffer: t_alloc!(Vec, u8, A),
         pos: u64,
-    ) -> BufResult<usize, vec_alloc!(u8, A)> {
+    ) -> BufResult<usize, t_alloc!(Vec, u8, A)> {
         loop_read_to_end!(buffer, total: u64, loop self.read_at(buffer.slice(total as usize..), pos + total))
     }
 

--- a/compio-io/src/read/mod.rs
+++ b/compio-io/src/read/mod.rs
@@ -2,9 +2,7 @@
 use std::alloc::Allocator;
 use std::{io::Cursor, rc::Rc, sync::Arc};
 
-use compio_buf::{
-    box_alloc, buf_try, vec_alloc, BufResult, IntoInner, IoBuf, IoBufMut, IoVectoredBufMut,
-};
+use compio_buf::{buf_try, t_alloc, BufResult, IntoInner, IoBuf, IoBufMut, IoVectoredBufMut};
 
 mod buf;
 #[macro_use]
@@ -74,7 +72,7 @@ impl<A: AsyncRead + ?Sized> AsyncRead for &mut A {
 }
 
 impl<R: AsyncRead + ?Sized, #[cfg(feature = "allocator_api")] A: Allocator> AsyncRead
-    for box_alloc!(R, A)
+    for t_alloc!(Box, R, A)
 {
     #[inline(always)]
     async fn read<T: IoBufMut>(&mut self, buf: T) -> BufResult<usize, T> {
@@ -181,7 +179,7 @@ impl_read_at!(@ptr &A, &mut A);
 impl_read_at!(@ptra Box, Rc, Arc);
 impl_read_at!(@slice [u8], const LEN => [u8; LEN]);
 
-impl<#[cfg(feature = "allocator_api")] A: Allocator> AsyncReadAt for vec_alloc!(u8, A) {
+impl<#[cfg(feature = "allocator_api")] A: Allocator> AsyncReadAt for t_alloc!(Vec, u8, A) {
     async fn read_at<T: IoBufMut>(&self, buf: T, pos: u64) -> BufResult<usize, T> {
         self.as_slice().read_at(buf, pos).await
     }

--- a/compio-io/src/write/mod.rs
+++ b/compio-io/src/write/mod.rs
@@ -2,7 +2,7 @@
 use std::alloc::Allocator;
 use std::io::Cursor;
 
-use compio_buf::{box_alloc, buf_try, vec_alloc, BufResult, IntoInner, IoBuf, IoVectoredBuf};
+use compio_buf::{buf_try, t_alloc, BufResult, IntoInner, IoBuf, IoVectoredBuf};
 
 use crate::IoResult;
 
@@ -69,7 +69,7 @@ impl<A: AsyncWrite + ?Sized> AsyncWrite for &mut A {
 }
 
 impl<W: AsyncWrite + ?Sized, #[cfg(feature = "allocator_api")] A: Allocator> AsyncWrite
-    for box_alloc!(W, A)
+    for t_alloc!(Box, W, A)
 {
     async fn write<T: IoBuf>(&mut self, buf: T) -> BufResult<usize, T> {
         (**self).write(buf).await
@@ -154,7 +154,7 @@ impl<A: AsyncWriteAt + ?Sized> AsyncWriteAt for &mut A {
 }
 
 impl<W: AsyncWriteAt + ?Sized, #[cfg(feature = "allocator_api")] A: Allocator> AsyncWriteAt
-    for box_alloc!(W, A)
+    for t_alloc!(Box, W, A)
 {
     async fn write_at<T: IoBuf>(&mut self, buf: T, pos: u64) -> BufResult<usize, T> {
         (**self).write_at(buf, pos).await
@@ -190,7 +190,7 @@ impl_write_at!([u8], const LEN => [u8; LEN]);
 /// This implementation aligns the behavior of files. If `pos` is larger than
 /// the vector length, the vectored will be extended, and the extended area will
 /// be filled with 0.
-impl<#[cfg(feature = "allocator_api")] A: Allocator> AsyncWriteAt for vec_alloc!(u8, A) {
+impl<#[cfg(feature = "allocator_api")] A: Allocator> AsyncWriteAt for t_alloc!(Vec, u8, A) {
     async fn write_at<T: IoBuf>(&mut self, buf: T, pos: u64) -> BufResult<usize, T> {
         let pos = pos as usize;
         let slice = buf.as_slice();

--- a/compio-runtime/Cargo.toml
+++ b/compio-runtime/Cargo.toml
@@ -39,6 +39,7 @@ criterion = { workspace = true, optional = true }
 crossbeam-queue = { workspace = true }
 futures-util = { workspace = true }
 once_cell = { workspace = true }
+scoped-tls = "1.0.1"
 send_wrapper = "0.6.0"
 slab = { workspace = true, optional = true }
 smallvec = "1.11.1"

--- a/compio-runtime/src/attacher.rs
+++ b/compio-runtime/src/attacher.rs
@@ -40,9 +40,7 @@ impl<S: AsRawFd> Attacher<S> {
     /// * IOCP: a handle could not be attached more than once. If you want to
     ///   clone the handle, create the [`Attacher`] before cloning.
     pub fn new(source: S) -> io::Result<Self> {
-        let r = Runtime::current();
-        let inner = r.inner();
-        inner.attach(source.as_raw_fd())?;
+        Runtime::with_current(|r| r.attach(source.as_raw_fd()))?;
         Ok(unsafe { Self::new_unchecked(source) })
     }
 }

--- a/compio-runtime/src/lib.rs
+++ b/compio-runtime/src/lib.rs
@@ -22,4 +22,4 @@ pub mod time;
 pub use async_task::Task;
 pub use attacher::*;
 use compio_buf::BufResult;
-pub use runtime::{spawn, spawn_blocking, EnterGuard, Runtime, RuntimeBuilder};
+pub use runtime::{spawn, spawn_blocking, submit, Runtime, RuntimeBuilder};

--- a/compio-runtime/src/runtime/mod.rs
+++ b/compio-runtime/src/runtime/mod.rs
@@ -80,9 +80,16 @@ impl Runtime {
     ///
     /// This method will panic if there are no running [`Runtime`].
     pub fn with_current<T, F: FnOnce(&Self) -> T>(f: F) -> T {
-        Self::try_with_current(f)
-            .ok()
-            .expect("not in a compio runtime")
+        #[cold]
+        fn not_in_compio_runtime() -> ! {
+            panic!("not in a compio runtime")
+        }
+
+        if CURRENT_RUNTIME.is_set() {
+            CURRENT_RUNTIME.with(f)
+        } else {
+            not_in_compio_runtime()
+        }
     }
 
     /// Set this runtime as current runtime, and perform a function in the

--- a/compio-runtime/src/runtime/mod.rs
+++ b/compio-runtime/src/runtime/mod.rs
@@ -4,7 +4,9 @@ use std::{
     collections::VecDeque,
     future::{poll_fn, ready, Future},
     io,
+    marker::PhantomData,
     panic::AssertUnwindSafe,
+    rc::Rc,
     sync::Arc,
     task::{Context, Poll},
     time::Duration,
@@ -41,6 +43,9 @@ pub struct Runtime {
     sync_runnables: Arc<SegQueue<Runnable>>,
     #[cfg(feature = "time")]
     timer_runtime: RefCell<TimerRuntime>,
+    // Other fields don't make it !Send, but actually `local_runnables` implies it should be !Send,
+    // otherwise it won't be valid if the runtime is sent to other threads.
+    _p: PhantomData<Rc<VecDeque<Runnable>>>,
 }
 
 impl Runtime {
@@ -61,6 +66,7 @@ impl Runtime {
             sync_runnables: Arc::new(SegQueue::new()),
             #[cfg(feature = "time")]
             timer_runtime: RefCell::new(TimerRuntime::new()),
+            _p: PhantomData,
         })
     }
 

--- a/compio-runtime/src/runtime/mod.rs
+++ b/compio-runtime/src/runtime/mod.rs
@@ -83,12 +83,13 @@ impl RuntimeInner {
             if let Some(task) = next_task {
                 task.run();
             }
-            let next_task = self.sync_runnables.pop();
-            let has_sync_task = next_task.is_some();
-            if let Some(task) = next_task {
-                task.run();
-            }
-            if !has_local_task && !has_sync_task {
+            // Cheaper than pop.
+            let has_sync_task = !self.sync_runnables.is_empty();
+            if has_sync_task {
+                if let Some(task) = self.sync_runnables.pop() {
+                    task.run();
+                }
+            } else if !has_local_task {
                 break;
             }
         }

--- a/compio-runtime/src/runtime/mod.rs
+++ b/compio-runtime/src/runtime/mod.rs
@@ -5,7 +5,6 @@ use std::{
     future::{poll_fn, ready, Future},
     io,
     panic::AssertUnwindSafe,
-    rc::{Rc, Weak},
     sync::Arc,
     task::{Context, Poll},
     time::Duration,
@@ -30,9 +29,13 @@ pub(crate) mod time;
 use crate::runtime::time::{TimerFuture, TimerRuntime};
 use crate::{runtime::op::OpFuture, BufResult};
 
+scoped_tls::scoped_thread_local!(static CURRENT_RUNTIME: Runtime);
+
 pub type JoinHandle<T> = Task<Result<T, Box<dyn Any + Send>>>;
 
-pub(crate) struct RuntimeInner {
+/// The async runtime of compio. It is a thread local runtime, and cannot be
+/// sent to other threads.
+pub struct Runtime {
     driver: RefCell<Proactor>,
     local_runnables: Arc<SendWrapper<RefCell<VecDeque<Runnable>>>>,
     sync_runnables: Arc<SegQueue<Runnable>>,
@@ -40,8 +43,18 @@ pub(crate) struct RuntimeInner {
     timer_runtime: RefCell<TimerRuntime>,
 }
 
-impl RuntimeInner {
-    pub fn new(builder: &ProactorBuilder) -> io::Result<Self> {
+impl Runtime {
+    /// Create [`Runtime`] with default config.
+    pub fn new() -> io::Result<Self> {
+        Self::builder().build()
+    }
+
+    /// Create a builder for [`Runtime`].
+    pub fn builder() -> RuntimeBuilder {
+        RuntimeBuilder::new()
+    }
+
+    fn with_builder(builder: &ProactorBuilder) -> io::Result<Self> {
         Ok(Self {
             driver: RefCell::new(builder.build()?),
             local_runnables: Arc::new(SendWrapper::new(RefCell::new(VecDeque::new()))),
@@ -51,7 +64,38 @@ impl RuntimeInner {
         })
     }
 
-    // Safety: be careful about the captured lifetime.
+    /// Try to perform a function on the current runtime, and if no runtime is
+    /// running, return the function back.
+    pub fn try_with_current<T, F: FnOnce(&Self) -> T>(f: F) -> Result<T, F> {
+        if CURRENT_RUNTIME.is_set() {
+            Ok(CURRENT_RUNTIME.with(f))
+        } else {
+            Err(f)
+        }
+    }
+
+    /// Perform a function on the current runtime.
+    ///
+    /// ## Panics
+    ///
+    /// This method will panic if there are no running [`Runtime`].
+    pub fn with_current<T, F: FnOnce(&Self) -> T>(f: F) -> T {
+        Self::try_with_current(f)
+            .ok()
+            .expect("not in a compio runtime")
+    }
+
+    /// Set this runtime as current runtime, and perform a function in the
+    /// current scope.
+    pub fn enter<T, F: FnOnce() -> T>(&self, f: F) -> T {
+        CURRENT_RUNTIME.set(self, f)
+    }
+
+    /// Spawns a new asynchronous task, returning a [`Task`] for it.
+    ///
+    /// # Safety
+    ///
+    /// The caller should ensure the captured lifetime long enough.
     pub unsafe fn spawn_unchecked<F: Future>(&self, future: F) -> Task<F::Output> {
         let local_runnables = self.local_runnables.clone();
         let sync_runnables = self.sync_runnables.clone();
@@ -73,6 +117,9 @@ impl RuntimeInner {
         task
     }
 
+    /// Low level API to control the runtime.
+    ///
+    /// Run the scheduled tasks.
     pub fn run(&self) {
         use std::ops::Deref;
 
@@ -95,22 +142,32 @@ impl RuntimeInner {
         }
     }
 
+    /// Block on the future till it completes.
     pub fn block_on<F: Future>(&self, future: F) -> F::Output {
-        let mut result = None;
-        unsafe { self.spawn_unchecked(async { result = Some(future.await) }) }.detach();
-        loop {
-            self.run();
-            if let Some(result) = result.take() {
-                return result;
+        CURRENT_RUNTIME.set(self, || {
+            let mut result = None;
+            unsafe { self.spawn_unchecked(async { result = Some(future.await) }) }.detach();
+            loop {
+                self.run();
+                if let Some(result) = result.take() {
+                    return result;
+                }
+                self.poll();
             }
-            self.poll();
-        }
+        })
     }
 
+    /// Spawns a new asynchronous task, returning a [`Task`] for it.
+    ///
+    /// Spawning a task enables the task to execute concurrently to other tasks.
+    /// There is no guarantee that a spawned task will execute to completion.
     pub fn spawn<F: Future + 'static>(&self, future: F) -> JoinHandle<F::Output> {
         unsafe { self.spawn_unchecked(AssertUnwindSafe(future).catch_unwind()) }
     }
 
+    /// Spawns a blocking task in a new thread, and wait for it.
+    ///
+    /// The task will not be cancelled even if the future is dropped.
     pub fn spawn_blocking<T: Send + 'static>(
         &self,
         f: impl (FnOnce() -> T) + Send + Sync + 'static,
@@ -146,14 +203,21 @@ impl RuntimeInner {
         unsafe { self.spawn_unchecked(closure) }
     }
 
+    /// Attach a raw file descriptor/handle/socket to the runtime.
+    ///
+    /// You only need this when authoring your own high-level APIs. High-level
+    /// resources in this crate are attached automatically.
     pub fn attach(&self, fd: RawFd) -> io::Result<()> {
         self.driver.borrow_mut().attach(fd)
     }
 
-    pub fn submit_raw<T: OpCode + 'static>(&self, op: T) -> PushEntry<Key<T>, BufResult<usize, T>> {
+    fn submit_raw<T: OpCode + 'static>(&self, op: T) -> PushEntry<Key<T>, BufResult<usize, T>> {
         self.driver.borrow_mut().push(op)
     }
 
+    /// Submit an operation to the runtime.
+    ///
+    /// You only need this when authoring your own [`OpCode`].
     pub fn submit<T: OpCode + 'static>(&self, op: T) -> impl Future<Output = BufResult<usize, T>> {
         match self.submit_raw(op) {
             PushEntry::Pending(user_data) => Either::Left(OpFuture::new(user_data)),
@@ -162,7 +226,7 @@ impl RuntimeInner {
     }
 
     #[cfg(feature = "time")]
-    pub fn create_timer(&self, delay: std::time::Duration) -> impl Future<Output = ()> {
+    pub(crate) fn create_timer(&self, delay: std::time::Duration) -> impl Future<Output = ()> {
         let mut timer_runtime = self.timer_runtime.borrow_mut();
         if let Some(key) = timer_runtime.insert(delay) {
             Either::Left(TimerFuture::new(key))
@@ -171,16 +235,16 @@ impl RuntimeInner {
         }
     }
 
-    pub fn cancel_op<T: OpCode>(&self, op: Key<T>) {
+    pub(crate) fn cancel_op<T: OpCode>(&self, op: Key<T>) {
         self.driver.borrow_mut().cancel(op);
     }
 
     #[cfg(feature = "time")]
-    pub fn cancel_timer(&self, key: usize) {
+    pub(crate) fn cancel_timer(&self, key: usize) {
         self.timer_runtime.borrow_mut().cancel(key);
     }
 
-    pub fn poll_task<T: OpCode>(
+    pub(crate) fn poll_task<T: OpCode>(
         &self,
         cx: &mut Context,
         op: Key<T>,
@@ -194,7 +258,7 @@ impl RuntimeInner {
     }
 
     #[cfg(feature = "time")]
-    pub fn poll_timer(&self, cx: &mut Context, key: usize) -> Poll<()> {
+    pub(crate) fn poll_timer(&self, cx: &mut Context, key: usize) -> Poll<()> {
         instrument!(compio_log::Level::DEBUG, "poll_timer", ?cx, ?key);
         let mut timer_runtime = self.timer_runtime.borrow_mut();
         if !timer_runtime.is_completed(key) {
@@ -207,6 +271,9 @@ impl RuntimeInner {
         }
     }
 
+    /// Low level API to control the runtime.
+    ///
+    /// Get the timeout value to be passed to [`Proactor::poll`].
     pub fn current_timeout(&self) -> Option<Duration> {
         #[cfg(not(feature = "time"))]
         let timeout = None;
@@ -215,6 +282,10 @@ impl RuntimeInner {
         timeout
     }
 
+    /// Low level API to control the runtime.
+    ///
+    /// Poll the inner proactor. It is equal to calling [`Runtime::poll_with`]
+    /// with [`Runtime::current_timeout`].
     pub fn poll(&self) {
         instrument!(compio_log::Level::DEBUG, "poll");
         let timeout = self.current_timeout();
@@ -222,6 +293,9 @@ impl RuntimeInner {
         self.poll_with(timeout)
     }
 
+    /// Low level API to control the runtime.
+    ///
+    /// Poll the inner proactor with a custom timeout.
     pub fn poll_with(&self, timeout: Option<Duration>) {
         instrument!(compio_log::Level::DEBUG, "poll_with");
 
@@ -243,194 +317,9 @@ impl RuntimeInner {
     }
 }
 
-impl AsRawFd for RuntimeInner {
-    fn as_raw_fd(&self) -> RawFd {
-        self.driver.borrow().as_raw_fd()
-    }
-}
-
-struct RuntimeContext {
-    depth: usize,
-    ptr: Weak<RuntimeInner>,
-}
-
-impl RuntimeContext {
-    pub fn new() -> Self {
-        Self {
-            depth: 0,
-            ptr: Weak::new(),
-        }
-    }
-
-    pub fn inc_depth(&mut self) -> usize {
-        let depth = self.depth;
-        self.depth += 1;
-        depth
-    }
-
-    pub fn dec_depth(&mut self) -> usize {
-        self.depth -= 1;
-        self.depth
-    }
-
-    pub fn set_runtime(&mut self, ptr: Weak<RuntimeInner>) -> Weak<RuntimeInner> {
-        std::mem::replace(&mut self.ptr, ptr)
-    }
-
-    pub fn upgrade_runtime(&self) -> Option<Runtime> {
-        self.ptr.upgrade().map(|inner| Runtime { inner })
-    }
-}
-
-thread_local! {
-    static CURRENT_RUNTIME: RefCell<RuntimeContext> = RefCell::new(RuntimeContext::new());
-}
-
-/// The async runtime of compio. It is a thread local runtime, and cannot be
-/// sent to other threads.
-#[derive(Clone)]
-pub struct Runtime {
-    inner: Rc<RuntimeInner>,
-}
-
-impl Runtime {
-    /// Create [`Runtime`] with default config.
-    pub fn new() -> io::Result<Self> {
-        Self::builder().build()
-    }
-
-    /// Create a builder for [`Runtime`].
-    pub fn builder() -> RuntimeBuilder {
-        RuntimeBuilder::new()
-    }
-
-    /// Get the current running [`Runtime`].
-    pub fn try_current() -> Option<Self> {
-        CURRENT_RUNTIME.with_borrow(|r| r.upgrade_runtime())
-    }
-
-    /// Get the current running [`Runtime`].
-    ///
-    /// ## Panics
-    ///
-    /// This method will panic if there are no running [`Runtime`].
-    pub fn current() -> Self {
-        Self::try_current().expect("not in a compio runtime")
-    }
-
-    pub(crate) fn inner(&self) -> &RuntimeInner {
-        &self.inner
-    }
-
-    /// Enter the runtime context. This runtime will be set as the `current`
-    /// one.
-    ///
-    /// ## Panics
-    ///
-    /// When calling `Runtime::enter` multiple times, the returned guards
-    /// **must** be dropped in the reverse order that they were acquired.
-    /// Failure to do so will result in a panic and possible memory leaks.
-    ///
-    /// Do **not** do the following, this shows a scenario that will result in a
-    /// panic and possible memory leak.
-    ///
-    /// ```should_panic
-    /// use compio_runtime::Runtime;
-    ///
-    /// let rt1 = Runtime::new().unwrap();
-    /// let rt2 = Runtime::new().unwrap();
-    ///
-    /// let enter1 = rt1.enter();
-    /// let enter2 = rt2.enter();
-    ///
-    /// drop(enter1);
-    /// drop(enter2);
-    /// ```
-    pub fn enter(&self) -> EnterGuard {
-        EnterGuard::new(self)
-    }
-
-    /// Block on the future till it completes.
-    pub fn block_on<F: Future>(&self, future: F) -> F::Output {
-        let guard = self.enter();
-        guard.block_on(future)
-    }
-
-    /// Spawns a new asynchronous task, returning a [`Task`] for it.
-    ///
-    /// Spawning a task enables the task to execute concurrently to other tasks.
-    /// There is no guarantee that a spawned task will execute to completion.
-    pub fn spawn<F: Future + 'static>(&self, future: F) -> JoinHandle<F::Output> {
-        self.inner.spawn(future)
-    }
-
-    /// Spawns a blocking task in a new thread, and wait for it.
-    ///
-    /// The task will not be cancelled even if the future is dropped.
-    pub fn spawn_blocking<T: Send + 'static>(
-        &self,
-        f: impl (FnOnce() -> T) + Send + Sync + 'static,
-    ) -> JoinHandle<T> {
-        self.inner.spawn_blocking(f)
-    }
-
-    /// Spawns a new asynchronous task, returning a [`Task`] for it.
-    ///
-    /// # Safety
-    ///
-    /// The caller should ensure the captured lifetime long enough.
-    pub unsafe fn spawn_unchecked<F: Future>(&self, future: F) -> Task<F::Output> {
-        self.inner.spawn_unchecked(future)
-    }
-
-    /// Low level API to control the runtime.
-    ///
-    /// Run the scheduled tasks.
-    pub fn run(&self) {
-        self.inner.run()
-    }
-
-    /// Low level API to control the runtime.
-    ///
-    /// Get the timeout value to be passed to [`Proactor::poll`].
-    pub fn current_timeout(&self) -> Option<Duration> {
-        self.inner.current_timeout()
-    }
-
-    /// Low level API to control the runtime.
-    ///
-    /// Poll the inner proactor. It is equal to calling [`Runtime::poll_with`]
-    /// with [`Runtime::current_timeout`].
-    pub fn poll(&self) {
-        self.inner.poll()
-    }
-
-    /// Low level API to control the runtime.
-    ///
-    /// Poll the inner proactor with a custom timeout.
-    pub fn poll_with(&self, timeout: Option<Duration>) {
-        self.inner.poll_with(timeout)
-    }
-
-    /// Attach a raw file descriptor/handle/socket to the runtime.
-    ///
-    /// You only need this when authoring your own high-level APIs. High-level
-    /// resources in this crate are attached automatically.
-    pub fn attach(&self, fd: RawFd) -> io::Result<()> {
-        self.inner.attach(fd)
-    }
-
-    /// Submit an operation to the runtime.
-    ///
-    /// You only need this when authoring your own [`OpCode`].
-    pub fn submit<T: OpCode + 'static>(&self, op: T) -> impl Future<Output = BufResult<usize, T>> {
-        self.inner.submit(op)
-    }
-}
-
 impl AsRawFd for Runtime {
     fn as_raw_fd(&self) -> RawFd {
-        self.inner.as_raw_fd()
+        self.driver.borrow().as_raw_fd()
     }
 }
 
@@ -476,62 +365,7 @@ impl RuntimeBuilder {
 
     /// Build [`Runtime`].
     pub fn build(&self) -> io::Result<Runtime> {
-        Ok(Runtime {
-            inner: Rc::new(RuntimeInner::new(&self.proactor_builder)?),
-        })
-    }
-}
-
-/// Runtime context guard.
-///
-/// When the guard is dropped, exit the corresponding runtime context.
-#[must_use]
-pub struct EnterGuard<'a> {
-    runtime: &'a Runtime,
-    old_ptr: Weak<RuntimeInner>,
-    depth: usize,
-}
-
-impl<'a> EnterGuard<'a> {
-    fn new(runtime: &'a Runtime) -> Self {
-        let (old_ptr, depth) = CURRENT_RUNTIME.with_borrow_mut(|ctx| {
-            (
-                ctx.set_runtime(Rc::downgrade(&runtime.inner)),
-                ctx.inc_depth(),
-            )
-        });
-        Self {
-            runtime,
-            old_ptr,
-            depth,
-        }
-    }
-
-    /// Block on the future in the runtime backed of this guard.
-    pub fn block_on<F: Future>(&self, future: F) -> F::Output {
-        self.runtime.inner.block_on(future)
-    }
-}
-
-#[cold]
-fn panic_incorrect_drop_order() {
-    if !std::thread::panicking() {
-        panic!(
-            "`EnterGuard` values dropped out of order. Guards returned by `Runtime::enter()` must \
-             be dropped in the reverse order as they were acquired."
-        )
-    }
-}
-
-impl Drop for EnterGuard<'_> {
-    fn drop(&mut self) {
-        let depth = CURRENT_RUNTIME.with_borrow_mut(|ctx| {
-            ctx.set_runtime(std::mem::take(&mut self.old_ptr));
-            ctx.dec_depth()
-        });
-        if depth != self.depth {
-            panic_incorrect_drop_order()
-        }
+        Runtime::with_builder(&self.proactor_builder)
     }
 }
 
@@ -557,9 +391,9 @@ impl Drop for EnterGuard<'_> {
 /// ## Panics
 ///
 /// This method doesn't create runtime. It tries to obtain the current runtime
-/// by [`Runtime::current`].
+/// by [`Runtime::with_current`].
 pub fn spawn<F: Future + 'static>(future: F) -> JoinHandle<F::Output> {
-    Runtime::current().spawn(future)
+    Runtime::with_current(|r| r.spawn(future))
 }
 
 /// Spawns a blocking task in a new thread, and wait for it.
@@ -569,9 +403,19 @@ pub fn spawn<F: Future + 'static>(future: F) -> JoinHandle<F::Output> {
 /// ## Panics
 ///
 /// This method doesn't create runtime. It tries to obtain the current runtime
-/// by [`Runtime::current`].
+/// by [`Runtime::with_current`].
 pub fn spawn_blocking<T: Send + 'static>(
     f: impl (FnOnce() -> T) + Send + Sync + 'static,
 ) -> JoinHandle<T> {
-    Runtime::current().spawn_blocking(f)
+    Runtime::with_current(|r| r.spawn_blocking(f))
+}
+
+/// Submit an operation to the current runtime, and return a future for it.
+///
+/// ## Panics
+///
+/// This method doesn't create runtime. It tries to obtain the current runtime
+/// by [`Runtime::with_current`].
+pub fn submit<T: OpCode + 'static>(op: T) -> impl Future<Output = BufResult<usize, T>> {
+    Runtime::with_current(|r| r.submit(op))
 }

--- a/compio-runtime/src/runtime/time.rs
+++ b/compio-runtime/src/runtime/time.rs
@@ -138,13 +138,13 @@ impl Future for TimerFuture {
     type Output = ();
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        Runtime::current().inner().poll_timer(cx, self.key)
+        Runtime::with_current(|r| r.poll_timer(cx, self.key))
     }
 }
 
 impl Drop for TimerFuture {
     fn drop(&mut self) {
-        Runtime::current().inner().cancel_timer(self.key);
+        Runtime::with_current(|r| r.cancel_timer(self.key));
     }
 }
 

--- a/compio-runtime/src/time.rs
+++ b/compio-runtime/src/time.rs
@@ -33,7 +33,7 @@ use crate::Runtime;
 /// # })
 /// ```
 pub async fn sleep(duration: Duration) {
-    Runtime::current().inner().create_timer(duration).await
+    Runtime::with_current(|r| r.create_timer(duration)).await
 }
 
 /// Waits until `deadline` is reached.

--- a/compio-runtime/tests/event.rs
+++ b/compio-runtime/tests/event.rs
@@ -54,7 +54,7 @@ fn win32_event() {
 
         let event_raw = event.as_raw_handle() as _;
 
-        let wait = compio_runtime::Runtime::current().submit(WaitEvent { event });
+        let wait = compio_runtime::submit(WaitEvent { event });
 
         let task = compio_runtime::spawn_blocking(move || {
             unsafe { SetEvent(event_raw) };

--- a/compio/benches/monoio_wrap/mod.rs
+++ b/compio/benches/monoio_wrap/mod.rs
@@ -1,0 +1,33 @@
+use std::{cell::RefCell, future::Future};
+
+use criterion::async_executor::AsyncExecutor;
+
+pub struct MonoioRuntime(RefCell<monoio::Runtime<monoio::IoUringDriver>>);
+
+impl Default for MonoioRuntime {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl MonoioRuntime {
+    pub fn new() -> Self {
+        Self(RefCell::new(
+            monoio::RuntimeBuilder::<monoio::IoUringDriver>::new()
+                .build()
+                .unwrap(),
+        ))
+    }
+}
+
+impl AsyncExecutor for MonoioRuntime {
+    fn block_on<T>(&self, future: impl Future<Output = T>) -> T {
+        self.0.borrow_mut().block_on(future)
+    }
+}
+
+impl AsyncExecutor for &MonoioRuntime {
+    fn block_on<T>(&self, future: impl Future<Output = T>) -> T {
+        self.0.borrow_mut().block_on(future)
+    }
+}

--- a/compio/benches/net.rs
+++ b/compio/benches/net.rs
@@ -30,8 +30,7 @@ fn echo_tokio(b: &mut Bencher, content: &[u8; BUFFER_SIZE]) {
         let start = Instant::now();
         for _i in 0..iter {
             let (mut tx, (mut rx, _)) =
-                futures_util::try_join!(tokio::net::TcpStream::connect(addr), listener.accept())
-                    .unwrap();
+                tokio::try_join!(tokio::net::TcpStream::connect(addr), listener.accept()).unwrap();
 
             let client = async move {
                 let mut buffer = [0u8; BUFFER_SIZE];
@@ -47,7 +46,7 @@ fn echo_tokio(b: &mut Bencher, content: &[u8; BUFFER_SIZE]) {
                     rx.write_all(&buffer).await.unwrap();
                 }
             };
-            futures_util::join!(client, server);
+            tokio::join!(client, server);
         }
         start.elapsed()
     })

--- a/compio/benches/net.rs
+++ b/compio/benches/net.rs
@@ -1,129 +1,107 @@
-use criterion::{criterion_group, criterion_main, Criterion};
+use std::{net::Ipv4Addr, rc::Rc, time::Instant};
 
-criterion_group!(net, tcp, udp);
+use criterion::{criterion_group, criterion_main, Bencher, Criterion, Throughput};
+use rand::{thread_rng, RngCore};
+
+criterion_group!(net, echo);
 criterion_main!(net);
 
-fn tcp(c: &mut Criterion) {
-    const PACKET_LEN: usize = 1048576;
-    static PACKET: &[u8] = &[1u8; PACKET_LEN];
+const BUFFER_SIZE: usize = 4096;
+const BUFFER_COUNT: usize = 1024;
 
-    let mut group = c.benchmark_group("tcp");
+fn echo_tokio(b: &mut Bencher, content: &[u8; BUFFER_SIZE]) {
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
-    group.bench_function("tokio", |b| {
-        let runtime = tokio::runtime::Builder::new_current_thread()
-            .enable_all()
-            .build()
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    b.to_async(&runtime).iter_custom(|iter| async move {
+        let listener = tokio::net::TcpListener::bind((Ipv4Addr::LOCALHOST, 0))
+            .await
             .unwrap();
-        b.to_async(&runtime).iter(|| async {
-            use tokio::io::{AsyncReadExt, AsyncWriteExt};
+        let addr = listener.local_addr().unwrap();
 
-            let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
-            let addr = listener.local_addr().unwrap();
-            let tx = tokio::net::TcpStream::connect(addr);
-            let rx = listener.accept();
-            let (mut tx, (mut rx, _)) = tokio::try_join!(tx, rx).unwrap();
-            tx.write_all(PACKET).await.unwrap();
-            let mut buffer = Vec::with_capacity(PACKET_LEN);
-            while buffer.len() < PACKET_LEN {
-                rx.read_buf(&mut buffer).await.unwrap();
-            }
-            buffer
-        })
-    });
+        let start = Instant::now();
+        for _i in 0..iter {
+            let (mut tx, (mut rx, _)) =
+                futures_util::try_join!(tokio::net::TcpStream::connect(addr), listener.accept())
+                    .unwrap();
 
-    group.bench_function("compio", |b| {
-        let runtime = compio::runtime::Runtime::new().unwrap();
-        b.to_async(&runtime).iter(|| async {
-            use compio::io::{AsyncReadExt, AsyncWriteExt};
-
-            let listener = compio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
-            let addr = listener.local_addr().unwrap();
-            let tx = compio::net::TcpStream::connect(addr);
-            let rx = listener.accept();
-            let (mut tx, (mut rx, _)) = futures_util::try_join!(tx, rx).unwrap();
-            tx.write_all(PACKET).await.0.unwrap();
-            let buffer = Vec::with_capacity(PACKET_LEN);
-            let (_, buffer) = rx.read_exact(buffer).await.unwrap();
-            buffer
-        })
-    });
-
-    group.finish();
+            let client = async move {
+                let mut buffer = [0u8; BUFFER_SIZE];
+                for _i in 0..BUFFER_COUNT {
+                    tx.write_all(content).await.unwrap();
+                    tx.read_exact(&mut buffer).await.unwrap();
+                }
+            };
+            let server = async move {
+                let mut buffer = [0u8; BUFFER_SIZE];
+                for _i in 0..BUFFER_COUNT {
+                    rx.read_exact(&mut buffer).await.unwrap();
+                    rx.write_all(&buffer).await.unwrap();
+                }
+            };
+            futures_util::join!(client, server);
+        }
+        start.elapsed()
+    })
 }
 
-fn udp(c: &mut Criterion) {
-    const PACKET_LEN: usize = 1024;
-    static PACKET: &[u8] = &[1u8; PACKET_LEN];
+fn echo_compio(b: &mut Bencher, content: Rc<[u8; BUFFER_SIZE]>) {
+    use compio_io::{AsyncReadExt, AsyncWriteExt};
 
-    let mut group = c.benchmark_group("udp");
+    let runtime = compio::runtime::Runtime::new().unwrap();
+    b.to_async(&runtime).iter_custom(|iter| {
+        let content = content.clone();
+        async move {
+            let listener = compio::net::TcpListener::bind((Ipv4Addr::LOCALHOST, 0))
+                .await
+                .unwrap();
+            let addr = listener.local_addr().unwrap();
 
-    // The socket may be dropped by firewall when the number is too large.
-    #[cfg(target_os = "linux")]
-    group
-        .sample_size(16)
-        .measurement_time(std::time::Duration::from_millis(2))
-        .warm_up_time(std::time::Duration::from_millis(2));
+            let start = Instant::now();
+            for _i in 0..iter {
+                let (mut tx, (mut rx, _)) = futures_util::try_join!(
+                    compio::net::TcpStream::connect(addr),
+                    listener.accept()
+                )
+                .unwrap();
 
-    group.bench_function("tokio", |b| {
-        let runtime = tokio::runtime::Builder::new_current_thread()
-            .enable_all()
-            .build()
-            .unwrap();
-        b.to_async(&runtime).iter(|| async {
-            let rx = tokio::net::UdpSocket::bind("127.0.0.1:0").await.unwrap();
-            let addr_rx = rx.local_addr().unwrap();
-            let tx = tokio::net::UdpSocket::bind("127.0.0.1:0").await.unwrap();
-            let addr_tx = tx.local_addr().unwrap();
-
-            rx.connect(addr_tx).await.unwrap();
-            tx.connect(addr_rx).await.unwrap();
-
-            {
-                let mut pos = 0;
-                while pos < PACKET_LEN {
-                    let res = tx.send(&PACKET[pos..]).await;
-                    pos += res.unwrap();
-                }
+                let client = async {
+                    let mut content = content.clone();
+                    let mut buffer = Box::new([0u8; BUFFER_SIZE]);
+                    for _i in 0..BUFFER_COUNT {
+                        (_, content) = tx.write_all(content).await.unwrap();
+                        (_, buffer) = tx.read_exact(buffer).await.unwrap();
+                    }
+                };
+                let server = async move {
+                    let mut buffer = Box::new([0u8; BUFFER_SIZE]);
+                    for _i in 0..BUFFER_COUNT {
+                        (_, buffer) = rx.read_exact(buffer).await.unwrap();
+                        (_, buffer) = rx.write_all(buffer).await.unwrap();
+                    }
+                };
+                futures_util::join!(client, server);
             }
-            {
-                let mut buffer = vec![0; PACKET_LEN];
-                let mut pos = 0;
-                while pos < PACKET_LEN {
-                    let res = rx.recv(&mut buffer[pos..]).await;
-                    pos += res.unwrap();
-                }
-                buffer
-            }
-        })
-    });
+            start.elapsed()
+        }
+    })
+}
 
-    group.bench_function("compio", |b| {
-        let runtime = compio::runtime::Runtime::new().unwrap();
-        b.to_async(&runtime).iter(|| async {
-            let rx = compio::net::UdpSocket::bind("127.0.0.1:0").await.unwrap();
-            let addr_rx = rx.local_addr().unwrap();
-            let tx = compio::net::UdpSocket::bind("127.0.0.1:0").await.unwrap();
-            let addr_tx = tx.local_addr().unwrap();
+fn echo(c: &mut Criterion) {
+    let mut rng = thread_rng();
 
-            rx.connect(addr_tx).await.unwrap();
-            tx.connect(addr_rx).await.unwrap();
+    let mut content = [0u8; BUFFER_SIZE];
+    rng.fill_bytes(&mut content);
+    let content = Rc::new(content);
 
-            {
-                let mut pos = 0;
-                while pos < PACKET_LEN {
-                    let (res, _) = tx.send(&PACKET[pos..]).await.unwrap();
-                    pos += res;
-                }
-            }
-            {
-                let mut buffer = Vec::with_capacity(PACKET_LEN);
-                while buffer.len() < PACKET_LEN {
-                    (_, buffer) = rx.recv(buffer).await.unwrap();
-                }
-                buffer
-            }
-        })
-    });
+    let mut group = c.benchmark_group("echo");
+    group.throughput(Throughput::Bytes((BUFFER_SIZE * BUFFER_COUNT * 2) as u64));
+
+    group.bench_function("tokio", |b| echo_tokio(b, &content));
+    group.bench_function("compio", |b| echo_compio(b, content.clone()));
 
     group.finish();
 }


### PR DESCRIPTION
* impl IoBuf for Rc & Arc
* check is_empty before pop when using SegQueue
* use `scoped-tls` instead of Weak tls
  * The idea is from `monoio`, who copies code of `scoped-tls` into its own codebase. It reduces time when getting current `Runtime`.

I also found that the cost of `SendWrapper` is significant, but it will be addressed by #252 .

The benchmark shows that on Linux, compio is 15% (14% with LTO, and 5% with faster `SendWrapper`) *slower* than tokio; on Windows, compio is 5% (18% with LTO) *faster* than tokio.