### PR TITLE
feat: add ancillary data support

### DIFF
--- a/compio-driver/src/iocp/op.rs
+++ b/compio-driver/src/iocp/op.rs
@@ -790,7 +790,7 @@ pub struct RecvMsg<T: IoVectoredBufMut, C: IoBufMut, S> {
 }
 
 impl<T: IoVectoredBufMut, C: IoBufMut, S> RecvMsg<T, C, S> {
-    /// Create [`RecvMsgVectored`].
+    /// Create [`RecvMsg`].
     ///
     /// # Panics
     ///
@@ -865,7 +865,7 @@ pub struct SendMsg<T: IoVectoredBuf, C: IoBuf, S> {
 }
 
 impl<T: IoVectoredBuf, C: IoBuf, S> SendMsg<T, C, S> {
-    /// Create [`SendMsgVectored`].
+    /// Create [`SendMsg`].
     ///
     /// # Panics
     ///

--- a/compio-driver/src/iocp/op.rs
+++ b/compio-driver/src/iocp/op.rs
@@ -791,6 +791,10 @@ pub struct RecvMsg<T: IoVectoredBufMut, C: IoBufMut, S> {
 
 impl<T: IoVectoredBufMut, C: IoBufMut, S> RecvMsg<T, C, S> {
     /// Create [`RecvMsgVectored`].
+    ///
+    /// # Panics
+    ///
+    /// This function will panic if the control message buffer is misaligned.
     pub fn new(fd: SharedFd<S>, buffer: T, control: C) -> Self {
         assert!(
             control.as_buf_ptr().cast::<CMSGHDR>().is_aligned(),
@@ -862,6 +866,10 @@ pub struct SendMsg<T: IoVectoredBuf, C: IoBuf, S> {
 
 impl<T: IoVectoredBuf, C: IoBuf, S> SendMsg<T, C, S> {
     /// Create [`SendMsgVectored`].
+    ///
+    /// # Panics
+    ///
+    /// This function will panic if the control message buffer is misaligned.
     pub fn new(fd: SharedFd<S>, buffer: T, control: C, addr: SockAddr) -> Self {
         assert!(
             control.as_buf_ptr().cast::<CMSGHDR>().is_aligned(),

--- a/compio-driver/src/iour/op.rs
+++ b/compio-driver/src/iour/op.rs
@@ -556,6 +556,54 @@ impl<T: IoVectoredBuf, S> IntoInner for SendToVectored<T, S> {
     }
 }
 
+impl<S: AsRawFd> RecvMsgHeader<S> {
+    pub fn create_entry(&mut self) -> OpEntry {
+        opcode::RecvMsg::new(Fd(self.fd.as_raw_fd()), &mut self.msg)
+            .build()
+            .into()
+    }
+}
+
+impl<T: IoBufMut, C: IoBufMut, S: AsRawFd> OpCode for RecvMsg<T, C, S> {
+    fn create_entry(self: Pin<&mut Self>) -> OpEntry {
+        let this = unsafe { self.get_unchecked_mut() };
+        this.set_msg();
+        this.header.create_entry()
+    }
+}
+
+impl<T: IoVectoredBufMut, C: IoBufMut, S: AsRawFd> OpCode for RecvMsgVectored<T, C, S> {
+    fn create_entry(self: Pin<&mut Self>) -> OpEntry {
+        let this = unsafe { self.get_unchecked_mut() };
+        this.set_msg();
+        this.header.create_entry()
+    }
+}
+
+impl<S: AsRawFd> SendMsgHeader<S> {
+    pub fn create_entry(&mut self) -> OpEntry {
+        opcode::SendMsg::new(Fd(self.fd.as_raw_fd()), &self.msg)
+            .build()
+            .into()
+    }
+}
+
+impl<T: IoBuf, C: IoBuf, S: AsRawFd> OpCode for SendMsg<T, C, S> {
+    fn create_entry(self: Pin<&mut Self>) -> OpEntry {
+        let this = unsafe { self.get_unchecked_mut() };
+        this.set_msg();
+        this.header.create_entry()
+    }
+}
+
+impl<T: IoVectoredBuf, C: IoBuf, S: AsRawFd> OpCode for SendMsgVectored<T, C, S> {
+    fn create_entry(self: Pin<&mut Self>) -> OpEntry {
+        let this = unsafe { self.get_unchecked_mut() };
+        this.set_msg();
+        this.header.create_entry()
+    }
+}
+
 impl<S: AsRawFd> OpCode for PollOnce<S> {
     fn create_entry(self: Pin<&mut Self>) -> OpEntry {
         let flags = match self.interest {

--- a/compio-driver/src/iour/op.rs
+++ b/compio-driver/src/iour/op.rs
@@ -556,51 +556,23 @@ impl<T: IoVectoredBuf, S> IntoInner for SendToVectored<T, S> {
     }
 }
 
-impl<S: AsRawFd> RecvMsgHeader<S> {
-    pub fn create_entry(&mut self) -> OpEntry {
-        opcode::RecvMsg::new(Fd(self.fd.as_raw_fd()), &mut self.msg)
+impl<T: IoVectoredBufMut, C: IoBufMut, S: AsRawFd> OpCode for RecvMsg<T, C, S> {
+    fn create_entry(self: Pin<&mut Self>) -> OpEntry {
+        let this = unsafe { self.get_unchecked_mut() };
+        this.set_msg();
+        opcode::RecvMsg::new(Fd(this.fd.as_raw_fd()), &mut this.msg)
             .build()
             .into()
     }
 }
 
-impl<T: IoBufMut, C: IoBufMut, S: AsRawFd> OpCode for RecvMsg<T, C, S> {
+impl<T: IoVectoredBuf, C: IoBuf, S: AsRawFd> OpCode for SendMsg<T, C, S> {
     fn create_entry(self: Pin<&mut Self>) -> OpEntry {
         let this = unsafe { self.get_unchecked_mut() };
         this.set_msg();
-        this.header.create_entry()
-    }
-}
-
-impl<T: IoVectoredBufMut, C: IoBufMut, S: AsRawFd> OpCode for RecvMsgVectored<T, C, S> {
-    fn create_entry(self: Pin<&mut Self>) -> OpEntry {
-        let this = unsafe { self.get_unchecked_mut() };
-        this.set_msg();
-        this.header.create_entry()
-    }
-}
-
-impl<S: AsRawFd> SendMsgHeader<S> {
-    pub fn create_entry(&mut self) -> OpEntry {
-        opcode::SendMsg::new(Fd(self.fd.as_raw_fd()), &self.msg)
+        opcode::SendMsg::new(Fd(this.fd.as_raw_fd()), &this.msg)
             .build()
             .into()
-    }
-}
-
-impl<T: IoBuf, C: IoBuf, S: AsRawFd> OpCode for SendMsg<T, C, S> {
-    fn create_entry(self: Pin<&mut Self>) -> OpEntry {
-        let this = unsafe { self.get_unchecked_mut() };
-        this.set_msg();
-        this.header.create_entry()
-    }
-}
-
-impl<T: IoVectoredBuf, C: IoBuf, S: AsRawFd> OpCode for SendMsgVectored<T, C, S> {
-    fn create_entry(self: Pin<&mut Self>) -> OpEntry {
-        let this = unsafe { self.get_unchecked_mut() };
-        this.set_msg();
-        this.header.create_entry()
     }
 }
 

--- a/compio-driver/src/iour/op.rs
+++ b/compio-driver/src/iour/op.rs
@@ -559,7 +559,7 @@ impl<T: IoVectoredBuf, S> IntoInner for SendToVectored<T, S> {
 impl<T: IoVectoredBufMut, C: IoBufMut, S: AsRawFd> OpCode for RecvMsg<T, C, S> {
     fn create_entry(self: Pin<&mut Self>) -> OpEntry {
         let this = unsafe { self.get_unchecked_mut() };
-        this.set_msg();
+        unsafe { this.set_msg() };
         opcode::RecvMsg::new(Fd(this.fd.as_raw_fd()), &mut this.msg)
             .build()
             .into()
@@ -569,7 +569,7 @@ impl<T: IoVectoredBufMut, C: IoBufMut, S: AsRawFd> OpCode for RecvMsg<T, C, S> {
 impl<T: IoVectoredBuf, C: IoBuf, S: AsRawFd> OpCode for SendMsg<T, C, S> {
     fn create_entry(self: Pin<&mut Self>) -> OpEntry {
         let this = unsafe { self.get_unchecked_mut() };
-        this.set_msg();
+        unsafe { this.set_msg() };
         opcode::SendMsg::new(Fd(this.fd.as_raw_fd()), &this.msg)
             .build()
             .into()

--- a/compio-driver/src/op.rs
+++ b/compio-driver/src/op.rs
@@ -11,8 +11,8 @@ use socket2::SockAddr;
 #[cfg(windows)]
 pub use crate::sys::op::ConnectNamedPipe;
 pub use crate::sys::op::{
-    Accept, Recv, RecvFrom, RecvFromVectored, RecvMsg, RecvMsgVectored, RecvVectored, Send,
-    SendMsg, SendMsgVectored, SendTo, SendToVectored, SendVectored,
+    Accept, Recv, RecvFrom, RecvFromVectored, RecvMsg, RecvVectored, Send, SendMsg, SendTo,
+    SendToVectored, SendVectored,
 };
 #[cfg(unix)]
 pub use crate::sys::op::{
@@ -69,36 +69,6 @@ impl<T> RecvResultExt for BufResult<usize, (T, sockaddr_storage, socklen_t)> {
             },
             |(buffer, ..)| buffer,
         )
-    }
-}
-
-// FIXME: Using this struct instead of a simple tuple because we can implement
-// neither `BufResultExt` on `BufResult<(usize, O), (T, C)>` nor `SetBufInit` on
-// `(T, C)`. But it's not elegant. `.map_advanced` call happens in `compio-net`
-// so we must expose this struct. There should be better ways to do this.
-/// Helper struct for [`RecvMsg`], [`SendMsg`], and vectored variants.
-pub struct MsgBuf<T, C> {
-    /// The buffer for message
-    pub inner: T,
-    /// The buffer for ancillary data
-    pub control: C,
-}
-
-impl<T, C> MsgBuf<T, C> {
-    /// Create [`MsgBuf`].
-    pub fn new(inner: T, control: C) -> Self {
-        Self { inner, control }
-    }
-
-    /// Unpack to tuple.
-    pub fn into_tuple(self) -> (T, C) {
-        (self.inner, self.control)
-    }
-}
-
-impl<T: SetBufInit, C> SetBufInit for MsgBuf<T, C> {
-    unsafe fn set_buf_init(&mut self, len: usize) {
-        self.inner.set_buf_init(len);
     }
 }
 

--- a/compio-driver/src/poll/op.rs
+++ b/compio-driver/src/poll/op.rs
@@ -749,6 +749,88 @@ impl<T: IoVectoredBuf, S> IntoInner for SendToVectored<T, S> {
     }
 }
 
+impl<S: AsRawFd> RecvMsgHeader<S> {
+    unsafe fn call(&mut self) -> libc::ssize_t {
+        libc::recvmsg(self.fd.as_raw_fd(), &mut self.msg, 0)
+    }
+}
+
+impl<T: IoBufMut, C: IoBufMut, S: AsRawFd> OpCode for RecvMsg<T, C, S> {
+    fn pre_submit(self: Pin<&mut Self>) -> io::Result<Decision> {
+        let this = unsafe { self.get_unchecked_mut() };
+        this.set_msg();
+        syscall!(
+            this.header.call(),
+            wait_readable(this.header.fd.as_raw_fd())
+        )
+    }
+
+    fn on_event(self: Pin<&mut Self>, event: &Event) -> Poll<io::Result<usize>> {
+        debug_assert!(event.readable);
+
+        let this = unsafe { self.get_unchecked_mut() };
+        syscall!(break this.header.call())
+    }
+}
+
+impl<T: IoVectoredBufMut, C: IoBufMut, S: AsRawFd> OpCode for RecvMsgVectored<T, C, S> {
+    fn pre_submit(self: Pin<&mut Self>) -> io::Result<Decision> {
+        let this = unsafe { self.get_unchecked_mut() };
+        this.set_msg();
+        syscall!(
+            this.header.call(),
+            wait_readable(this.header.fd.as_raw_fd())
+        )
+    }
+
+    fn on_event(self: Pin<&mut Self>, event: &Event) -> Poll<io::Result<usize>> {
+        debug_assert!(event.readable);
+
+        let this = unsafe { self.get_unchecked_mut() };
+        syscall!(break this.header.call())
+    }
+}
+
+impl<S: AsRawFd> SendMsgHeader<S> {
+    unsafe fn call(&self) -> libc::ssize_t {
+        libc::sendmsg(self.fd.as_raw_fd(), &self.msg, 0)
+    }
+}
+
+impl<T: IoBuf, C: IoBuf, S: AsRawFd> OpCode for SendMsg<T, C, S> {
+    fn pre_submit(self: Pin<&mut Self>) -> io::Result<Decision> {
+        let this = unsafe { self.get_unchecked_mut() };
+        this.set_msg();
+        syscall!(
+            this.header.call(),
+            wait_writable(this.header.fd.as_raw_fd())
+        )
+    }
+
+    fn on_event(self: Pin<&mut Self>, event: &Event) -> Poll<io::Result<usize>> {
+        debug_assert!(event.writable);
+
+        syscall!(break self.header.call())
+    }
+}
+
+impl<T: IoVectoredBuf, C: IoBuf, S: AsRawFd> OpCode for SendMsgVectored<T, C, S> {
+    fn pre_submit(self: Pin<&mut Self>) -> io::Result<Decision> {
+        let this = unsafe { self.get_unchecked_mut() };
+        this.set_msg();
+        syscall!(
+            this.header.call(),
+            wait_writable(this.header.fd.as_raw_fd())
+        )
+    }
+
+    fn on_event(self: Pin<&mut Self>, event: &Event) -> Poll<io::Result<usize>> {
+        debug_assert!(event.writable);
+
+        syscall!(break self.header.call())
+    }
+}
+
 impl<S: AsRawFd> OpCode for PollOnce<S> {
     fn pre_submit(self: Pin<&mut Self>) -> io::Result<Decision> {
         Ok(Decision::wait_for(self.fd.as_raw_fd(), self.interest))

--- a/compio-driver/src/poll/op.rs
+++ b/compio-driver/src/poll/op.rs
@@ -758,7 +758,7 @@ impl<T: IoVectoredBufMut, C: IoBufMut, S: AsRawFd> RecvMsg<T, C, S> {
 impl<T: IoVectoredBufMut, C: IoBufMut, S: AsRawFd> OpCode for RecvMsg<T, C, S> {
     fn pre_submit(self: Pin<&mut Self>) -> io::Result<Decision> {
         let this = unsafe { self.get_unchecked_mut() };
-        this.set_msg();
+        unsafe { this.set_msg() };
         syscall!(this.call(), wait_readable(this.fd.as_raw_fd()))
     }
 
@@ -779,7 +779,7 @@ impl<T: IoVectoredBuf, C: IoBuf, S: AsRawFd> SendMsg<T, C, S> {
 impl<T: IoVectoredBuf, C: IoBuf, S: AsRawFd> OpCode for SendMsg<T, C, S> {
     fn pre_submit(self: Pin<&mut Self>) -> io::Result<Decision> {
         let this = unsafe { self.get_unchecked_mut() };
-        this.set_msg();
+        unsafe { this.set_msg() };
         syscall!(this.call(), wait_writable(this.fd.as_raw_fd()))
     }
 

--- a/compio-driver/src/unix/op.rs
+++ b/compio-driver/src/unix/op.rs
@@ -384,6 +384,10 @@ pub struct RecvMsg<T: IoVectoredBufMut, C: IoBufMut, S> {
 impl<T: IoVectoredBufMut, C: IoBufMut, S> RecvMsg<T, C, S> {
     /// Create [`RecvMsgVectored`].
     pub fn new(fd: SharedFd<S>, buffer: T, control: C) -> Self {
+        assert!(
+            control.as_buf_ptr().cast::<libc::cmsghdr>().is_aligned(),
+            "misaligned control message buffer"
+        );
         Self {
             addr: unsafe { std::mem::zeroed() },
             msg: unsafe { std::mem::zeroed() },
@@ -430,6 +434,10 @@ pub struct SendMsg<T: IoVectoredBuf, C: IoBuf, S> {
 impl<T: IoVectoredBuf, C: IoBuf, S> SendMsg<T, C, S> {
     /// Create [`SendMsgVectored`].
     pub fn new(fd: SharedFd<S>, buffer: T, control: C, addr: SockAddr) -> Self {
+        assert!(
+            control.as_buf_ptr().cast::<libc::cmsghdr>().is_aligned(),
+            "misaligned control message buffer"
+        );
         Self {
             msg: unsafe { std::mem::zeroed() },
             fd,

--- a/compio-driver/src/unix/op.rs
+++ b/compio-driver/src/unix/op.rs
@@ -1,4 +1,4 @@
-use std::{ffi::CString, marker::PhantomPinned, mem::MaybeUninit, net::Shutdown};
+use std::{ffi::CString, marker::PhantomPinned, net::Shutdown};
 
 use compio_buf::{
     IntoInner, IoBuf, IoBufMut, IoSlice, IoSliceMut, IoVectoredBuf, IoVectoredBufMut,
@@ -370,198 +370,94 @@ impl<T: IoVectoredBuf, S> IntoInner for SendVectored<T, S> {
     }
 }
 
-pub(crate) struct RecvMsgHeader<S> {
-    pub(crate) fd: SharedFd<S>,
-    pub(crate) addr: sockaddr_storage,
+/// Receive data and source address with ancillary data into vectored buffer.
+pub struct RecvMsg<T: IoVectoredBufMut, C: IoBufMut, S> {
     pub(crate) msg: libc::msghdr,
+    pub(crate) addr: sockaddr_storage,
+    pub(crate) fd: SharedFd<S>,
+    pub(crate) buffer: T,
+    pub(crate) control: C,
+    pub(crate) slices: Vec<IoSliceMut>,
     _p: PhantomPinned,
 }
 
-impl<S> RecvMsgHeader<S> {
-    pub fn new(fd: SharedFd<S>) -> Self {
+impl<T: IoVectoredBufMut, C: IoBufMut, S> RecvMsg<T, C, S> {
+    /// Create [`RecvMsgVectored`].
+    pub fn new(fd: SharedFd<S>, buffer: T, control: C) -> Self {
         Self {
-            fd,
             addr: unsafe { std::mem::zeroed() },
             msg: unsafe { std::mem::zeroed() },
-            _p: PhantomPinned,
-        }
-    }
-}
-
-impl<S> RecvMsgHeader<S> {
-    pub fn set_msg(&mut self, slices: &mut [IoSliceMut], control: &mut [MaybeUninit<u8>]) {
-        self.msg.msg_name = std::ptr::addr_of_mut!(self.addr) as _;
-        self.msg.msg_namelen = std::mem::size_of_val(&self.addr) as _;
-        self.msg.msg_iov = slices.as_mut_ptr() as _;
-        self.msg.msg_iovlen = slices.len() as _;
-        self.msg.msg_control = control.as_mut_ptr() as _;
-        self.msg.msg_controllen = control.len() as _;
-    }
-
-    pub fn into_addr(self) -> (sockaddr_storage, socklen_t) {
-        (self.addr, self.msg.msg_namelen)
-    }
-}
-
-/// Receive data and source address with ancillary data.
-pub struct RecvMsg<T: IoBufMut, C: IoBufMut, S> {
-    pub(crate) header: RecvMsgHeader<S>,
-    pub(crate) buffer: MsgBuf<T, C>,
-    pub(crate) slices: [IoSliceMut; 1],
-}
-
-impl<T: IoBufMut, C: IoBufMut, S> RecvMsg<T, C, S> {
-    /// Create [`RecvMsg`].
-    pub fn new(fd: SharedFd<S>, buffer: MsgBuf<T, C>) -> Self {
-        Self {
-            header: RecvMsgHeader::new(fd),
-            buffer,
-            // SAFETY: We never use this slice.
-            slices: [unsafe { IoSliceMut::from_slice(&mut []) }],
-        }
-    }
-
-    pub(crate) fn set_msg(&mut self) {
-        self.slices[0] = unsafe { self.buffer.inner.as_io_slice_mut() };
-        self.header
-            .set_msg(&mut self.slices, self.buffer.control.as_mut_slice());
-    }
-}
-
-impl<T: IoBufMut, C: IoBufMut, S> IntoInner for RecvMsg<T, C, S> {
-    type Inner = (MsgBuf<T, C>, sockaddr_storage, socklen_t);
-
-    fn into_inner(self) -> Self::Inner {
-        let (addr, addr_len) = self.header.into_addr();
-        (self.buffer, addr, addr_len)
-    }
-}
-
-/// Receive data and source address with ancillary data into vectored buffer.
-pub struct RecvMsgVectored<T: IoVectoredBufMut, C: IoBufMut, S> {
-    pub(crate) header: RecvMsgHeader<S>,
-    pub(crate) buffer: MsgBuf<T, C>,
-    pub(crate) slices: Vec<IoSliceMut>,
-}
-
-impl<T: IoVectoredBufMut, C: IoBufMut, S> RecvMsgVectored<T, C, S> {
-    /// Create [`RecvMsgVectored`].
-    pub fn new(fd: SharedFd<S>, buffer: MsgBuf<T, C>) -> Self {
-        Self {
-            header: RecvMsgHeader::new(fd),
-            buffer,
-            slices: vec![],
-        }
-    }
-
-    pub(crate) fn set_msg(&mut self) {
-        self.slices = unsafe { self.buffer.inner.as_io_slices_mut() };
-        self.header
-            .set_msg(&mut self.slices, self.buffer.control.as_mut_slice());
-    }
-}
-
-impl<T: IoVectoredBufMut, C: IoBufMut, S> IntoInner for RecvMsgVectored<T, C, S> {
-    type Inner = (MsgBuf<T, C>, sockaddr_storage, socklen_t);
-
-    fn into_inner(self) -> Self::Inner {
-        let (addr, addr_len) = self.header.into_addr();
-        (self.buffer, addr, addr_len)
-    }
-}
-
-pub(crate) struct SendMsgHeader<S> {
-    pub(crate) fd: SharedFd<S>,
-    pub(crate) addr: SockAddr,
-    pub(crate) msg: libc::msghdr,
-    _p: PhantomPinned,
-}
-
-impl<S> SendMsgHeader<S> {
-    pub fn new(fd: SharedFd<S>, addr: SockAddr) -> Self {
-        Self {
             fd,
-            addr,
-            msg: unsafe { std::mem::zeroed() },
-            _p: PhantomPinned,
-        }
-    }
-}
-
-impl<S> SendMsgHeader<S> {
-    pub fn set_msg(&mut self, slices: &[IoSlice], control: &[u8]) {
-        self.msg.msg_name = std::ptr::addr_of_mut!(self.addr) as _;
-        self.msg.msg_namelen = std::mem::size_of_val(&self.addr) as _;
-        self.msg.msg_iov = slices.as_ptr() as _;
-        self.msg.msg_iovlen = slices.len() as _;
-        self.msg.msg_control = control.as_ptr() as _;
-        self.msg.msg_controllen = control.len() as _;
-    }
-}
-
-/// Send data to specified address accompanied by ancillary data.
-pub struct SendMsg<T: IoBuf, C: IoBuf, S> {
-    pub(crate) header: SendMsgHeader<S>,
-    pub(crate) buffer: MsgBuf<T, C>,
-    pub(crate) slices: [IoSlice; 1],
-}
-
-impl<T: IoBuf, C: IoBuf, S> SendMsg<T, C, S> {
-    /// Create [`SendMsg`].
-    pub fn new(fd: SharedFd<S>, buffer: MsgBuf<T, C>, addr: SockAddr) -> Self {
-        Self {
-            header: SendMsgHeader::new(fd, addr),
             buffer,
-            // SAFETY: We never use this slice.
-            slices: [unsafe { IoSlice::from_slice(&[]) }],
+            control,
+            slices: vec![],
+            _p: PhantomPinned,
         }
     }
 
     pub(crate) fn set_msg(&mut self) {
-        self.slices[0] = unsafe { self.buffer.inner.as_io_slice() };
-        self.header
-            .set_msg(&self.slices, self.buffer.control.as_slice());
+        self.slices = unsafe { self.buffer.as_io_slices_mut() };
+
+        self.msg.msg_name = std::ptr::addr_of_mut!(self.addr) as _;
+        self.msg.msg_namelen = std::mem::size_of_val(&self.addr) as _;
+        self.msg.msg_iov = self.slices.as_mut_ptr() as _;
+        self.msg.msg_iovlen = self.slices.len() as _;
+        self.msg.msg_control = self.control.as_buf_mut_ptr() as _;
+        self.msg.msg_controllen = self.control.buf_len() as _;
     }
 }
 
-impl<T: IoBuf, C: IoBuf, S> IntoInner for SendMsg<T, C, S> {
-    type Inner = MsgBuf<T, C>;
+impl<T: IoVectoredBufMut, C: IoBufMut, S> IntoInner for RecvMsg<T, C, S> {
+    type Inner = ((T, C), sockaddr_storage, socklen_t);
 
     fn into_inner(self) -> Self::Inner {
-        self.buffer
+        ((self.buffer, self.control), self.addr, self.msg.msg_namelen)
     }
 }
 
 /// Send data to specified address accompanied by ancillary data from vectored
 /// buffer.
-pub struct SendMsgVectored<T: IoVectoredBuf, C: IoBuf, S> {
-    pub(crate) header: SendMsgHeader<S>,
-    pub(crate) buffer: MsgBuf<T, C>,
+pub struct SendMsg<T: IoVectoredBuf, C: IoBuf, S> {
+    pub(crate) msg: libc::msghdr,
+    pub(crate) fd: SharedFd<S>,
+    pub(crate) buffer: T,
+    pub(crate) control: C,
+    pub(crate) addr: SockAddr,
     pub(crate) slices: Vec<IoSlice>,
+    _p: PhantomPinned,
 }
 
-impl<T: IoVectoredBuf, C: IoBuf, S> SendMsgVectored<T, C, S> {
+impl<T: IoVectoredBuf, C: IoBuf, S> SendMsg<T, C, S> {
     /// Create [`SendMsgVectored`].
-    pub fn new(fd: SharedFd<S>, buffer: MsgBuf<T, C>, addr: SockAddr) -> Self {
+    pub fn new(fd: SharedFd<S>, buffer: T, control: C, addr: SockAddr) -> Self {
         Self {
-            header: SendMsgHeader::new(fd, addr),
+            msg: unsafe { std::mem::zeroed() },
+            fd,
             buffer,
+            control,
+            addr,
             slices: vec![],
+            _p: PhantomPinned,
         }
     }
 
     pub(crate) fn set_msg(&mut self) {
-        self.slices = unsafe { self.buffer.inner.as_io_slices() };
-        self.header
-            .set_msg(&self.slices, self.buffer.control.as_slice());
+        self.slices = unsafe { self.buffer.as_io_slices() };
+
+        self.msg.msg_name = std::ptr::addr_of_mut!(self.addr) as _;
+        self.msg.msg_namelen = std::mem::size_of_val(&self.addr) as _;
+        self.msg.msg_iov = self.slices.as_ptr() as _;
+        self.msg.msg_iovlen = self.slices.len() as _;
+        self.msg.msg_control = self.control.as_buf_ptr() as _;
+        self.msg.msg_controllen = self.control.buf_len() as _;
     }
 }
 
-impl<T: IoVectoredBuf, C: IoBuf, S> IntoInner for SendMsgVectored<T, C, S> {
-    type Inner = MsgBuf<T, C>;
+impl<T: IoVectoredBuf, C: IoBuf, S> IntoInner for SendMsg<T, C, S> {
+    type Inner = (T, C);
 
     fn into_inner(self) -> Self::Inner {
-        self.buffer
+        (self.buffer, self.control)
     }
 }
 

--- a/compio-driver/src/unix/op.rs
+++ b/compio-driver/src/unix/op.rs
@@ -452,8 +452,8 @@ impl<T: IoVectoredBuf, C: IoBuf, S> SendMsg<T, C, S> {
     pub(crate) fn set_msg(&mut self) {
         self.slices = unsafe { self.buffer.as_io_slices() };
 
-        self.msg.msg_name = std::ptr::addr_of_mut!(self.addr) as _;
-        self.msg.msg_namelen = std::mem::size_of_val(&self.addr) as _;
+        self.msg.msg_name = self.addr.as_ptr() as _;
+        self.msg.msg_namelen = self.addr.len();
         self.msg.msg_iov = self.slices.as_ptr() as _;
         self.msg.msg_iovlen = self.slices.len() as _;
         self.msg.msg_control = self.control.as_buf_ptr() as _;

--- a/compio-driver/src/unix/op.rs
+++ b/compio-driver/src/unix/op.rs
@@ -403,8 +403,8 @@ impl<T: IoVectoredBufMut, C: IoBufMut, S> RecvMsg<T, C, S> {
         }
     }
 
-    pub(crate) fn set_msg(&mut self) {
-        self.slices = unsafe { self.buffer.as_io_slices_mut() };
+    pub(crate) unsafe fn set_msg(&mut self) {
+        self.slices = self.buffer.as_io_slices_mut();
 
         self.msg.msg_name = std::ptr::addr_of_mut!(self.addr) as _;
         self.msg.msg_namelen = std::mem::size_of_val(&self.addr) as _;
@@ -457,8 +457,8 @@ impl<T: IoVectoredBuf, C: IoBuf, S> SendMsg<T, C, S> {
         }
     }
 
-    pub(crate) fn set_msg(&mut self) {
-        self.slices = unsafe { self.buffer.as_io_slices() };
+    pub(crate) unsafe fn set_msg(&mut self) {
+        self.slices = self.buffer.as_io_slices();
 
         self.msg.msg_name = self.addr.as_ptr() as _;
         self.msg.msg_namelen = self.addr.len();

--- a/compio-driver/src/unix/op.rs
+++ b/compio-driver/src/unix/op.rs
@@ -382,7 +382,7 @@ pub struct RecvMsg<T: IoVectoredBufMut, C: IoBufMut, S> {
 }
 
 impl<T: IoVectoredBufMut, C: IoBufMut, S> RecvMsg<T, C, S> {
-    /// Create [`RecvMsgVectored`].
+    /// Create [`RecvMsg`].
     ///
     /// # Panics
     ///
@@ -436,7 +436,7 @@ pub struct SendMsg<T: IoVectoredBuf, C: IoBuf, S> {
 }
 
 impl<T: IoVectoredBuf, C: IoBuf, S> SendMsg<T, C, S> {
-    /// Create [`SendMsgVectored`].
+    /// Create [`SendMsg`].
     ///
     /// # Panics
     ///

--- a/compio-driver/src/unix/op.rs
+++ b/compio-driver/src/unix/op.rs
@@ -383,6 +383,10 @@ pub struct RecvMsg<T: IoVectoredBufMut, C: IoBufMut, S> {
 
 impl<T: IoVectoredBufMut, C: IoBufMut, S> RecvMsg<T, C, S> {
     /// Create [`RecvMsgVectored`].
+    ///
+    /// # Panics
+    ///
+    /// This function will panic if the control message buffer is misaligned.
     pub fn new(fd: SharedFd<S>, buffer: T, control: C) -> Self {
         assert!(
             control.as_buf_ptr().cast::<libc::cmsghdr>().is_aligned(),
@@ -433,6 +437,10 @@ pub struct SendMsg<T: IoVectoredBuf, C: IoBuf, S> {
 
 impl<T: IoVectoredBuf, C: IoBuf, S> SendMsg<T, C, S> {
     /// Create [`SendMsgVectored`].
+    ///
+    /// # Panics
+    ///
+    /// This function will panic if the control message buffer is misaligned.
     pub fn new(fd: SharedFd<S>, buffer: T, control: C, addr: SockAddr) -> Self {
         assert!(
             control.as_buf_ptr().cast::<libc::cmsghdr>().is_aligned(),

--- a/compio-net/src/cmsg/mod.rs
+++ b/compio-net/src/cmsg/mod.rs
@@ -1,0 +1,115 @@
+use std::marker::PhantomData;
+
+use compio_buf::{IoBuf, IoBufMut};
+
+cfg_if::cfg_if! {
+    if #[cfg(windows)] {
+        #[path = "windows.rs"]
+        mod sys;
+    } else if #[cfg(unix)] {
+        #[path = "unix.rs"]
+        mod sys;
+    }
+}
+
+pub use sys::CMsgRef;
+
+/// An iterator for control messages.
+pub struct CMsgIter<'a> {
+    inner: sys::CMsgIter,
+    _p: PhantomData<&'a ()>,
+}
+
+impl<'a> CMsgIter<'a> {
+    /// Create [`CMsgIter`] with the given buffer.
+    ///
+    /// # Panics
+    ///
+    /// This function will panic if the buffer is too short or not properly
+    /// aligned.
+    ///
+    /// # Safety
+    ///
+    /// The buffer should contain valid control messages.
+    pub unsafe fn new<B: IoBuf>(buffer: &'a B) -> Self {
+        Self {
+            inner: sys::CMsgIter::new(buffer.as_buf_ptr(), buffer.buf_len()),
+            _p: PhantomData,
+        }
+    }
+}
+
+impl<'a> Iterator for CMsgIter<'a> {
+    type Item = CMsgRef<'a>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        unsafe {
+            let cmsg = self.inner.current();
+            self.inner.next();
+            cmsg
+        }
+    }
+}
+
+/// Helper to construct control message.
+pub struct CMsgBuilder<B> {
+    inner: sys::CMsgIter,
+    buffer: B,
+    len: usize,
+}
+
+impl<B> CMsgBuilder<B> {
+    /// Finishes building, returns the buffer and the length of the control
+    /// message.
+    pub fn build(self) -> (B, usize) {
+        (self.buffer, self.len)
+    }
+
+    /// Try to append a control message entry into the buffer. If the buffer
+    /// does not have enough space or is not properly aligned with the value
+    /// type, returns `None`.
+    ///
+    /// # Safety
+    ///
+    /// TODO: This function may be safe? Given that the buffer is zeroed,
+    /// properly aligned and has enough space, safety conditions of all unsafe
+    /// functions involved are satisfied, except for `CMSG_*`/`wsa_cmsg_*`, as
+    /// their safety are not documented.
+    pub unsafe fn try_push<T>(
+        &mut self,
+        level: sys::c_int,
+        ty: sys::c_int,
+        value: T,
+    ) -> Option<()> {
+        if !self.inner.is_aligned::<T>() || !self.inner.is_space_enough::<T>() {
+            return None;
+        }
+
+        let mut cmsg = self.inner.current_mut()?;
+        cmsg.set_level(level);
+        cmsg.set_ty(ty);
+        cmsg.set_data(value);
+
+        self.inner.next();
+        self.len += sys::space_of::<T>();
+        Some(())
+    }
+}
+
+impl<B: IoBufMut> CMsgBuilder<B> {
+    /// Create [`CMsgBuilder`] with the given buffer. The buffer will be zeroed
+    /// on creation.
+    ///
+    /// # Panics
+    ///
+    /// This function will panic if the buffer is too short or not properly
+    /// aligned.
+    pub fn new(mut buffer: B) -> Self {
+        buffer.as_mut_slice().fill(std::mem::MaybeUninit::zeroed());
+        Self {
+            inner: sys::CMsgIter::new(buffer.as_buf_mut_ptr(), buffer.buf_len()),
+            buffer,
+            len: 0,
+        }
+    }
+}

--- a/compio-net/src/cmsg/mod.rs
+++ b/compio-net/src/cmsg/mod.rs
@@ -1,7 +1,5 @@
 use std::marker::PhantomData;
 
-use compio_buf::{IoBuf, IoBufMut};
-
 cfg_if::cfg_if! {
     if #[cfg(windows)] {
         #[path = "windows.rs"]
@@ -31,9 +29,9 @@ impl<'a> CMsgIter<'a> {
     /// # Safety
     ///
     /// The buffer should contain valid control messages.
-    pub unsafe fn new<B: IoBuf>(buffer: &'a B) -> Self {
+    pub unsafe fn new(buffer: &'a [u8]) -> Self {
         Self {
-            inner: sys::CMsgIter::new(buffer.as_buf_ptr(), buffer.buf_len()),
+            inner: sys::CMsgIter::new(buffer.as_ptr(), buffer.len()),
             _p: PhantomData,
         }
     }
@@ -52,46 +50,13 @@ impl<'a> Iterator for CMsgIter<'a> {
 }
 
 /// Helper to construct control message.
-pub struct CMsgBuilder<B> {
+pub struct CMsgBuilder<'a> {
     inner: sys::CMsgIter,
-    buffer: B,
     len: usize,
+    _p: PhantomData<&'a mut ()>,
 }
 
-impl<B> CMsgBuilder<B> {
-    /// Finishes building, returns the buffer and the length of the control
-    /// message.
-    pub fn build(self) -> (B, usize) {
-        (self.buffer, self.len)
-    }
-
-    /// Try to append a control message entry into the buffer. If the buffer
-    /// does not have enough space or is not properly aligned with the value
-    /// type, returns `None`.
-    ///
-    /// # Safety
-    ///
-    /// TODO: This function may be safe? Given that the buffer is zeroed,
-    /// properly aligned and has enough space, safety conditions of all unsafe
-    /// functions involved are satisfied, except for `CMSG_*`/`wsa_cmsg_*`, as
-    /// their safety are not documented.
-    pub unsafe fn try_push<T>(&mut self, level: i32, ty: i32, value: T) -> Option<()> {
-        if !self.inner.is_aligned::<T>() || !self.inner.is_space_enough::<T>() {
-            return None;
-        }
-
-        let mut cmsg = self.inner.current_mut()?;
-        cmsg.set_level(level);
-        cmsg.set_ty(ty);
-        cmsg.set_data(value);
-
-        self.inner.next();
-        self.len += sys::space_of::<T>();
-        Some(())
-    }
-}
-
-impl<B: IoBufMut> CMsgBuilder<B> {
+impl<'a> CMsgBuilder<'a> {
     /// Create [`CMsgBuilder`] with the given buffer. The buffer will be zeroed
     /// on creation.
     ///
@@ -99,12 +64,39 @@ impl<B: IoBufMut> CMsgBuilder<B> {
     ///
     /// This function will panic if the buffer is too short or not properly
     /// aligned.
-    pub fn new(mut buffer: B) -> Self {
-        buffer.as_mut_slice().fill(std::mem::MaybeUninit::zeroed());
+    pub fn new(buffer: &'a mut [u8]) -> Self {
+        buffer.fill(0);
         Self {
-            inner: sys::CMsgIter::new(buffer.as_buf_mut_ptr(), buffer.buf_len()),
-            buffer,
+            inner: sys::CMsgIter::new(buffer.as_ptr(), buffer.len()),
             len: 0,
+            _p: PhantomData,
         }
+    }
+
+    /// Finishes building, returns length of the control message.
+    pub fn finish(self) -> usize {
+        self.len
+    }
+
+    /// Try to append a control message entry into the buffer. If the buffer
+    /// does not have enough space or is not properly aligned with the value
+    /// type, returns `None`.
+    pub fn try_push<T>(&mut self, level: i32, ty: i32, value: T) -> Option<()> {
+        if !self.inner.is_aligned::<T>() || !self.inner.is_space_enough::<T>() {
+            return None;
+        }
+
+        // SAFETY: the buffer is zeroed and the pointer is valid and aligned
+        unsafe {
+            let mut cmsg = self.inner.current_mut()?;
+            cmsg.set_level(level);
+            cmsg.set_ty(ty);
+            cmsg.set_data(value);
+
+            self.inner.next();
+            self.len += sys::space_of::<T>();
+        }
+
+        Some(())
     }
 }

--- a/compio-net/src/cmsg/mod.rs
+++ b/compio-net/src/cmsg/mod.rs
@@ -75,12 +75,7 @@ impl<B> CMsgBuilder<B> {
     /// properly aligned and has enough space, safety conditions of all unsafe
     /// functions involved are satisfied, except for `CMSG_*`/`wsa_cmsg_*`, as
     /// their safety are not documented.
-    pub unsafe fn try_push<T>(
-        &mut self,
-        level: sys::c_int,
-        ty: sys::c_int,
-        value: T,
-    ) -> Option<()> {
+    pub unsafe fn try_push<T>(&mut self, level: i32, ty: i32, value: T) -> Option<()> {
         if !self.inner.is_aligned::<T>() || !self.inner.is_space_enough::<T>() {
             return None;
         }

--- a/compio-net/src/cmsg/unix.rs
+++ b/compio-net/src/cmsg/unix.rs
@@ -1,7 +1,4 @@
-use std::mem;
-
-pub use libc::c_int;
-use libc::{cmsghdr, msghdr, CMSG_DATA, CMSG_FIRSTHDR, CMSG_LEN, CMSG_NXTHDR, CMSG_SPACE};
+use libc::{c_int, cmsghdr, msghdr, CMSG_DATA, CMSG_FIRSTHDR, CMSG_LEN, CMSG_NXTHDR, CMSG_SPACE};
 
 /// Reference to a control message.
 pub struct CMsgRef<'a>(&'a cmsghdr);
@@ -47,7 +44,7 @@ impl<'a> CMsgMut<'a> {
     }
 
     pub(crate) unsafe fn set_data<T>(&mut self, data: T) {
-        self.0.cmsg_len = CMSG_LEN(mem::size_of::<T>() as _) as _;
+        self.0.cmsg_len = CMSG_LEN(std::mem::size_of::<T>() as _) as _;
         let data_ptr = CMSG_DATA(self.0);
         std::ptr::write(data_ptr.cast::<T>(), data);
     }
@@ -63,7 +60,7 @@ impl CMsgIter {
         assert!(len >= unsafe { CMSG_SPACE(0) as _ }, "buffer too short");
         assert!(ptr.cast::<cmsghdr>().is_aligned(), "misaligned buffer");
 
-        let mut msg: msghdr = unsafe { mem::zeroed() };
+        let mut msg: msghdr = unsafe { std::mem::zeroed() };
         msg.msg_control = ptr as _;
         msg.msg_controllen = len as _;
         // SAFETY: msg is initialized and valid
@@ -91,7 +88,7 @@ impl CMsgIter {
 
     pub(crate) fn is_space_enough<T>(&self) -> bool {
         if !self.cmsg.is_null() {
-            let space = unsafe { CMSG_SPACE(mem::size_of::<T>() as _) as usize };
+            let space = unsafe { CMSG_SPACE(std::mem::size_of::<T>() as _) as usize };
             #[allow(clippy::unnecessary_cast)]
             let max = self.msg.msg_control as usize + self.msg.msg_controllen as usize;
             self.cmsg as usize + space <= max
@@ -102,5 +99,5 @@ impl CMsgIter {
 }
 
 pub(crate) fn space_of<T>() -> usize {
-    unsafe { CMSG_SPACE(mem::size_of::<T>() as _) as _ }
+    unsafe { CMSG_SPACE(std::mem::size_of::<T>() as _) as _ }
 }

--- a/compio-net/src/cmsg/unix.rs
+++ b/compio-net/src/cmsg/unix.rs
@@ -1,0 +1,106 @@
+use std::mem;
+
+pub use libc::c_int;
+use libc::{cmsghdr, msghdr, CMSG_DATA, CMSG_FIRSTHDR, CMSG_LEN, CMSG_NXTHDR, CMSG_SPACE};
+
+/// Reference to a control message.
+pub struct CMsgRef<'a>(&'a cmsghdr);
+
+impl<'a> CMsgRef<'a> {
+    /// Returns the level of the control message.
+    pub fn level(&self) -> c_int {
+        self.0.cmsg_level
+    }
+
+    /// Returns the type of the control message.
+    pub fn ty(&self) -> c_int {
+        self.0.cmsg_type
+    }
+
+    /// Returns the length of the control message.
+    #[allow(clippy::len_without_is_empty)]
+    pub fn len(&self) -> usize {
+        self.0.cmsg_len as _
+    }
+
+    /// Returns a reference to the data of the control message.
+    ///
+    /// # Safety
+    ///
+    /// The data part must be properly aligned and contains an initialized
+    /// instance of `T`.
+    pub unsafe fn data<T>(&self) -> &T {
+        let data_ptr = CMSG_DATA(self.0);
+        data_ptr.cast::<T>().as_ref().unwrap()
+    }
+}
+
+pub(crate) struct CMsgMut<'a>(&'a mut cmsghdr);
+
+impl<'a> CMsgMut<'a> {
+    pub(crate) fn set_level(&mut self, level: c_int) {
+        self.0.cmsg_level = level;
+    }
+
+    pub(crate) fn set_ty(&mut self, ty: c_int) {
+        self.0.cmsg_type = ty;
+    }
+
+    pub(crate) unsafe fn set_data<T>(&mut self, data: T) {
+        self.0.cmsg_len = CMSG_LEN(mem::size_of::<T>() as _) as _;
+        let data_ptr = CMSG_DATA(self.0);
+        std::ptr::write(data_ptr.cast::<T>(), data);
+    }
+}
+
+pub(crate) struct CMsgIter {
+    msg: msghdr,
+    cmsg: *mut cmsghdr,
+}
+
+impl CMsgIter {
+    pub(crate) fn new(ptr: *const u8, len: usize) -> Self {
+        assert!(len >= unsafe { CMSG_SPACE(0) as _ }, "buffer too short");
+        assert!(ptr.cast::<cmsghdr>().is_aligned(), "misaligned buffer");
+
+        let mut msg: msghdr = unsafe { mem::zeroed() };
+        msg.msg_control = ptr as _;
+        msg.msg_controllen = len as _;
+        // SAFETY: msg is initialized and valid
+        let cmsg = unsafe { CMSG_FIRSTHDR(&msg) };
+        Self { msg, cmsg }
+    }
+
+    pub(crate) unsafe fn current<'a>(&self) -> Option<CMsgRef<'a>> {
+        self.cmsg.as_ref().map(CMsgRef)
+    }
+
+    pub(crate) unsafe fn next(&mut self) {
+        if !self.cmsg.is_null() {
+            self.cmsg = CMSG_NXTHDR(&self.msg, self.cmsg);
+        }
+    }
+
+    pub(crate) unsafe fn current_mut<'a>(&self) -> Option<CMsgMut<'a>> {
+        self.cmsg.as_mut().map(CMsgMut)
+    }
+
+    pub(crate) fn is_aligned<T>(&self) -> bool {
+        self.msg.msg_control.cast::<T>().is_aligned()
+    }
+
+    pub(crate) fn is_space_enough<T>(&self) -> bool {
+        if !self.cmsg.is_null() {
+            let space = unsafe { CMSG_SPACE(mem::size_of::<T>() as _) as usize };
+            #[allow(clippy::unnecessary_cast)]
+            let max = self.msg.msg_control as usize + self.msg.msg_controllen as usize;
+            self.cmsg as usize + space <= max
+        } else {
+            false
+        }
+    }
+}
+
+pub(crate) fn space_of<T>() -> usize {
+    unsafe { CMSG_SPACE(mem::size_of::<T>() as _) as _ }
+}

--- a/compio-net/src/cmsg/windows.rs
+++ b/compio-net/src/cmsg/windows.rs
@@ -1,0 +1,157 @@
+use std::{mem, ptr::null_mut};
+
+pub use i32 as c_int;
+use windows_sys::Win32::Networking::WinSock::{CMSGHDR, WSABUF, WSAMSG};
+
+// Macros from https://github.com/microsoft/win32metadata/blob/main/generation/WinSDK/RecompiledIdlHeaders/shared/ws2def.h
+#[inline]
+const fn wsa_cmsghdr_align(length: usize) -> usize {
+    (length + mem::align_of::<CMSGHDR>() - 1) & !(mem::align_of::<CMSGHDR>() - 1)
+}
+
+// WSA_CMSGDATA_ALIGN(sizeof(CMSGHDR))
+const WSA_CMSGDATA_OFFSET: usize =
+    (mem::size_of::<CMSGHDR>() + mem::align_of::<usize>() - 1) & !(mem::align_of::<usize>() - 1);
+
+#[inline]
+unsafe fn wsa_cmsg_firsthdr(msg: *const WSAMSG) -> *mut CMSGHDR {
+    if (*msg).Control.len as usize >= mem::size_of::<CMSGHDR>() {
+        (*msg).Control.buf as _
+    } else {
+        null_mut()
+    }
+}
+
+#[inline]
+unsafe fn wsa_cmsg_nxthdr(msg: *const WSAMSG, cmsg: *const CMSGHDR) -> *mut CMSGHDR {
+    if cmsg.is_null() {
+        wsa_cmsg_firsthdr(msg)
+    } else {
+        let next = cmsg as usize + wsa_cmsghdr_align((*cmsg).cmsg_len);
+        if next + mem::size_of::<CMSGHDR>()
+            > (*msg).Control.buf as usize + (*msg).Control.len as usize
+        {
+            null_mut()
+        } else {
+            next as _
+        }
+    }
+}
+
+#[inline]
+unsafe fn wsa_cmsg_data(cmsg: *const CMSGHDR) -> *mut u8 {
+    (cmsg as usize + WSA_CMSGDATA_OFFSET) as _
+}
+
+#[inline]
+const fn wsa_cmsg_space(length: usize) -> usize {
+    WSA_CMSGDATA_OFFSET + wsa_cmsghdr_align(length)
+}
+
+#[inline]
+const fn wsa_cmsg_len(length: usize) -> usize {
+    WSA_CMSGDATA_OFFSET + length
+}
+
+/// Reference to a control message.
+pub struct CMsgRef<'a>(&'a CMSGHDR);
+
+impl<'a> CMsgRef<'a> {
+    /// Returns the level of the control message.
+    pub fn level(&self) -> i32 {
+        self.0.cmsg_level
+    }
+
+    /// Returns the type of the control message.
+    pub fn ty(&self) -> i32 {
+        self.0.cmsg_type
+    }
+
+    /// Returns the length of the control message.
+    #[allow(clippy::len_without_is_empty)]
+    pub fn len(&self) -> usize {
+        self.0.cmsg_len
+    }
+
+    /// Returns a reference to the data of the control message.
+    ///
+    /// # Safety
+    ///
+    /// The data part must be properly aligned and contains an initialized
+    /// instance of `T`.
+    pub unsafe fn data<T>(&self) -> &T {
+        let data_ptr = wsa_cmsg_data(self.0);
+        data_ptr.cast::<T>().as_ref().unwrap()
+    }
+}
+
+pub(crate) struct CMsgMut<'a>(&'a mut CMSGHDR);
+
+impl<'a> CMsgMut<'a> {
+    pub(crate) fn set_level(&mut self, level: i32) {
+        self.0.cmsg_level = level;
+    }
+
+    pub(crate) fn set_ty(&mut self, ty: i32) {
+        self.0.cmsg_type = ty;
+    }
+
+    pub(crate) unsafe fn set_data<T>(&mut self, data: T) {
+        self.0.cmsg_len = wsa_cmsg_len(mem::size_of::<T>() as _) as _;
+        let data_ptr = wsa_cmsg_data(self.0);
+        std::ptr::write(data_ptr.cast::<T>(), data);
+    }
+}
+
+pub(crate) struct CMsgIter {
+    msg: WSAMSG,
+    cmsg: *mut CMSGHDR,
+}
+
+impl CMsgIter {
+    pub(crate) fn new(ptr: *const u8, len: usize) -> Self {
+        assert!(len >= wsa_cmsg_space(0) as _, "buffer too short");
+        assert!(ptr.cast::<CMSGHDR>().is_aligned(), "misaligned buffer");
+
+        let mut msg: WSAMSG = unsafe { mem::zeroed() };
+        msg.Control = WSABUF {
+            len: len as _,
+            buf: ptr as _,
+        };
+        // SAFETY: msg is initialized and valid
+        let cmsg = unsafe { wsa_cmsg_firsthdr(&msg) };
+        Self { msg, cmsg }
+    }
+
+    pub(crate) unsafe fn current<'a>(&self) -> Option<CMsgRef<'a>> {
+        self.cmsg.as_ref().map(CMsgRef)
+    }
+
+    pub(crate) unsafe fn next(&mut self) {
+        if !self.cmsg.is_null() {
+            self.cmsg = wsa_cmsg_nxthdr(&self.msg, self.cmsg);
+        }
+    }
+
+    pub(crate) unsafe fn current_mut<'a>(&self) -> Option<CMsgMut<'a>> {
+        self.cmsg.as_mut().map(CMsgMut)
+    }
+
+    pub(crate) fn is_aligned<T>(&self) -> bool {
+        self.msg.Control.buf.cast::<T>().is_aligned()
+    }
+
+    pub(crate) fn is_space_enough<T>(&self) -> bool {
+        if !self.cmsg.is_null() {
+            let space = wsa_cmsg_space(mem::size_of::<T>() as _);
+            let max = self.msg.Control.buf as usize + self.msg.Control.len as usize;
+            self.cmsg as usize + space <= max
+        } else {
+            false
+        }
+    }
+}
+
+pub(crate) fn space_of<T>() -> usize {
+    wsa_cmsg_space(mem::size_of::<T>() as _)
+}

--- a/compio-net/src/lib.rs
+++ b/compio-net/src/lib.rs
@@ -5,6 +5,7 @@
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 #![warn(missing_docs)]
 
+mod cmsg;
 mod poll_fd;
 mod resolve;
 mod socket;
@@ -13,6 +14,7 @@ mod tcp;
 mod udp;
 mod unix;
 
+pub use cmsg::*;
 pub use poll_fd::*;
 pub use resolve::ToSocketAddrsAsync;
 pub(crate) use resolve::{each_addr, first_addr_buf};

--- a/compio-net/src/udp.rs
+++ b/compio-net/src/udp.rs
@@ -315,6 +315,11 @@ impl UdpSocket {
         )
         .await
     }
+
+    /// Sets a socket option.
+    pub fn set_socket_option<T>(&self, level: i32, name: i32, value: &T) -> io::Result<()> {
+        self.inner.set_socket_option(level, name, value)
+    }
 }
 
 impl_raw_fd!(UdpSocket, socket2::Socket, inner, socket);

--- a/compio-net/tests/cmsg.rs
+++ b/compio-net/tests/cmsg.rs
@@ -1,0 +1,50 @@
+use compio_buf::IoBuf;
+use compio_net::{CMsgBuilder, CMsgIter};
+
+#[test]
+fn test_cmsg() {
+    let buf = vec![0u8; 64];
+    let mut builder = CMsgBuilder::new(buf);
+
+    unsafe {
+        builder.try_push(0, 0, ()).unwrap(); // 16 / 12
+        builder.try_push(1, 1, u32::MAX).unwrap(); // 16 + 4 + 4 / 12 + 4
+        builder.try_push(2, 2, i64::MIN).unwrap(); // 16 + 8 / 12 + 8
+    }
+    let (buf, len) = builder.build();
+    assert!(len == 64 || len == 48);
+
+    let buf = buf.slice(..len);
+    let mut iter = unsafe { CMsgIter::new(&buf) };
+
+    let cmsg = iter.next().unwrap();
+    assert_eq!(
+        (cmsg.level(), cmsg.ty(), unsafe { cmsg.data::<()>() }),
+        (0, 0, &())
+    );
+    let cmsg = iter.next().unwrap();
+    assert_eq!(
+        (cmsg.level(), cmsg.ty(), unsafe { cmsg.data::<u32>() }),
+        (1, 1, &u32::MAX)
+    );
+    let cmsg = iter.next().unwrap();
+    assert_eq!(
+        (cmsg.level(), cmsg.ty(), unsafe { cmsg.data::<i64>() }),
+        (2, 2, &i64::MIN)
+    );
+    assert!(iter.next().is_none());
+}
+
+#[test]
+#[should_panic]
+fn invalid_buffer_length() {
+    let buf = vec![0u8; 1];
+    CMsgBuilder::new(buf);
+}
+
+#[test]
+#[should_panic]
+fn invalid_buffer_alignment() {
+    let buf = vec![0u8; 64];
+    CMsgBuilder::new(buf.slice(1..));
+}

--- a/compio-net/tests/cmsg.rs
+++ b/compio-net/tests/cmsg.rs
@@ -3,48 +3,45 @@ use compio_net::{CMsgBuilder, CMsgIter};
 
 #[test]
 fn test_cmsg() {
-    let buf = vec![0u8; 64];
-    let mut builder = CMsgBuilder::new(buf);
+    let mut buf = [0u8; 64];
+    let mut builder = CMsgBuilder::new(&mut buf);
 
-    unsafe {
-        builder.try_push(0, 0, ()).unwrap(); // 16 / 12
-        builder.try_push(1, 1, u32::MAX).unwrap(); // 16 + 4 + 4 / 12 + 4
-        builder.try_push(2, 2, i64::MIN).unwrap(); // 16 + 8 / 12 + 8
-    }
-    let (buf, len) = builder.build();
+    builder.try_push(0, 0, ()).unwrap(); // 16 / 12
+    builder.try_push(1, 1, u32::MAX).unwrap(); // 16 + 4 + 4 / 12 + 4
+    builder.try_push(2, 2, i64::MIN).unwrap(); // 16 + 8 / 12 + 8
+    let len = builder.finish();
     assert!(len == 64 || len == 48);
 
-    let buf = buf.slice(..len);
-    let mut iter = unsafe { CMsgIter::new(&buf) };
+    unsafe {
+        let buf = buf.slice(..len);
+        let mut iter = CMsgIter::new(&buf);
 
-    let cmsg = iter.next().unwrap();
-    assert_eq!(
-        (cmsg.level(), cmsg.ty(), unsafe { cmsg.data::<()>() }),
-        (0, 0, &())
-    );
-    let cmsg = iter.next().unwrap();
-    assert_eq!(
-        (cmsg.level(), cmsg.ty(), unsafe { cmsg.data::<u32>() }),
-        (1, 1, &u32::MAX)
-    );
-    let cmsg = iter.next().unwrap();
-    assert_eq!(
-        (cmsg.level(), cmsg.ty(), unsafe { cmsg.data::<i64>() }),
-        (2, 2, &i64::MIN)
-    );
-    assert!(iter.next().is_none());
+        let cmsg = iter.next().unwrap();
+        assert_eq!((cmsg.level(), cmsg.ty(), cmsg.data::<()>()), (0, 0, &()));
+        let cmsg = iter.next().unwrap();
+        assert_eq!(
+            (cmsg.level(), cmsg.ty(), cmsg.data::<u32>()),
+            (1, 1, &u32::MAX)
+        );
+        let cmsg = iter.next().unwrap();
+        assert_eq!(
+            (cmsg.level(), cmsg.ty(), cmsg.data::<i64>()),
+            (2, 2, &i64::MIN)
+        );
+        assert!(iter.next().is_none());
+    }
 }
 
 #[test]
 #[should_panic]
 fn invalid_buffer_length() {
-    let buf = vec![0u8; 1];
-    CMsgBuilder::new(buf);
+    let mut buf = [0u8; 1];
+    CMsgBuilder::new(&mut buf);
 }
 
 #[test]
 #[should_panic]
 fn invalid_buffer_alignment() {
-    let buf = vec![0u8; 64];
-    CMsgBuilder::new(buf.slice(1..));
+    let mut buf = [0u8; 64];
+    CMsgBuilder::new(&mut buf[1..]);
 }

--- a/compio-net/tests/udp.rs
+++ b/compio-net/tests/udp.rs
@@ -89,7 +89,7 @@ async fn send_msg_with_ipv6_ecn() {
     let mut control = vec![0u8; 32];
     let mut builder = CMsgBuilder::new(&mut control);
 
-    const ECN_BITS: i32 = 0b11;
+    const ECN_BITS: i32 = 0b10;
 
     #[cfg(unix)]
     builder

--- a/compio-net/tests/udp.rs
+++ b/compio-net/tests/udp.rs
@@ -1,4 +1,4 @@
-use compio_net::UdpSocket;
+use compio_net::{CMsgBuilder, CMsgIter, UdpSocket};
 
 #[compio_macros::test]
 async fn connect() {
@@ -63,4 +63,54 @@ async fn send_to() {
         passive3.recv_from(Vec::with_capacity(20)).await,
         active_addr
     );
+}
+
+#[compio_macros::test]
+async fn send_msg_with_ipv6_ecn() {
+    #[cfg(unix)]
+    use libc::{IPPROTO_IPV6, IPV6_RECVTCLASS, IPV6_TCLASS};
+    #[cfg(windows)]
+    use windows_sys::Win32::Networking::WinSock::{
+        IPPROTO_IPV6, IPV6_ECN, IPV6_RECVTCLASS, IPV6_TCLASS,
+    };
+
+    const MSG: &str = "foo bar baz";
+
+    let passive = UdpSocket::bind("[::1]:0").await.unwrap();
+    let passive_addr = passive.local_addr().unwrap();
+
+    passive
+        .set_socket_option(IPPROTO_IPV6, IPV6_RECVTCLASS, &1)
+        .unwrap();
+
+    let active = UdpSocket::bind("[::1]:0").await.unwrap();
+    let active_addr = active.local_addr().unwrap();
+
+    let mut control = vec![0u8; 32];
+    let mut builder = CMsgBuilder::new(&mut control);
+
+    const ECN_BITS: i32 = 0b11;
+
+    #[cfg(unix)]
+    builder
+        .try_push(IPPROTO_IPV6, IPV6_TCLASS, ECN_BITS)
+        .unwrap();
+    #[cfg(windows)]
+    builder.try_push(IPPROTO_IPV6, IPV6_ECN, ECN_BITS).unwrap();
+
+    let len = builder.finish();
+    control.truncate(len);
+
+    active.send_msg(MSG, control, passive_addr).await.unwrap();
+
+    let res = passive.recv_msg(Vec::with_capacity(20), [0u8; 32]).await;
+    assert_eq!(res.0.unwrap().1, active_addr);
+    assert_eq!(res.1.0, MSG.as_bytes());
+    unsafe {
+        let mut iter = CMsgIter::new(&res.1.1);
+        let cmsg = iter.next().unwrap();
+        assert_eq!(cmsg.level(), IPPROTO_IPV6);
+        assert_eq!(cmsg.ty(), IPV6_TCLASS);
+        assert_eq!(cmsg.data::<i32>(), &ECN_BITS);
+    }
 }


### PR DESCRIPTION
This PR added support for control messages, or rather ancillary data.

## Detail
- `compio-driver`: new opcode `RecvMsg` and `SendMsg`
- `compio-net`:
  - Add `CMsgIter` and `CMsgBuilder` helper to deal with control message
  - Add `recv_msg`, `send_msg` and vectored variant on `Socket`
  - Add `set_socket_option` on `Socket`
- Add corresponding unit tests