### PR TITLE
feat(io): add *_read_uninit for compat

### DIFF
--- a/compio-io/Cargo.toml
+++ b/compio-io/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "compio-io"
-version = "0.4.0"
+version = "0.4.1"
 description = "IO traits for completion based async IO"
 categories = ["asynchronous"]
 keywords = ["async", "io"]

--- a/compio-io/src/compat.rs
+++ b/compio-io/src/compat.rs
@@ -286,26 +286,16 @@ impl<S: crate::AsyncRead + 'static> AsyncStream<S> {
         cx: &mut Context<'_>,
         buf: &mut [MaybeUninit<u8>],
     ) -> Poll<io::Result<usize>> {
-        #[cfg(feature = "read_buf")]
-        {
-            let this = self.project();
+        let this = self.project();
 
-            let inner: &'static mut SyncStream<S> =
-                unsafe { &mut *(this.inner.get_unchecked_mut() as *mut _) };
-            poll_future_would_block!(
-                this.read_future,
-                cx,
-                inner.fill_read_buf(),
-                inner.read_buf_uninit(buf)
-            )
-        }
-        #[cfg(not(feature = "read_buf"))]
-        {
-            buf.fill(MaybeUninit::new(0));
-            self.poll_read(cx, unsafe {
-                std::slice::from_raw_parts_mut(buf.as_mut_ptr().cast(), buf.len())
-            })
-        }
+        let inner: &'static mut SyncStream<S> =
+            unsafe { &mut *(this.inner.get_unchecked_mut() as *mut _) };
+        poll_future_would_block!(
+            this.read_future,
+            cx,
+            inner.fill_read_buf(),
+            inner.read_buf_uninit(buf)
+        )
     }
 }
 


### PR DESCRIPTION
Useful for different `Read` and `AsyncRead` definitions.