### PR TITLE
doc: fix clippy "first doc comment paragraph is too long"

### DIFF
--- a/compio-driver/src/op.rs
+++ b/compio-driver/src/op.rs
@@ -1,4 +1,5 @@
 //! The async operations.
+//!
 //! Types in this mod represents the low-level operations passed to kernel.
 //! The operation itself doesn't perform anything.
 //! You need to pass them to [`crate::Proactor`], and poll the driver.

--- a/compio-io/src/compat.rs
+++ b/compio-io/src/compat.rs
@@ -13,9 +13,10 @@ use pin_project_lite::pin_project;
 use crate::{buffer::Buffer, util::DEFAULT_BUF_SIZE};
 
 /// A wrapper for [`AsyncRead`](crate::AsyncRead) +
-/// [`AsyncWrite`](crate::AsyncWrite), providing sync traits impl. The sync
-/// methods will return [`io::ErrorKind::WouldBlock`] error if the inner buffer
-/// needs more data.
+/// [`AsyncWrite`](crate::AsyncWrite), providing sync traits impl.
+///
+/// The sync methods will return [`io::ErrorKind::WouldBlock`] error if the
+/// inner buffer needs more data.
 #[derive(Debug)]
 pub struct SyncStream<S> {
     stream: S,


### PR DESCRIPTION
Clippy added [`too_long_first_doc_paragraph`](https://rust-lang.github.io/rust-clippy/master/index.html#/too_long_first_doc_paragraph) rule recently. This PR fixes the warnings caused by this rule.