### PR TITLE
ci: guard compio is compatible with stable rust

### DIFF
--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ${{ matrix.setup.os }}
     strategy:
       matrix:
-        toolchain: ["nightly", "stable"]
+        toolchain: ["nightly", "beta", "stable"]
         setup:
           - os: "ubuntu-20.04"
           - os: "ubuntu-22.04"

--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ${{ matrix.setup.os }}
     strategy:
       matrix:
-        toolchain: ["nightly", "beta"]
+        toolchain: ["nightly", "stable"]
         setup:
           - os: "ubuntu-20.04"
           - os: "ubuntu-22.04"


### PR DESCRIPTION
The next step would be deciding an MSRV and we can mark it in Cargo.toml `rust-version` and guard it by CI.