### PR TITLE
feat(driver): add io-uring sqpoll support

### DIFF
--- a/compio-driver/src/iour/mod.rs
+++ b/compio-driver/src/iour/mod.rs
@@ -82,7 +82,11 @@ impl Driver {
         instrument!(compio_log::Level::TRACE, "new", ?builder);
         trace!("new iour driver");
         let notifier = Notifier::new()?;
-        let mut inner = IoUring::builder().build(builder.capacity)?;
+        let mut io_uring_builder = IoUring::builder();
+        if let Some(sqpoll_idle) = builder.sqpoll_idle {
+            io_uring_builder.setup_sqpoll(sqpoll_idle.as_millis() as _);
+        }
+        let mut inner = io_uring_builder.build(builder.capacity)?;
         #[allow(clippy::useless_conversion)]
         unsafe {
             inner

--- a/compio-driver/src/lib.rs
+++ b/compio-driver/src/lib.rs
@@ -401,6 +401,7 @@ impl ThreadPoolBuilder {
 pub struct ProactorBuilder {
     capacity: u32,
     pool_builder: ThreadPoolBuilder,
+    sqpoll_idle: Option<Duration>,
 }
 
 impl Default for ProactorBuilder {
@@ -415,6 +416,7 @@ impl ProactorBuilder {
         Self {
             capacity: 1024,
             pool_builder: ThreadPoolBuilder::new(),
+            sqpoll_idle: None,
         }
     }
 
@@ -463,6 +465,19 @@ impl ProactorBuilder {
     /// Create or reuse the thread pool from the config.
     pub fn create_or_get_thread_pool(&self) -> AsyncifyPool {
         self.pool_builder.create_or_reuse()
+    }
+
+    /// Set `io-uring` sqpoll idle milliseconds, when `sqpoll_idle` is set,
+    /// io-uring sqpoll feature will be enabled
+    ///
+    /// # Notes
+    ///
+    /// - Only effective when the `io-uring` feature is enabled
+    /// - `idle` must >= 1ms, otherwise will set sqpoll idle 0ms
+    /// - `idle` will be rounded down
+    pub fn sqpoll_idle(&mut self, idle: Duration) -> &mut Self {
+        self.sqpoll_idle = Some(idle);
+        self
     }
 
     /// Build the [`Proactor`].

--- a/compio-signal/src/lib.rs
+++ b/compio-signal/src/lib.rs
@@ -17,6 +17,7 @@
 #![cfg_attr(feature = "once_cell_try", feature(once_cell_try))]
 #![cfg_attr(feature = "lazy_cell", feature(lazy_cell))]
 #![warn(missing_docs)]
+#![allow(stable_features)]
 
 #[cfg(windows)]
 pub mod windows;


### PR DESCRIPTION
io-uring supports the `sqpoll` feature, which reduces syscalls during heavy IO operations.

However, infrequent IO operations may lead to excessive CPU utilization, so `sqpoll` is disabled by default