### PR TITLE
fix(driver/net): ancillary data

### DIFF
--- a/compio-driver/src/iocp/op.rs
+++ b/compio-driver/src/iocp/op.rs
@@ -835,7 +835,7 @@ impl<T: IoVectoredBufMut, C: IoBufMut, S: AsRawFd> OpCode for RecvMsg<T, C, S> {
             })?;
 
         let this = self.get_unchecked_mut();
-        let mut slices = this.buffer.as_io_slices_mut();
+        let mut slices = this.buffer.io_slices_mut();
         let mut msg = WSAMSG {
             name: &mut this.addr as *mut _ as _,
             namelen: this.addr_len,
@@ -906,7 +906,7 @@ impl<T: IoVectoredBuf, C: IoBuf, S: AsRawFd> OpCode for SendMsg<T, C, S> {
     unsafe fn operate(self: Pin<&mut Self>, optr: *mut OVERLAPPED) -> Poll<io::Result<usize>> {
         let this = self.get_unchecked_mut();
 
-        let slices = this.buffer.as_io_slices();
+        let slices = this.buffer.io_slices();
         let msg = WSAMSG {
             name: this.addr.as_ptr() as _,
             namelen: this.addr.len(),

--- a/compio-driver/src/unix/op.rs
+++ b/compio-driver/src/unix/op.rs
@@ -411,15 +411,20 @@ impl<T: IoVectoredBufMut, C: IoBufMut, S> RecvMsg<T, C, S> {
         self.msg.msg_iov = self.slices.as_mut_ptr() as _;
         self.msg.msg_iovlen = self.slices.len() as _;
         self.msg.msg_control = self.control.as_buf_mut_ptr() as _;
-        self.msg.msg_controllen = self.control.buf_len() as _;
+        self.msg.msg_controllen = self.control.buf_capacity() as _;
     }
 }
 
 impl<T: IoVectoredBufMut, C: IoBufMut, S> IntoInner for RecvMsg<T, C, S> {
-    type Inner = ((T, C), sockaddr_storage, socklen_t);
+    type Inner = ((T, C), sockaddr_storage, socklen_t, usize);
 
     fn into_inner(self) -> Self::Inner {
-        ((self.buffer, self.control), self.addr, self.msg.msg_namelen)
+        (
+            (self.buffer, self.control),
+            self.addr,
+            self.msg.msg_namelen,
+            self.msg.msg_controllen as _,
+        )
     }
 }
 

--- a/compio-driver/src/unix/op.rs
+++ b/compio-driver/src/unix/op.rs
@@ -404,7 +404,7 @@ impl<T: IoVectoredBufMut, C: IoBufMut, S> RecvMsg<T, C, S> {
     }
 
     pub(crate) unsafe fn set_msg(&mut self) {
-        self.slices = self.buffer.as_io_slices_mut();
+        self.slices = self.buffer.io_slices_mut();
 
         self.msg.msg_name = std::ptr::addr_of_mut!(self.addr) as _;
         self.msg.msg_namelen = std::mem::size_of_val(&self.addr) as _;
@@ -463,7 +463,7 @@ impl<T: IoVectoredBuf, C: IoBuf, S> SendMsg<T, C, S> {
     }
 
     pub(crate) unsafe fn set_msg(&mut self) {
-        self.slices = self.buffer.as_io_slices();
+        self.slices = self.buffer.io_slices();
 
         self.msg.msg_name = self.addr.as_ptr() as _;
         self.msg.msg_namelen = self.addr.len();

--- a/compio-net/src/udp.rs
+++ b/compio-net/src/udp.rs
@@ -228,11 +228,11 @@ impl UdpSocket {
         &self,
         buffer: T,
         control: C,
-    ) -> BufResult<(usize, SocketAddr), (T, C)> {
+    ) -> BufResult<(usize, usize, SocketAddr), (T, C)> {
         self.inner
             .recv_msg(buffer, control)
             .await
-            .map_res(|(n, addr)| (n, addr.as_socket().expect("should be SocketAddr")))
+            .map_res(|(n, m, addr)| (n, m, addr.as_socket().expect("should be SocketAddr")))
     }
 
     /// Receives a single datagram message and ancillary data on the socket. On
@@ -241,11 +241,11 @@ impl UdpSocket {
         &self,
         buffer: T,
         control: C,
-    ) -> BufResult<(usize, SocketAddr), (T, C)> {
+    ) -> BufResult<(usize, usize, SocketAddr), (T, C)> {
         self.inner
             .recv_msg_vectored(buffer, control)
             .await
-            .map_res(|(n, addr)| (n, addr.as_socket().expect("should be SocketAddr")))
+            .map_res(|(n, m, addr)| (n, m, addr.as_socket().expect("should be SocketAddr")))
     }
 
     /// Sends data on the socket to the given address. On success, returns the


### PR DESCRIPTION
This PR fixes ancillary data support previously introduced in #275 by:
1. adapt to `IoVectoredBuf` changes made by #277 
2. respect control message length modified by syscall in `RecvMsg`