### PR TITLE
refactor(dispatcher): reduces alloc and API change

### DIFF
--- a/compio-dispatcher/Cargo.toml
+++ b/compio-dispatcher/Cargo.toml
@@ -23,3 +23,5 @@ compio-buf = { workspace = true }
 compio-io = { workspace = true }
 compio-net = { workspace = true }
 compio-macros = { workspace = true }
+
+futures-util = { workspace = true }

--- a/compio-dispatcher/Cargo.toml
+++ b/compio-dispatcher/Cargo.toml
@@ -16,7 +16,7 @@ compio-driver = { workspace = true }
 compio-runtime = { workspace = true, features = ["event", "time"] }
 
 flume = { workspace = true }
-futures-util = { workspace = true }
+futures-channel = { workspace = true }
 
 [dev-dependencies]
 compio-buf = { workspace = true }

--- a/compio-dispatcher/tests/listener.rs
+++ b/compio-dispatcher/tests/listener.rs
@@ -29,12 +29,12 @@ async fn listener_dispatch() {
     for _i in 0..CLIENT_NUM {
         let (mut srv, _) = listener.accept().await.unwrap();
         let handle = dispatcher
-            .execute(move || async move {
+            .dispatch(move || async move {
                 let (_, buf) = srv.read_exact(ArrayVec::<u8, 12>::new()).await.unwrap();
                 assert_eq!(buf.as_slice(), b"Hello world!");
             })
             .unwrap();
-        handles.push(handle.join());
+        handles.push(handle);
     }
     while handles.next().await.is_some() {}
     let (_, results) = futures_util::join!(task, dispatcher.join());

--- a/compio-runtime/src/lib.rs
+++ b/compio-runtime/src/lib.rs
@@ -22,4 +22,4 @@ pub mod time;
 pub use async_task::Task;
 pub use attacher::*;
 use compio_buf::BufResult;
-pub use runtime::{spawn, spawn_blocking, submit, Runtime, RuntimeBuilder};
+pub use runtime::{spawn, spawn_blocking, submit, JoinHandle, Runtime, RuntimeBuilder};

--- a/compio-runtime/src/runtime/mod.rs
+++ b/compio-runtime/src/runtime/mod.rs
@@ -33,6 +33,8 @@ use crate::{runtime::op::OpFuture, BufResult};
 
 scoped_tls::scoped_thread_local!(static CURRENT_RUNTIME: Runtime);
 
+/// Type alias for `Task<Result<T, Box<dyn Any + Send>>>`, which resolves to an
+/// `Err` when the spawned future panicked.
 pub type JoinHandle<T> = Task<Result<T, Box<dyn Any + Send>>>;
 
 /// The async runtime of compio. It is a thread local runtime, and cannot be

--- a/compio/examples/dispatcher.rs
+++ b/compio/examples/dispatcher.rs
@@ -35,13 +35,13 @@ async fn main() {
     for _i in 0..CLIENT_NUM {
         let (mut srv, _) = listener.accept().await.unwrap();
         let handle = dispatcher
-            .execute(move || async move {
+            .dispatch(move || async move {
                 let BufResult(res, buf) = srv.read(Vec::with_capacity(20)).await;
                 res.unwrap();
                 println!("{}", std::str::from_utf8(&buf).unwrap());
             })
             .unwrap();
-        handles.push(handle.join());
+        handles.push(handle);
     }
     while handles.next().await.is_some() {}
     dispatcher.join().await.unwrap();


### PR DESCRIPTION
This PR reduces allocation in the process of dispatching, and adds ability to recover the closure passed in by the user.
