### PR TITLE
feat(net): add from_std for UdpSocket

### DIFF
--- a/compio-io/Cargo.toml
+++ b/compio-io/Cargo.toml
@@ -18,8 +18,9 @@ pin-project-lite = { version = "0.2.14", optional = true }
 
 [dev-dependencies]
 compio-runtime = { workspace = true }
-# use tokio to show this crate doesn't depend on the compio runtime
+# use tokio & futures to show this crate doesn't depend on the compio runtime
 tokio = { workspace = true, features = ["macros", "rt"] }
+futures-executor = "0.3.30"
 
 [features]
 default = []

--- a/compio-io/tests/compat.rs
+++ b/compio-io/tests/compat.rs
@@ -1,74 +1,83 @@
 use std::io::Cursor;
 
 use compio_io::compat::AsyncStream;
+use futures_executor::block_on;
 use futures_util::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt};
 
-#[tokio::test]
-async fn async_compat_read() {
-    let src = &[1u8, 1, 4, 5, 1, 4, 1, 9, 1, 9, 8, 1, 0][..];
-    let mut stream = AsyncStream::new(src);
+#[test]
+fn async_compat_read() {
+    block_on(async {
+        let src = &[1u8, 1, 4, 5, 1, 4, 1, 9, 1, 9, 8, 1, 0][..];
+        let mut stream = AsyncStream::new(src);
 
-    let mut buf = [0; 6];
-    let len = stream.read(&mut buf).await.unwrap();
+        let mut buf = [0; 6];
+        let len = stream.read(&mut buf).await.unwrap();
 
-    assert_eq!(len, 6);
-    assert_eq!(buf, [1, 1, 4, 5, 1, 4]);
+        assert_eq!(len, 6);
+        assert_eq!(buf, [1, 1, 4, 5, 1, 4]);
 
-    let mut buf = [0; 20];
-    let len = stream.read(&mut buf).await.unwrap();
-    assert_eq!(len, 7);
-    assert_eq!(&buf[..7], [1, 9, 1, 9, 8, 1, 0]);
+        let mut buf = [0; 20];
+        let len = stream.read(&mut buf).await.unwrap();
+        assert_eq!(len, 7);
+        assert_eq!(&buf[..7], [1, 9, 1, 9, 8, 1, 0]);
+    })
 }
 
-#[tokio::test]
-async fn async_compat_bufread() {
-    let src = &[1u8, 1, 4, 5, 1, 4, 1, 9, 1, 9, 8, 1, 0][..];
-    let mut stream = AsyncStream::new(src);
+#[test]
+fn async_compat_bufread() {
+    block_on(async {
+        let src = &[1u8, 1, 4, 5, 1, 4, 1, 9, 1, 9, 8, 1, 0][..];
+        let mut stream = AsyncStream::new(src);
 
-    let slice = stream.fill_buf().await.unwrap();
-    assert_eq!(slice, [1, 1, 4, 5, 1, 4, 1, 9, 1, 9, 8, 1, 0]);
-    stream.consume_unpin(6);
+        let slice = stream.fill_buf().await.unwrap();
+        assert_eq!(slice, [1, 1, 4, 5, 1, 4, 1, 9, 1, 9, 8, 1, 0]);
+        stream.consume_unpin(6);
 
-    let mut buf = [0; 7];
-    let len = stream.read(&mut buf).await.unwrap();
+        let mut buf = [0; 7];
+        let len = stream.read(&mut buf).await.unwrap();
 
-    assert_eq!(len, 7);
-    assert_eq!(buf, [1, 9, 1, 9, 8, 1, 0]);
+        assert_eq!(len, 7);
+        assert_eq!(buf, [1, 9, 1, 9, 8, 1, 0]);
+    })
 }
 
-#[tokio::test]
-async fn async_compat_write() {
-    let dst = Cursor::new([0u8; 10]);
-    let mut stream = AsyncStream::new(dst);
+#[test]
+fn async_compat_write() {
+    block_on(async {
+        let dst = Cursor::new([0u8; 10]);
+        let mut stream = AsyncStream::new(dst);
 
-    let len = stream.write(&[1, 1, 4, 5, 1, 4]).await.unwrap();
-    stream.flush().await.unwrap();
+        let len = stream.write(&[1, 1, 4, 5, 1, 4]).await.unwrap();
+        stream.flush().await.unwrap();
 
-    assert_eq!(len, 6);
-    assert_eq!(stream.get_ref().position(), 6);
-    assert_eq!(stream.get_ref().get_ref(), &[1, 1, 4, 5, 1, 4, 0, 0, 0, 0]);
+        assert_eq!(len, 6);
+        assert_eq!(stream.get_ref().position(), 6);
+        assert_eq!(stream.get_ref().get_ref(), &[1, 1, 4, 5, 1, 4, 0, 0, 0, 0]);
 
-    let dst = Cursor::new([0u8; 10]);
-    let mut stream = AsyncStream::with_capacity(10, dst);
-    let len = stream
-        .write(&[1, 1, 4, 5, 1, 4, 1, 9, 1, 9, 8, 1, 0])
-        .await
-        .unwrap();
-    assert_eq!(len, 10);
+        let dst = Cursor::new([0u8; 10]);
+        let mut stream = AsyncStream::with_capacity(10, dst);
+        let len = stream
+            .write(&[1, 1, 4, 5, 1, 4, 1, 9, 1, 9, 8, 1, 0])
+            .await
+            .unwrap();
+        assert_eq!(len, 10);
 
-    stream.flush().await.unwrap();
-    assert_eq!(stream.get_ref().get_ref(), &[1, 1, 4, 5, 1, 4, 1, 9, 1, 9]);
+        stream.flush().await.unwrap();
+        assert_eq!(stream.get_ref().get_ref(), &[1, 1, 4, 5, 1, 4, 1, 9, 1, 9]);
+    })
 }
 
-#[tokio::test]
-async fn async_compat_flush_fail() {
-    let dst = Cursor::new([0u8; 10]);
-    let mut stream = AsyncStream::new(dst);
-    let len = stream
-        .write(&[1, 1, 4, 5, 1, 4, 1, 9, 1, 9, 8, 1, 0])
-        .await
-        .unwrap();
-    assert_eq!(len, 13);
-    let err = stream.flush().await.unwrap_err();
-    assert_eq!(err.kind(), std::io::ErrorKind::UnexpectedEof);
+#[test]
+fn async_compat_flush_fail() {
+    block_on(async {
+        let dst = Cursor::new([0u8; 10]);
+        let mut stream = AsyncStream::new(dst);
+        let len = stream
+            .write(&[1, 1, 4, 5, 1, 4, 1, 9, 1, 9, 8, 1, 0])
+            .await
+            .unwrap();
+        assert_eq!(len, 13);
+        let err = stream.flush().await.unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::UnexpectedEof);
+    })
 }

--- a/compio-net/Cargo.toml
+++ b/compio-net/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "compio-net"
-version = "0.5.0"
+version = "0.5.1"
 description = "Networking IO for compio"
 categories = ["asynchronous", "network-programming"]
 keywords = ["async", "net"]

--- a/compio-net/src/udp.rs
+++ b/compio-net/src/udp.rs
@@ -2,7 +2,7 @@ use std::{future::Future, io, net::SocketAddr};
 
 use compio_buf::{BufResult, IoBuf, IoBufMut, IoVectoredBuf, IoVectoredBufMut};
 use compio_driver::impl_raw_fd;
-use socket2::{Protocol, SockAddr, Type};
+use socket2::{Protocol, SockAddr, Socket as Socket2, Type};
 
 use crate::{Socket, ToSocketAddrsAsync};
 
@@ -114,6 +114,13 @@ impl UdpSocket {
             self.inner.connect(&SockAddr::from(addr))
         })
         .await
+    }
+
+    /// Creates new UdpSocket from a std::net::UdpSocket.
+    pub fn from_std(socket: std::net::UdpSocket) -> io::Result<Self> {
+        Ok(Self {
+            inner: Socket::from_socket2(Socket2::from(socket))?,
+        })
     }
 
     /// Close the socket. If the returned future is dropped before polling, the


### PR DESCRIPTION
`cyper` will use it to create a dual-stack endpoint.