### PR TITLE
refactor: update rustfmt config

### DIFF
--- a/compio-buf/src/io_vec_buf.rs
+++ b/compio-buf/src/io_vec_buf.rs
@@ -1,7 +1,7 @@
 use std::ops::{Deref, DerefMut};
 
 use crate::{
-    t_alloc, IndexedIter, IoBuf, IoBufMut, IoSlice, IoSliceMut, OwnedIterator, SetBufInit,
+    IndexedIter, IoBuf, IoBufMut, IoSlice, IoSliceMut, OwnedIterator, SetBufInit, t_alloc,
 };
 
 /// A type that's either owned or borrowed. Like [`Cow`](std::rc::Cow) but

--- a/compio-dispatcher/src/lib.rs
+++ b/compio-dispatcher/src/lib.rs
@@ -8,12 +8,12 @@ use std::{
     num::NonZeroUsize,
     panic::resume_unwind,
     sync::{Arc, Mutex},
-    thread::{available_parallelism, JoinHandle},
+    thread::{JoinHandle, available_parallelism},
 };
 
 use compio_driver::{AsyncifyPool, DispatchError, Dispatchable, ProactorBuilder};
-use compio_runtime::{event::Event, JoinHandle as CompioJoinHandle, Runtime};
-use flume::{unbounded, Sender};
+use compio_runtime::{JoinHandle as CompioJoinHandle, Runtime, event::Event};
+use flume::{Sender, unbounded};
 use futures_channel::oneshot;
 
 type Spawning = Box<dyn Spawnable + Send>;

--- a/compio-dispatcher/tests/listener.rs
+++ b/compio-dispatcher/tests/listener.rs
@@ -5,7 +5,7 @@ use compio_dispatcher::Dispatcher;
 use compio_io::{AsyncReadExt, AsyncWriteExt};
 use compio_net::{TcpListener, TcpStream};
 use compio_runtime::spawn;
-use futures_util::{stream::FuturesUnordered, StreamExt};
+use futures_util::{StreamExt, stream::FuturesUnordered};
 
 #[compio_macros::test]
 async fn listener_dispatch() {

--- a/compio-driver/src/asyncify.rs
+++ b/compio-driver/src/asyncify.rs
@@ -1,13 +1,13 @@
 use std::{
     fmt,
     sync::{
-        atomic::{AtomicUsize, Ordering},
         Arc,
+        atomic::{AtomicUsize, Ordering},
     },
     time::Duration,
 };
 
-use crossbeam_channel::{bounded, Receiver, Sender, TrySendError};
+use crossbeam_channel::{Receiver, Sender, TrySendError, bounded};
 
 /// An error that may be emitted when all worker threads are busy. It simply
 /// returns the dispatchable value with a convenient [`fmt::Debug`] and

--- a/compio-driver/src/fd.rs
+++ b/compio-driver/src/fd.rs
@@ -3,13 +3,13 @@ use std::os::fd::FromRawFd;
 #[cfg(windows)]
 use std::os::windows::io::{FromRawHandle, FromRawSocket, RawHandle, RawSocket};
 use std::{
-    future::{poll_fn, Future},
+    future::{Future, poll_fn},
     mem::ManuallyDrop,
     ops::Deref,
     panic::RefUnwindSafe,
     sync::{
-        atomic::{AtomicBool, Ordering},
         Arc,
+        atomic::{AtomicBool, Ordering},
     },
     task::Poll,
 };

--- a/compio-driver/src/fusion/mod.rs
+++ b/compio-driver/src/fusion/mod.rs
@@ -10,8 +10,8 @@ pub(crate) mod op;
 pub use std::os::fd::{AsRawFd, OwnedFd, RawFd};
 use std::{io, task::Poll, time::Duration};
 
-pub(crate) use iour::{sockaddr_storage, socklen_t};
 pub use iour::{OpCode as IourOpCode, OpEntry};
+pub(crate) use iour::{sockaddr_storage, socklen_t};
 pub use poll::{Decision, OpCode as PollOpCode};
 
 pub use crate::driver_type::DriverType; // Re-export so current user won't be broken

--- a/compio-driver/src/fusion/op.rs
+++ b/compio-driver/src/fusion/op.rs
@@ -4,8 +4,8 @@ use compio_buf::{IntoInner, IoBuf, IoBufMut, IoVectoredBuf, IoVectoredBufMut};
 use socket2::SockAddr;
 
 use super::*;
-pub use crate::unix::op::*;
 use crate::SharedFd;
+pub use crate::unix::op::*;
 
 macro_rules! op {
     (<$($ty:ident: $trait:ident),* $(,)?> $name:ident( $($arg:ident: $arg_t:ty),* $(,)? )) => {

--- a/compio-driver/src/iocp/cp/global.rs
+++ b/compio-driver/src/iocp/cp/global.rs
@@ -12,7 +12,7 @@ use once_cell::sync::OnceCell as OnceLock;
 use windows_sys::Win32::System::IO::PostQueuedCompletionStatus;
 
 use super::CompletionPort;
-use crate::{syscall, Entry, Overlapped, RawFd};
+use crate::{Entry, Overlapped, RawFd, syscall};
 
 struct GlobalPort {
     port: CompletionPort,

--- a/compio-driver/src/iocp/cp/mod.rs
+++ b/compio-driver/src/iocp/cp/mod.rs
@@ -22,23 +22,23 @@ use std::{
 use compio_log::*;
 use windows_sys::Win32::{
     Foundation::{
-        RtlNtStatusToDosError, ERROR_BAD_COMMAND, ERROR_BROKEN_PIPE, ERROR_HANDLE_EOF,
-        ERROR_IO_INCOMPLETE, ERROR_NO_DATA, ERROR_PIPE_CONNECTED, ERROR_PIPE_NOT_CONNECTED,
-        FACILITY_NTWIN32, INVALID_HANDLE_VALUE, NTSTATUS, STATUS_PENDING, STATUS_SUCCESS,
+        ERROR_BAD_COMMAND, ERROR_BROKEN_PIPE, ERROR_HANDLE_EOF, ERROR_IO_INCOMPLETE, ERROR_NO_DATA,
+        ERROR_PIPE_CONNECTED, ERROR_PIPE_NOT_CONNECTED, FACILITY_NTWIN32, INVALID_HANDLE_VALUE,
+        NTSTATUS, RtlNtStatusToDosError, STATUS_PENDING, STATUS_SUCCESS,
     },
     Storage::FileSystem::SetFileCompletionNotificationModes,
     System::{
+        IO::{
+            CreateIoCompletionPort, GetQueuedCompletionStatusEx, OVERLAPPED_ENTRY,
+            PostQueuedCompletionStatus,
+        },
         SystemServices::ERROR_SEVERITY_ERROR,
         Threading::INFINITE,
         WindowsProgramming::{FILE_SKIP_COMPLETION_PORT_ON_SUCCESS, FILE_SKIP_SET_EVENT_ON_HANDLE},
-        IO::{
-            CreateIoCompletionPort, GetQueuedCompletionStatusEx, PostQueuedCompletionStatus,
-            OVERLAPPED_ENTRY,
-        },
     },
 };
 
-use crate::{syscall, Entry, Overlapped, RawFd};
+use crate::{Entry, Overlapped, RawFd, syscall};
 
 cfg_if::cfg_if! {
     if #[cfg(feature = "iocp-global")] {

--- a/compio-driver/src/iocp/mod.rs
+++ b/compio-driver/src/iocp/mod.rs
@@ -18,24 +18,24 @@ use std::{
 use compio_log::{instrument, trace};
 use windows_sys::Win32::{
     Foundation::{ERROR_BUSY, ERROR_TIMEOUT, WAIT_OBJECT_0, WAIT_TIMEOUT},
-    Networking::WinSock::{WSACleanup, WSAStartup, WSADATA},
+    Networking::WinSock::{WSACleanup, WSADATA, WSAStartup},
     System::{
-        Threading::{
-            CloseThreadpoolWait, CreateThreadpoolWait, SetThreadpoolWait,
-            WaitForThreadpoolWaitCallbacks, PTP_CALLBACK_INSTANCE, PTP_WAIT,
-        },
         IO::OVERLAPPED,
+        Threading::{
+            CloseThreadpoolWait, CreateThreadpoolWait, PTP_CALLBACK_INSTANCE, PTP_WAIT,
+            SetThreadpoolWait, WaitForThreadpoolWaitCallbacks,
+        },
     },
 };
 
-use crate::{syscall, AsyncifyPool, Entry, Key, OutEntries, ProactorBuilder};
+use crate::{AsyncifyPool, Entry, Key, OutEntries, ProactorBuilder, syscall};
 
 pub(crate) mod op;
 
 mod cp;
 
 pub(crate) use windows_sys::Win32::Networking::WinSock::{
-    socklen_t, SOCKADDR_STORAGE as sockaddr_storage,
+    SOCKADDR_STORAGE as sockaddr_storage, socklen_t,
 };
 
 /// On windows, handle and socket are in the same size.

--- a/compio-driver/src/iocp/op.rs
+++ b/compio-driver/src/iocp/op.rs
@@ -112,9 +112,9 @@ fn get_wsa_fn<F>(handle: RawFd, fguid: GUID) -> io::Result<Option<F>> {
 }
 
 impl<
-    D: std::marker::Send + 'static,
-    F: (FnOnce() -> BufResult<usize, D>) + std::marker::Send + std::marker::Sync + 'static,
-> OpCode for Asyncify<F, D>
+        D: std::marker::Send + 'static,
+        F: (FnOnce() -> BufResult<usize, D>) + std::marker::Send + std::marker::Sync + 'static,
+    > OpCode for Asyncify<F, D>
 {
     fn op_type(&self) -> OpType {
         OpType::Blocking

--- a/compio-driver/src/iocp/op.rs
+++ b/compio-driver/src/iocp/op.rs
@@ -10,7 +10,7 @@ use std::{
     task::Poll,
 };
 
-use aligned_array::{Aligned, A8};
+use aligned_array::{A8, Aligned};
 use compio_buf::{
     BufResult, IntoInner, IoBuf, IoBufMut, IoSlice, IoSliceMut, IoVectoredBuf, IoVectoredBufMut,
 };
@@ -18,30 +18,30 @@ use compio_buf::{
 use once_cell::sync::OnceCell as OnceLock;
 use socket2::SockAddr;
 use windows_sys::{
-    core::GUID,
     Win32::{
         Foundation::{
-            CloseHandle, GetLastError, ERROR_BROKEN_PIPE, ERROR_HANDLE_EOF, ERROR_IO_INCOMPLETE,
-            ERROR_IO_PENDING, ERROR_NOT_FOUND, ERROR_NO_DATA, ERROR_PIPE_CONNECTED,
-            ERROR_PIPE_NOT_CONNECTED,
+            CloseHandle, ERROR_BROKEN_PIPE, ERROR_HANDLE_EOF, ERROR_IO_INCOMPLETE,
+            ERROR_IO_PENDING, ERROR_NO_DATA, ERROR_NOT_FOUND, ERROR_PIPE_CONNECTED,
+            ERROR_PIPE_NOT_CONNECTED, GetLastError,
         },
         Networking::WinSock::{
-            closesocket, setsockopt, shutdown, socklen_t, WSAIoctl, WSARecv, WSARecvFrom, WSASend,
-            WSASendMsg, WSASendTo, CMSGHDR, LPFN_ACCEPTEX, LPFN_CONNECTEX,
-            LPFN_GETACCEPTEXSOCKADDRS, LPFN_WSARECVMSG, SD_BOTH, SD_RECEIVE, SD_SEND,
-            SIO_GET_EXTENSION_FUNCTION_POINTER, SOCKADDR, SOCKADDR_STORAGE, SOL_SOCKET,
-            SO_UPDATE_ACCEPT_CONTEXT, SO_UPDATE_CONNECT_CONTEXT, WSABUF, WSAID_ACCEPTEX,
-            WSAID_CONNECTEX, WSAID_GETACCEPTEXSOCKADDRS, WSAID_WSARECVMSG, WSAMSG,
+            CMSGHDR, LPFN_ACCEPTEX, LPFN_CONNECTEX, LPFN_GETACCEPTEXSOCKADDRS, LPFN_WSARECVMSG,
+            SD_BOTH, SD_RECEIVE, SD_SEND, SIO_GET_EXTENSION_FUNCTION_POINTER,
+            SO_UPDATE_ACCEPT_CONTEXT, SO_UPDATE_CONNECT_CONTEXT, SOCKADDR, SOCKADDR_STORAGE,
+            SOL_SOCKET, WSABUF, WSAID_ACCEPTEX, WSAID_CONNECTEX, WSAID_GETACCEPTEXSOCKADDRS,
+            WSAID_WSARECVMSG, WSAIoctl, WSAMSG, WSARecv, WSARecvFrom, WSASend, WSASendMsg,
+            WSASendTo, closesocket, setsockopt, shutdown, socklen_t,
         },
         Storage::FileSystem::{FlushFileBuffers, ReadFile, WriteFile},
         System::{
-            Pipes::ConnectNamedPipe,
             IO::{CancelIoEx, OVERLAPPED},
+            Pipes::ConnectNamedPipe,
         },
     },
+    core::GUID,
 };
 
-use crate::{op::*, syscall, AsRawFd, OpCode, OpType, RawFd, SharedFd};
+use crate::{AsRawFd, OpCode, OpType, RawFd, SharedFd, op::*, syscall};
 
 #[inline]
 fn winapi_result(transferred: u32) -> Poll<io::Result<usize>> {
@@ -112,9 +112,9 @@ fn get_wsa_fn<F>(handle: RawFd, fguid: GUID) -> io::Result<Option<F>> {
 }
 
 impl<
-        D: std::marker::Send + 'static,
-        F: (FnOnce() -> BufResult<usize, D>) + std::marker::Send + std::marker::Sync + 'static,
-    > OpCode for Asyncify<F, D>
+    D: std::marker::Send + 'static,
+    F: (FnOnce() -> BufResult<usize, D>) + std::marker::Send + std::marker::Sync + 'static,
+> OpCode for Asyncify<F, D>
 {
     fn op_type(&self) -> OpType {
         OpType::Blocking

--- a/compio-driver/src/iour/mod.rs
+++ b/compio-driver/src/iour/mod.rs
@@ -20,14 +20,14 @@ cfg_if::cfg_if! {
     }
 }
 use io_uring::{
+    IoUring,
     cqueue::more,
     opcode::{AsyncCancel, PollAdd},
     types::{Fd, SubmitArgs, Timespec},
-    IoUring,
 };
 pub(crate) use libc::{sockaddr_storage, socklen_t};
 
-use crate::{syscall, AsyncifyPool, Entry, Key, OutEntries, ProactorBuilder};
+use crate::{AsyncifyPool, Entry, Key, OutEntries, ProactorBuilder, syscall};
 
 pub(crate) mod op;
 

--- a/compio-driver/src/iour/op.rs
+++ b/compio-driver/src/iour/op.rs
@@ -15,9 +15,9 @@ pub use crate::unix::op::*;
 use crate::{op::*, syscall, OpEntry, SharedFd};
 
 impl<
-    D: std::marker::Send + 'static,
-    F: (FnOnce() -> BufResult<usize, D>) + std::marker::Send + std::marker::Sync + 'static,
-> OpCode for Asyncify<F, D>
+        D: std::marker::Send + 'static,
+        F: (FnOnce() -> BufResult<usize, D>) + std::marker::Send + std::marker::Sync + 'static,
+    > OpCode for Asyncify<F, D>
 {
     fn create_entry(self: Pin<&mut Self>) -> OpEntry {
         OpEntry::Blocking

--- a/compio-driver/src/iour/op.rs
+++ b/compio-driver/src/iour/op.rs
@@ -12,12 +12,12 @@ use socket2::SockAddr;
 
 use super::OpCode;
 pub use crate::unix::op::*;
-use crate::{op::*, syscall, OpEntry, SharedFd};
+use crate::{OpEntry, SharedFd, op::*, syscall};
 
 impl<
-        D: std::marker::Send + 'static,
-        F: (FnOnce() -> BufResult<usize, D>) + std::marker::Send + std::marker::Sync + 'static,
-    > OpCode for Asyncify<F, D>
+    D: std::marker::Send + 'static,
+    F: (FnOnce() -> BufResult<usize, D>) + std::marker::Send + std::marker::Sync + 'static,
+> OpCode for Asyncify<F, D>
 {
     fn create_entry(self: Pin<&mut Self>) -> OpEntry {
         OpEntry::Blocking

--- a/compio-driver/src/op.rs
+++ b/compio-driver/src/op.rs
@@ -21,8 +21,8 @@ pub use crate::sys::op::{
     ReadVectoredAt, Rename, Symlink, Unlink, WriteVectoredAt,
 };
 use crate::{
-    sys::{sockaddr_storage, socklen_t},
     OwnedFd, SharedFd,
+    sys::{sockaddr_storage, socklen_t},
 };
 
 /// Trait to update the buffer length inside the [`BufResult`].

--- a/compio-driver/src/poll/mod.rs
+++ b/compio-driver/src/poll/mod.rs
@@ -17,7 +17,7 @@ use crossbeam_queue::SegQueue;
 pub(crate) use libc::{sockaddr_storage, socklen_t};
 use polling::{Event, Events, PollMode, Poller};
 
-use crate::{op::Interest, syscall, AsyncifyPool, Entry, Key, OutEntries, ProactorBuilder};
+use crate::{AsyncifyPool, Entry, Key, OutEntries, ProactorBuilder, op::Interest, syscall};
 
 pub(crate) mod op;
 

--- a/compio-driver/src/poll/op.rs
+++ b/compio-driver/src/poll/op.rs
@@ -14,14 +14,14 @@ use libc::{pread64 as pread, preadv64 as preadv, pwrite64 as pwrite, pwritev64 a
 use polling::Event;
 use socket2::SockAddr;
 
-use super::{sockaddr_storage, socklen_t, syscall, AsRawFd, Decision, OpCode};
+use super::{AsRawFd, Decision, OpCode, sockaddr_storage, socklen_t, syscall};
 pub use crate::unix::op::*;
-use crate::{op::*, SharedFd};
+use crate::{SharedFd, op::*};
 
 impl<
-        D: std::marker::Send + 'static,
-        F: (FnOnce() -> BufResult<usize, D>) + std::marker::Send + std::marker::Sync + 'static,
-    > OpCode for Asyncify<F, D>
+    D: std::marker::Send + 'static,
+    F: (FnOnce() -> BufResult<usize, D>) + std::marker::Send + std::marker::Sync + 'static,
+> OpCode for Asyncify<F, D>
 {
     fn pre_submit(self: Pin<&mut Self>) -> io::Result<Decision> {
         Ok(Decision::blocking_dummy())

--- a/compio-driver/src/poll/op.rs
+++ b/compio-driver/src/poll/op.rs
@@ -19,9 +19,9 @@ pub use crate::unix::op::*;
 use crate::{op::*, SharedFd};
 
 impl<
-    D: std::marker::Send + 'static,
-    F: (FnOnce() -> BufResult<usize, D>) + std::marker::Send + std::marker::Sync + 'static,
-> OpCode for Asyncify<F, D>
+        D: std::marker::Send + 'static,
+        F: (FnOnce() -> BufResult<usize, D>) + std::marker::Send + std::marker::Sync + 'static,
+    > OpCode for Asyncify<F, D>
 {
     fn pre_submit(self: Pin<&mut Self>) -> io::Result<Decision> {
         Ok(Decision::blocking_dummy())

--- a/compio-driver/src/unix/op.rs
+++ b/compio-driver/src/unix/op.rs
@@ -6,7 +6,7 @@ use compio_buf::{
 use libc::{sockaddr_storage, socklen_t};
 use socket2::SockAddr;
 
-use crate::{op::*, SharedFd};
+use crate::{SharedFd, op::*};
 
 /// Open or create a file with flags and mode.
 pub struct OpenFile {

--- a/compio-driver/tests/file.rs
+++ b/compio-driver/tests/file.rs
@@ -1,9 +1,9 @@
 use std::{io, time::Duration};
 
-use compio_buf::{arrayvec::ArrayVec, BufResult};
+use compio_buf::{BufResult, arrayvec::ArrayVec};
 use compio_driver::{
-    op::{Asyncify, CloseFile, ReadAt},
     AsRawFd, OpCode, OwnedFd, Proactor, PushEntry, SharedFd,
+    op::{Asyncify, CloseFile, ReadAt},
 };
 
 #[cfg(windows)]

--- a/compio-fs/src/async_fd.rs
+++ b/compio-fs/src/async_fd.rs
@@ -8,8 +8,8 @@ use std::os::windows::io::{
 
 use compio_buf::{BufResult, IntoInner, IoBuf, IoBufMut};
 use compio_driver::{
-    op::{BufResultExt, Recv, Send},
     AsRawFd, SharedFd, ToSharedFd,
+    op::{BufResultExt, Recv, Send},
 };
 use compio_io::{AsyncRead, AsyncWrite};
 use compio_runtime::Attacher;

--- a/compio-fs/src/file.rs
+++ b/compio-fs/src/file.rs
@@ -2,9 +2,8 @@ use std::{future::Future, io, mem::ManuallyDrop, panic::resume_unwind, path::Pat
 
 use compio_buf::{BufResult, IntoInner, IoBuf, IoBufMut};
 use compio_driver::{
-    impl_raw_fd,
+    ToSharedFd, impl_raw_fd,
     op::{BufResultExt, CloseFile, ReadAt, Sync, WriteAt},
-    ToSharedFd,
 };
 use compio_io::{AsyncReadAt, AsyncWriteAt};
 use compio_runtime::Attacher;
@@ -108,7 +107,7 @@ impl File {
     pub async fn set_permissions(&self, perm: Permissions) -> io::Result<()> {
         use std::os::unix::fs::PermissionsExt;
 
-        use compio_driver::{syscall, AsRawFd};
+        use compio_driver::{AsRawFd, syscall};
 
         let file = self.inner.clone();
         compio_runtime::spawn_blocking(move || {

--- a/compio-fs/src/named_pipe.rs
+++ b/compio-fs/src/named_pipe.rs
@@ -7,7 +7,7 @@ use std::ptr::null_mut;
 use std::{ffi::OsStr, io, os::windows::io::FromRawHandle, ptr::null};
 
 use compio_buf::{BufResult, IoBuf, IoBufMut};
-use compio_driver::{impl_raw_fd, op::ConnectNamedPipe, syscall, AsRawFd, RawFd, ToSharedFd};
+use compio_driver::{AsRawFd, RawFd, ToSharedFd, impl_raw_fd, op::ConnectNamedPipe, syscall};
 use compio_io::{AsyncRead, AsyncReadAt, AsyncWrite, AsyncWriteAt};
 use widestring::U16CString;
 use windows_sys::Win32::{
@@ -715,7 +715,7 @@ impl ServerOptions {
     /// use windows_sys::Win32::{
     ///     Foundation::ERROR_SUCCESS,
     ///     Security::{
-    ///         Authorization::{SetSecurityInfo, SE_KERNEL_OBJECT},
+    ///         Authorization::{SE_KERNEL_OBJECT, SetSecurityInfo},
     ///         DACL_SECURITY_INFORMATION,
     ///     },
     /// };
@@ -752,7 +752,7 @@ impl ServerOptions {
     /// use windows_sys::Win32::{
     ///     Foundation::ERROR_ACCESS_DENIED,
     ///     Security::{
-    ///         Authorization::{SetSecurityInfo, SE_KERNEL_OBJECT},
+    ///         Authorization::{SE_KERNEL_OBJECT, SetSecurityInfo},
     ///         DACL_SECURITY_INFORMATION,
     ///     },
     /// };

--- a/compio-fs/src/open_options/unix.rs
+++ b/compio-fs/src/open_options/unix.rs
@@ -1,8 +1,8 @@
 use std::{io, os::fd::FromRawFd, path::Path};
 
-use compio_driver::{op::OpenFile, RawFd};
+use compio_driver::{RawFd, op::OpenFile};
 
-use crate::{path_string, File};
+use crate::{File, path_string};
 
 #[derive(Clone, Debug)]
 pub struct OpenOptions {

--- a/compio-fs/src/pipe.rs
+++ b/compio-fs/src/pipe.rs
@@ -9,9 +9,9 @@ use std::{
 
 use compio_buf::{BufResult, IntoInner, IoBuf, IoBufMut, IoVectoredBuf, IoVectoredBufMut};
 use compio_driver::{
-    impl_raw_fd,
+    AsRawFd, ToSharedFd, impl_raw_fd,
     op::{BufResultExt, Recv, RecvVectored, Send, SendVectored},
-    syscall, AsRawFd, ToSharedFd,
+    syscall,
 };
 use compio_io::{AsyncRead, AsyncWrite};
 

--- a/compio-fs/src/stdio/windows.rs
+++ b/compio-fs/src/stdio/windows.rs
@@ -8,8 +8,8 @@ use std::{
 
 use compio_buf::{BufResult, IntoInner, IoBuf, IoBufMut};
 use compio_driver::{
-    op::{BufResultExt, Recv, Send},
     AsRawFd, OpCode, OpType, RawFd, SharedFd,
+    op::{BufResultExt, Recv, Send},
 };
 use compio_io::{AsyncRead, AsyncWrite};
 use compio_runtime::Runtime;

--- a/compio-fs/src/utils/mod.rs
+++ b/compio-fs/src/utils/mod.rs
@@ -8,10 +8,10 @@ mod sys;
 
 use std::{io, path::Path};
 
-use compio_buf::{buf_try, BufResult, IoBuf};
+use compio_buf::{BufResult, IoBuf, buf_try};
 use compio_io::{AsyncReadAtExt, AsyncWriteAtExt};
 
-use crate::{metadata, File};
+use crate::{File, metadata};
 
 /// Removes a file from the filesystem.
 pub async fn remove_file(path: impl AsRef<Path>) -> io::Result<()> {

--- a/compio-fs/tests/utils.rs
+++ b/compio-fs/tests/utils.rs
@@ -64,11 +64,13 @@ async fn build_dir_mode_read_only() {
         .await
         .unwrap();
 
-    assert!(compio_fs::metadata(new_dir)
-        .await
-        .expect("metadata result")
-        .permissions()
-        .readonly());
+    assert!(
+        compio_fs::metadata(new_dir)
+            .await
+            .expect("metadata result")
+            .permissions()
+            .readonly()
+    );
 }
 
 #[compio_macros::test]

--- a/compio-fs/tests/utils.rs
+++ b/compio-fs/tests/utils.rs
@@ -64,13 +64,11 @@ async fn build_dir_mode_read_only() {
         .await
         .unwrap();
 
-    assert!(
-        compio_fs::metadata(new_dir)
-            .await
-            .expect("metadata result")
-            .permissions()
-            .readonly()
-    );
+    assert!(compio_fs::metadata(new_dir)
+        .await
+        .expect("metadata result")
+        .permissions()
+        .readonly());
 }
 
 #[compio_macros::test]

--- a/compio-io/src/buffer.rs
+++ b/compio-io/src/buffer.rs
@@ -9,7 +9,7 @@ use std::{
 
 use compio_buf::{BufResult, IntoInner, IoBuf, IoBufMut, SetBufInit, Slice};
 
-use crate::{util::MISSING_BUF, AsyncWrite, IoResult};
+use crate::{AsyncWrite, IoResult, util::MISSING_BUF};
 
 pub struct Inner {
     buf: Vec<u8>,

--- a/compio-io/src/read/buf.rs
+++ b/compio-io/src/read/buf.rs
@@ -1,6 +1,6 @@
-use compio_buf::{buf_try, BufResult, IntoInner, IoBuf, IoBufMut, IoVectoredBufMut};
+use compio_buf::{BufResult, IntoInner, IoBuf, IoBufMut, IoVectoredBufMut, buf_try};
 
-use crate::{buffer::Buffer, util::DEFAULT_BUF_SIZE, AsyncRead, IoResult};
+use crate::{AsyncRead, IoResult, buffer::Buffer, util::DEFAULT_BUF_SIZE};
 /// # AsyncBufRead
 ///
 /// Async read with buffered content.

--- a/compio-io/src/read/ext.rs
+++ b/compio-io/src/read/ext.rs
@@ -1,9 +1,9 @@
 #[cfg(feature = "allocator_api")]
 use std::alloc::Allocator;
 
-use compio_buf::{t_alloc, BufResult, IntoInner, IoBuf, IoBufMut, IoVectoredBufMut};
+use compio_buf::{BufResult, IntoInner, IoBuf, IoBufMut, IoVectoredBufMut, t_alloc};
 
-use crate::{util::Take, AsyncRead, AsyncReadAt, IoResult};
+use crate::{AsyncRead, AsyncReadAt, IoResult, util::Take};
 
 /// Shared code for read a scalar value from the underlying reader.
 macro_rules! read_scalar {

--- a/compio-io/src/read/mod.rs
+++ b/compio-io/src/read/mod.rs
@@ -2,7 +2,7 @@
 use std::alloc::Allocator;
 use std::{io::Cursor, ops::DerefMut, rc::Rc, sync::Arc};
 
-use compio_buf::{buf_try, t_alloc, BufResult, IntoInner, IoBuf, IoBufMut, IoVectoredBufMut};
+use compio_buf::{BufResult, IntoInner, IoBuf, IoBufMut, IoVectoredBufMut, buf_try, t_alloc};
 
 mod buf;
 #[macro_use]

--- a/compio-io/src/util/mod.rs
+++ b/compio-io/src/util/mod.rs
@@ -4,15 +4,15 @@ mod take;
 pub use take::Take;
 
 mod null;
-pub use null::{null, Null};
+pub use null::{Null, null};
 
 mod repeat;
-pub use repeat::{repeat, Repeat};
+pub use repeat::{Repeat, repeat};
 
 mod internal;
 pub(crate) use internal::*;
 
-use crate::{buffer::Buffer, AsyncRead, AsyncWrite, IoResult};
+use crate::{AsyncRead, AsyncWrite, IoResult, buffer::Buffer};
 
 /// Asynchronously copies the entire contents of a reader into a writer.
 ///

--- a/compio-io/src/util/null.rs
+++ b/compio-io/src/util/null.rs
@@ -51,7 +51,7 @@ impl AsyncWrite for Null {
 /// # Examples
 ///
 /// ```
-/// use compio_io::{null, AsyncRead, AsyncWrite};
+/// use compio_io::{AsyncRead, AsyncWrite, null};
 ///
 /// # compio_runtime::Runtime::new().unwrap().block_on(async {
 /// let mut buf = Vec::with_capacity(10);

--- a/compio-io/src/util/take.rs
+++ b/compio-io/src/util/take.rs
@@ -1,4 +1,4 @@
-use compio_buf::{buf_try, BufResult, IntoInner, IoBufMut};
+use compio_buf::{BufResult, IntoInner, IoBufMut, buf_try};
 
 use crate::{AsyncBufRead, AsyncRead, IoResult};
 

--- a/compio-io/src/write/buf.rs
+++ b/compio-io/src/write/buf.rs
@@ -1,11 +1,11 @@
 use std::future::ready;
 
-use compio_buf::{buf_try, BufResult, IntoInner, IoBuf, IoVectoredBuf};
+use compio_buf::{BufResult, IntoInner, IoBuf, IoVectoredBuf, buf_try};
 
 use crate::{
-    buffer::Buffer,
-    util::{slice_to_buf, DEFAULT_BUF_SIZE},
     AsyncWrite, IoResult,
+    buffer::Buffer,
+    util::{DEFAULT_BUF_SIZE, slice_to_buf},
 };
 
 /// Wraps a writer and buffers its output.

--- a/compio-io/src/write/mod.rs
+++ b/compio-io/src/write/mod.rs
@@ -2,7 +2,7 @@
 use std::alloc::Allocator;
 use std::io::Cursor;
 
-use compio_buf::{buf_try, t_alloc, BufResult, IntoInner, IoBuf, IoVectoredBuf};
+use compio_buf::{BufResult, IntoInner, IoBuf, IoVectoredBuf, buf_try, t_alloc};
 
 use crate::IoResult;
 

--- a/compio-io/tests/io.rs
+++ b/compio-io/tests/io.rs
@@ -1,9 +1,9 @@
 use std::io::Cursor;
 
-use compio_buf::{BufResult, IoBuf, IoBufMut, arrayvec::ArrayVec};
+use compio_buf::{arrayvec::ArrayVec, BufResult, IoBuf, IoBufMut};
 use compio_io::{
-    AsyncRead, AsyncReadAt, AsyncReadAtExt, AsyncReadExt, AsyncWrite, AsyncWriteAt,
-    AsyncWriteAtExt, AsyncWriteExt, split,
+    split, AsyncRead, AsyncReadAt, AsyncReadAtExt, AsyncReadExt, AsyncWrite, AsyncWriteAt,
+    AsyncWriteAtExt, AsyncWriteExt,
 };
 use futures_executor::block_on;
 

--- a/compio-io/tests/io.rs
+++ b/compio-io/tests/io.rs
@@ -1,9 +1,9 @@
 use std::io::Cursor;
 
-use compio_buf::{arrayvec::ArrayVec, BufResult, IoBuf, IoBufMut};
+use compio_buf::{BufResult, IoBuf, IoBufMut, arrayvec::ArrayVec};
 use compio_io::{
-    split, AsyncRead, AsyncReadAt, AsyncReadAtExt, AsyncReadExt, AsyncWrite, AsyncWriteAt,
-    AsyncWriteAtExt, AsyncWriteExt,
+    AsyncRead, AsyncReadAt, AsyncReadAtExt, AsyncReadExt, AsyncWrite, AsyncWriteAt,
+    AsyncWriteAtExt, AsyncWriteExt, split,
 };
 use futures_executor::block_on;
 

--- a/compio-macros/src/item_fn.rs
+++ b/compio-macros/src/item_fn.rs
@@ -1,7 +1,7 @@
 use proc_macro2::TokenStream;
 use quote::quote;
 use syn::{
-    parse::Parse, punctuated::Punctuated, Attribute, Expr, Lit, Meta, Signature, Visibility,
+    Attribute, Expr, Lit, Meta, Signature, Visibility, parse::Parse, punctuated::Punctuated,
 };
 
 type AttributeArgs = Punctuated<syn::Meta, syn::Token![,]>;

--- a/compio-macros/src/lib.rs
+++ b/compio-macros/src/lib.rs
@@ -5,9 +5,9 @@ mod main_fn;
 mod test_fn;
 
 use proc_macro::TokenStream;
+use proc_macro_crate::{FoundCrate, crate_name};
 use proc_macro2::{Ident, Span};
-use proc_macro_crate::{crate_name, FoundCrate};
-use quote::{quote, ToTokens};
+use quote::{ToTokens, quote};
 use syn::parse_macro_input;
 
 #[proc_macro_attribute]

--- a/compio-macros/src/main_fn.rs
+++ b/compio-macros/src/main_fn.rs
@@ -1,6 +1,6 @@
 use proc_macro2::TokenStream;
-use quote::{quote, ToTokens, TokenStreamExt};
-use syn::{parse::Parse, AttrStyle, Attribute, Signature, Visibility};
+use quote::{ToTokens, TokenStreamExt, quote};
+use syn::{AttrStyle, Attribute, Signature, Visibility, parse::Parse};
 
 use crate::{
     item_fn::{RawAttr, RawBodyItemFn},

--- a/compio-macros/src/test_fn.rs
+++ b/compio-macros/src/test_fn.rs
@@ -1,6 +1,6 @@
 use proc_macro2::TokenStream;
-use quote::{quote, ToTokens, TokenStreamExt};
-use syn::{parse::Parse, AttrStyle, Attribute, Signature, Visibility};
+use quote::{ToTokens, TokenStreamExt, quote};
+use syn::{AttrStyle, Attribute, Signature, Visibility, parse::Parse};
 
 use crate::{
     item_fn::{RawAttr, RawBodyItemFn},

--- a/compio-net/src/cmsg/unix.rs
+++ b/compio-net/src/cmsg/unix.rs
@@ -1,4 +1,4 @@
-use libc::{c_int, cmsghdr, msghdr, CMSG_DATA, CMSG_FIRSTHDR, CMSG_LEN, CMSG_NXTHDR, CMSG_SPACE};
+use libc::{CMSG_DATA, CMSG_FIRSTHDR, CMSG_LEN, CMSG_NXTHDR, CMSG_SPACE, c_int, cmsghdr, msghdr};
 
 pub(crate) struct CMsgRef<'a>(&'a cmsghdr);
 

--- a/compio-net/src/poll_fd/unix.rs
+++ b/compio-net/src/poll_fd/unix.rs
@@ -2,8 +2,8 @@ use std::{io, ops::Deref};
 
 use compio_buf::{BufResult, IntoInner};
 use compio_driver::{
-    op::{Interest, PollOnce},
     AsRawFd, RawFd, SharedFd, ToSharedFd,
+    op::{Interest, PollOnce},
 };
 
 #[derive(Debug)]

--- a/compio-net/src/poll_fd/windows.rs
+++ b/compio-net/src/poll_fd/windows.rs
@@ -9,14 +9,14 @@ use std::{
 };
 
 use compio_buf::{BufResult, IntoInner};
-use compio_driver::{syscall, AsRawFd, OpCode, OpType, RawFd, SharedFd, ToSharedFd};
+use compio_driver::{AsRawFd, OpCode, OpType, RawFd, SharedFd, ToSharedFd, syscall};
 use windows_sys::Win32::{
     Foundation::ERROR_IO_PENDING,
     Networking::WinSock::{
-        WSAEnumNetworkEvents, WSAEventSelect, FD_ACCEPT, FD_CONNECT, FD_MAX_EVENTS, FD_READ,
-        FD_WRITE, WSANETWORKEVENTS,
+        FD_ACCEPT, FD_CONNECT, FD_MAX_EVENTS, FD_READ, FD_WRITE, WSAEnumNetworkEvents,
+        WSAEventSelect, WSANETWORKEVENTS,
     },
-    System::{Threading::CreateEventW, IO::OVERLAPPED},
+    System::{IO::OVERLAPPED, Threading::CreateEventW},
 };
 
 #[derive(Debug)]

--- a/compio-net/src/resolve/mod.rs
+++ b/compio-net/src/resolve/mod.rs
@@ -14,7 +14,7 @@ use std::{
     net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6},
 };
 
-use compio_buf::{buf_try, BufResult};
+use compio_buf::{BufResult, buf_try};
 use either::Either;
 pub use sys::resolve_sock_addrs;
 

--- a/compio-net/src/resolve/windows.rs
+++ b/compio-net/src/resolve/windows.rs
@@ -10,10 +10,10 @@ use compio_runtime::event::EventHandle;
 use socket2::SockAddr;
 use widestring::U16CString;
 use windows_sys::Win32::{
-    Foundation::{GetLastError, ERROR_IO_PENDING, HANDLE},
+    Foundation::{ERROR_IO_PENDING, GetLastError, HANDLE},
     Networking::WinSock::{
-        FreeAddrInfoExW, GetAddrInfoExCancel, GetAddrInfoExOverlappedResult, GetAddrInfoExW,
-        ADDRINFOEXW, AF_UNSPEC, IPPROTO_TCP, NS_ALL, SOCK_STREAM,
+        ADDRINFOEXW, AF_UNSPEC, FreeAddrInfoExW, GetAddrInfoExCancel,
+        GetAddrInfoExOverlappedResult, GetAddrInfoExW, IPPROTO_TCP, NS_ALL, SOCK_STREAM,
     },
     System::IO::OVERLAPPED,
 };

--- a/compio-net/src/socket.rs
+++ b/compio-net/src/socket.rs
@@ -8,13 +8,13 @@ use compio_buf::{BufResult, IntoInner, IoBuf, IoBufMut, IoVectoredBuf, IoVectore
 #[cfg(unix)]
 use compio_driver::op::CreateSocket;
 use compio_driver::{
-    impl_raw_fd,
+    AsRawFd, ToSharedFd, impl_raw_fd,
     op::{
         Accept, BufResultExt, CloseSocket, Connect, Recv, RecvFrom, RecvFromVectored, RecvMsg,
         RecvResultExt, RecvVectored, Send, SendMsg, SendTo, SendToVectored, SendVectored,
         ShutdownSocket,
     },
-    syscall, AsRawFd, ToSharedFd,
+    syscall,
 };
 use compio_runtime::Attacher;
 use socket2::{Domain, Protocol, SockAddr, Socket as Socket2, Type};

--- a/compio-net/src/unix.rs
+++ b/compio-net/src/unix.rs
@@ -286,13 +286,10 @@ fn empty_unix_socket() -> SockAddr {
     unsafe {
         SockAddr::try_init(|addr, len| {
             let addr: *mut SOCKADDR_UN = addr.cast();
-            std::ptr::write(
-                addr,
-                SOCKADDR_UN {
-                    sun_family: AF_UNIX,
-                    sun_path: [0; 108],
-                },
-            );
+            std::ptr::write(addr, SOCKADDR_UN {
+                sun_family: AF_UNIX,
+                sun_path: [0; 108],
+            });
             std::ptr::write(len, 3);
             Ok(())
         })

--- a/compio-process/src/linux.rs
+++ b/compio-process/src/linux.rs
@@ -1,8 +1,8 @@
 use std::{io, process};
 
 use compio_driver::{
-    op::{Interest, PollOnce},
     SharedFd,
+    op::{Interest, PollOnce},
 };
 
 pub async fn child_wait(mut child: process::Child) -> io::Result<process::ExitStatus> {

--- a/compio-process/src/unix.rs
+++ b/compio-process/src/unix.rs
@@ -2,8 +2,8 @@ use std::{io, panic::resume_unwind, process};
 
 use compio_buf::{BufResult, IntoInner, IoBuf, IoBufMut};
 use compio_driver::{
-    op::{BufResultExt, Recv, Send},
     AsRawFd, RawFd, SharedFd, ToSharedFd,
+    op::{BufResultExt, Recv, Send},
 };
 use compio_io::{AsyncRead, AsyncWrite};
 

--- a/compio-process/src/windows.rs
+++ b/compio-process/src/windows.rs
@@ -8,11 +8,12 @@ use std::{
 
 use compio_buf::{BufResult, IntoInner, IoBuf, IoBufMut};
 use compio_driver::{
+    AsRawFd, OpCode, OpType, RawFd, SharedFd, ToSharedFd,
     op::{BufResultExt, Recv, Send},
-    syscall, AsRawFd, OpCode, OpType, RawFd, SharedFd, ToSharedFd,
+    syscall,
 };
 use compio_io::{AsyncRead, AsyncWrite};
-use windows_sys::Win32::System::{Threading::GetExitCodeProcess, IO::OVERLAPPED};
+use windows_sys::Win32::System::{IO::OVERLAPPED, Threading::GetExitCodeProcess};
 
 use crate::{ChildStderr, ChildStdin, ChildStdout};
 

--- a/compio-quic/benches/quic.rs
+++ b/compio-quic/benches/quic.rs
@@ -5,9 +5,9 @@ use std::{
 };
 
 use compio_buf::bytes::Bytes;
-use criterion::{criterion_group, criterion_main, Bencher, BenchmarkId, Criterion, Throughput};
-use futures_util::{stream::FuturesUnordered, StreamExt};
-use rand::{thread_rng, RngCore};
+use criterion::{Bencher, BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use futures_util::{StreamExt, stream::FuturesUnordered};
+use rand::{RngCore, thread_rng};
 
 criterion_group!(quic, echo);
 criterion_main!(quic);

--- a/compio-quic/examples/quic-dispatcher.rs
+++ b/compio-quic/examples/quic-dispatcher.rs
@@ -3,7 +3,7 @@ use std::num::NonZeroUsize;
 use compio_dispatcher::Dispatcher;
 use compio_quic::{ClientBuilder, Endpoint, ServerBuilder};
 use compio_runtime::spawn;
-use futures_util::{stream::FuturesUnordered, StreamExt};
+use futures_util::{StreamExt, stream::FuturesUnordered};
 
 #[compio_macros::main]
 async fn main() {

--- a/compio-quic/src/builder.rs
+++ b/compio-quic/src/builder.rs
@@ -2,8 +2,8 @@ use std::{io, sync::Arc};
 
 use compio_net::ToSocketAddrsAsync;
 use quinn_proto::{
-    crypto::rustls::{QuicClientConfig, QuicServerConfig},
     ClientConfig, ServerConfig,
+    crypto::rustls::{QuicClientConfig, QuicServerConfig},
 };
 
 use crate::Endpoint;
@@ -224,10 +224,10 @@ impl ServerBuilder<rustls::ServerConfig> {
 
 mod verifier {
     use rustls::{
+        DigitallySignedStruct, Error, SignatureScheme,
         client::danger::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier},
         crypto::WebPkiSupportedAlgorithms,
         pki_types::{CertificateDer, ServerName, UnixTime},
-        DigitallySignedStruct, Error, SignatureScheme,
     };
 
     #[derive(Debug)]

--- a/compio-quic/src/connection.rs
+++ b/compio-quic/src/connection.rs
@@ -1157,7 +1157,7 @@ pub(crate) mod h3_impl {
             cx: &mut Context<'_>,
         ) -> Poll<Result<Self::BidiStream, Self::OpenError>> {
             let (stream, is_0rtt) = ready!(self.0.poll_open_stream(Some(cx), Dir::Bi))?;
-            Poll::Ready(Ok(BidiStream::new(self.0.0.clone(), stream, is_0rtt)))
+            Poll::Ready(Ok(BidiStream::new(self.0 .0.clone(), stream, is_0rtt)))
         }
 
         fn poll_open_send(
@@ -1165,7 +1165,7 @@ pub(crate) mod h3_impl {
             cx: &mut Context<'_>,
         ) -> Poll<Result<Self::SendStream, Self::OpenError>> {
             let (stream, is_0rtt) = ready!(self.0.poll_open_stream(Some(cx), Dir::Uni))?;
-            Poll::Ready(Ok(SendStream::new(self.0.0.clone(), stream, is_0rtt)))
+            Poll::Ready(Ok(SendStream::new(self.0 .0.clone(), stream, is_0rtt)))
         }
 
         fn close(&mut self, code: Code, reason: &[u8]) {

--- a/compio-quic/src/endpoint.rs
+++ b/compio-quic/src/endpoint.rs
@@ -256,20 +256,19 @@ impl EndpointInner {
     async fn run(&self) -> io::Result<()> {
         let respond_fn = |buf: Vec<u8>, transmit: Transmit| self.respond(buf, transmit);
 
-        let mut recv_fut = pin!(
-            self.socket
-                .recv(Vec::with_capacity(
-                    self.state
-                        .lock()
-                        .unwrap()
-                        .endpoint
-                        .config()
-                        .get_max_udp_payload_size()
-                        .min(64 * 1024) as usize
-                        * self.socket.max_gro_segments(),
-                ))
-                .fuse()
-        );
+        let mut recv_fut = pin!(self
+            .socket
+            .recv(Vec::with_capacity(
+                self.state
+                    .lock()
+                    .unwrap()
+                    .endpoint
+                    .config()
+                    .get_max_udp_payload_size()
+                    .min(64 * 1024) as usize
+                    * self.socket.max_gro_segments(),
+            ))
+            .fuse());
 
         let mut event_stream = self.events.1.stream().ready_chunks(100);
 

--- a/compio-quic/src/lib.rs
+++ b/compio-quic/src/lib.rs
@@ -8,9 +8,10 @@
 #![warn(missing_docs)]
 
 pub use quinn_proto::{
-    congestion, crypto, AckFrequencyConfig, ApplicationClose, Chunk, ClientConfig, ClosedStream,
-    ConfigError, ConnectError, ConnectionClose, ConnectionStats, EndpointConfig, IdleTimeout,
-    MtuDiscoveryConfig, ServerConfig, StreamId, Transmit, TransportConfig, VarInt,
+    AckFrequencyConfig, ApplicationClose, Chunk, ClientConfig, ClosedStream, ConfigError,
+    ConnectError, ConnectionClose, ConnectionStats, EndpointConfig, IdleTimeout,
+    MtuDiscoveryConfig, ServerConfig, StreamId, Transmit, TransportConfig, VarInt, congestion,
+    crypto,
 };
 
 mod builder;

--- a/compio-quic/src/recv_stream.rs
+++ b/compio-quic/src/recv_stream.rs
@@ -6,8 +6,8 @@ use std::{
 };
 
 use compio_buf::{
-    bytes::{BufMut, Bytes},
     BufResult, IoBufMut,
+    bytes::{BufMut, Bytes},
 };
 use compio_io::AsyncRead;
 use futures_util::{future::poll_fn, ready};

--- a/compio-quic/src/send_stream.rs
+++ b/compio-quic/src/send_stream.rs
@@ -4,7 +4,7 @@ use std::{
     task::{Context, Poll},
 };
 
-use compio_buf::{bytes::Bytes, BufResult, IoBuf};
+use compio_buf::{BufResult, IoBuf, bytes::Bytes};
 use compio_io::AsyncWrite;
 use futures_util::{future::poll_fn, ready};
 use quinn_proto::{ClosedStream, FinishError, StreamId, VarInt, Written};
@@ -195,12 +195,15 @@ impl SendStream {
     /// This operation is *not* cancel-safe.
     pub async fn write_all(&mut self, buf: &[u8]) -> Result<(), WriteError> {
         let mut count = 0;
-        poll_fn(|cx| loop {
-            if count == buf.len() {
-                return Poll::Ready(Ok(()));
+        poll_fn(|cx| {
+            loop {
+                if count == buf.len() {
+                    return Poll::Ready(Ok(()));
+                }
+                let n =
+                    ready!(self.execute_poll_write(cx, |mut stream| stream.write(&buf[count..])))?;
+                count += n;
             }
-            let n = ready!(self.execute_poll_write(cx, |mut stream| stream.write(&buf[count..])))?;
-            count += n;
         })
         .await
     }
@@ -221,14 +224,16 @@ impl SendStream {
     /// This operation is *not* cancel-safe.
     pub async fn write_all_chunks(&mut self, bufs: &mut [Bytes]) -> Result<(), WriteError> {
         let mut chunks = 0;
-        poll_fn(|cx| loop {
-            if chunks == bufs.len() {
-                return Poll::Ready(Ok(()));
+        poll_fn(|cx| {
+            loop {
+                if chunks == bufs.len() {
+                    return Poll::Ready(Ok(()));
+                }
+                let written = ready!(self.execute_poll_write(cx, |mut stream| {
+                    stream.write_chunks(&mut bufs[chunks..])
+                }))?;
+                chunks += written.chunks;
             }
-            let written = ready!(self.execute_poll_write(cx, |mut stream| {
-                stream.write_chunks(&mut bufs[chunks..])
-            }))?;
-            chunks += written.chunks;
         })
         .await
     }
@@ -408,9 +413,10 @@ pub(crate) mod h3_impl {
         fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
             if let Some(data) = &mut self.buf {
                 while data.has_remaining() {
-                    let n = ready!(self
-                        .inner
-                        .execute_poll_write(cx, |mut stream| stream.write(data.chunk())))?;
+                    let n = ready!(
+                        self.inner
+                            .execute_poll_write(cx, |mut stream| stream.write(data.chunk()))
+                    )?;
                     data.advance(n);
                 }
             }
@@ -456,9 +462,10 @@ pub(crate) mod h3_impl {
                 "poll_send called while send stream is not ready"
             );
 
-            let n = ready!(self
-                .inner
-                .execute_poll_write(cx, |mut stream| stream.write(buf.chunk())))?;
+            let n = ready!(
+                self.inner
+                    .execute_poll_write(cx, |mut stream| stream.write(buf.chunk()))
+            )?;
             buf.advance(n);
             Poll::Ready(Ok(n))
         }

--- a/compio-quic/src/socket.rs
+++ b/compio-quic/src/socket.rs
@@ -16,7 +16,7 @@ use std::{
     sync::atomic::{AtomicBool, Ordering},
 };
 
-use compio_buf::{buf_try, BufResult, IntoInner, IoBuf, IoBufMut, SetBufInit};
+use compio_buf::{BufResult, IntoInner, IoBuf, IoBufMut, SetBufInit, buf_try};
 use compio_net::{CMsgBuilder, CMsgIter, UdpSocket};
 use quinn_proto::{EcnCodepoint, Transmit};
 #[cfg(windows)]

--- a/compio-quic/tests/common/mod.rs
+++ b/compio-quic/tests/common/mod.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use compio_log::subscriber::DefaultGuard;
 use compio_quic::{ClientBuilder, ClientConfig, ServerBuilder, ServerConfig, TransportConfig};
-use tracing_subscriber::{util::SubscriberInitExt, EnvFilter};
+use tracing_subscriber::{EnvFilter, util::SubscriberInitExt};
 
 pub fn subscribe() -> DefaultGuard {
     tracing_subscriber::fmt()

--- a/compio-quic/tests/echo.rs
+++ b/compio-quic/tests/echo.rs
@@ -9,7 +9,7 @@ use compio_quic::{Endpoint, RecvStream, SendStream, TransportConfig};
 mod common;
 use common::{config_pair, subscribe};
 use futures_util::join;
-use rand::{rngs::StdRng, RngCore, SeedableRng};
+use rand::{RngCore, SeedableRng, rngs::StdRng};
 
 struct EchoArgs {
     client_addr: SocketAddr,

--- a/compio-runtime/src/event.rs
+++ b/compio-runtime/src/event.rs
@@ -3,13 +3,13 @@
 use std::{
     pin::Pin,
     sync::{
-        atomic::{AtomicBool, Ordering},
         Arc,
+        atomic::{AtomicBool, Ordering},
     },
     task::{Context, Poll},
 };
 
-use futures_util::{task::AtomicWaker, Future};
+use futures_util::{Future, task::AtomicWaker};
 
 #[derive(Debug)]
 struct Inner {

--- a/compio-runtime/src/lib.rs
+++ b/compio-runtime/src/lib.rs
@@ -23,5 +23,5 @@ pub use async_task::Task;
 pub use attacher::*;
 use compio_buf::BufResult;
 pub use runtime::{
-    spawn, spawn_blocking, submit, submit_with_flags, JoinHandle, Runtime, RuntimeBuilder,
+    JoinHandle, Runtime, RuntimeBuilder, spawn, spawn_blocking, submit, submit_with_flags,
 };

--- a/compio-runtime/src/runtime/mod.rs
+++ b/compio-runtime/src/runtime/mod.rs
@@ -2,7 +2,7 @@ use std::{
     any::Any,
     cell::RefCell,
     collections::VecDeque,
-    future::{poll_fn, ready, Future},
+    future::{Future, poll_fn, ready},
     io,
     marker::PhantomData,
     panic::AssertUnwindSafe,
@@ -15,11 +15,11 @@ use std::{
 use async_task::{Runnable, Task};
 use compio_buf::IntoInner;
 use compio_driver::{
-    op::Asyncify, AsRawFd, Key, OpCode, Proactor, ProactorBuilder, PushEntry, RawFd,
+    AsRawFd, Key, OpCode, Proactor, ProactorBuilder, PushEntry, RawFd, op::Asyncify,
 };
 use compio_log::{debug, instrument};
 use crossbeam_queue::SegQueue;
-use futures_util::{future::Either, FutureExt};
+use futures_util::{FutureExt, future::Either};
 use smallvec::SmallVec;
 
 pub(crate) mod op;
@@ -31,7 +31,7 @@ use send_wrapper::SendWrapper;
 
 #[cfg(feature = "time")]
 use crate::runtime::time::{TimerFuture, TimerRuntime};
-use crate::{runtime::op::OpFlagsFuture, BufResult};
+use crate::{BufResult, runtime::op::OpFlagsFuture};
 
 scoped_tls::scoped_thread_local!(static CURRENT_RUNTIME: Runtime);
 

--- a/compio-runtime/src/runtime/send_wrapper.rs
+++ b/compio-runtime/src/runtime/send_wrapper.rs
@@ -54,11 +54,7 @@ impl<T> SendWrapper<T> {
     /// Returns a reference to the contained value, if valid.
     #[inline]
     pub fn get(&self) -> Option<&T> {
-        if self.valid() {
-            Some(&self.data)
-        } else {
-            None
-        }
+        if self.valid() { Some(&self.data) } else { None }
     }
 }
 

--- a/compio-runtime/src/runtime/send_wrapper.rs
+++ b/compio-runtime/src/runtime/send_wrapper.rs
@@ -54,7 +54,11 @@ impl<T> SendWrapper<T> {
     /// Returns a reference to the contained value, if valid.
     #[inline]
     pub fn get(&self) -> Option<&T> {
-        if self.valid() { Some(&self.data) } else { None }
+        if self.valid() {
+            Some(&self.data)
+        } else {
+            None
+        }
     }
 }
 

--- a/compio-runtime/src/time.rs
+++ b/compio-runtime/src/time.rs
@@ -7,7 +7,7 @@ use std::{
     time::{Duration, Instant},
 };
 
-use futures_util::{select, FutureExt};
+use futures_util::{FutureExt, select};
 
 use crate::Runtime;
 

--- a/compio-runtime/tests/custom_loop.rs
+++ b/compio-runtime/tests/custom_loop.rs
@@ -10,11 +10,11 @@ fn cf_run_loop() {
 
     use block2::{Block, StackBlock};
     use compio_driver::AsRawFd;
-    use compio_runtime::{event::Event, Runtime};
+    use compio_runtime::{Runtime, event::Event};
     use core_foundation::{
         base::TCFType,
-        filedescriptor::{kCFFileDescriptorReadCallBack, CFFileDescriptor, CFFileDescriptorRef},
-        runloop::{kCFRunLoopDefaultMode, CFRunLoop, CFRunLoopRef, CFRunLoopStop},
+        filedescriptor::{CFFileDescriptor, CFFileDescriptorRef, kCFFileDescriptorReadCallBack},
+        runloop::{CFRunLoop, CFRunLoopRef, CFRunLoopStop, kCFRunLoopDefaultMode},
         string::CFStringRef,
     };
 
@@ -112,15 +112,16 @@ fn message_queue() {
 
     use compio_driver::AsRawFd;
     use compio_runtime::{
-        event::{Event, EventHandle},
         Runtime,
+        event::{Event, EventHandle},
     };
     use windows_sys::Win32::{
         Foundation::{HANDLE, HWND, WAIT_FAILED},
         System::Threading::INFINITE,
         UI::WindowsAndMessaging::{
-            DispatchMessageW, KillTimer, MsgWaitForMultipleObjectsEx, PeekMessageW, SetTimer,
-            TranslateMessage, MWMO_ALERTABLE, MWMO_INPUTAVAILABLE, PM_REMOVE, QS_ALLINPUT,
+            DispatchMessageW, KillTimer, MWMO_ALERTABLE, MWMO_INPUTAVAILABLE,
+            MsgWaitForMultipleObjectsEx, PM_REMOVE, PeekMessageW, QS_ALLINPUT, SetTimer,
+            TranslateMessage,
         },
     };
 
@@ -218,8 +219,8 @@ fn glib_context() {
     use std::{future::Future, time::Duration};
 
     use compio_driver::AsRawFd;
-    use compio_runtime::{event::Event, Runtime};
-    use glib::{timeout_add_local_once, unix_fd_add_local, ControlFlow, IOCondition, MainContext};
+    use compio_runtime::{Runtime, event::Event};
+    use glib::{ControlFlow, IOCondition, MainContext, timeout_add_local_once, unix_fd_add_local};
 
     struct GLibRuntime {
         runtime: Runtime,

--- a/compio-runtime/tests/event.rs
+++ b/compio-runtime/tests/event.rs
@@ -25,10 +25,10 @@ fn win32_event() {
         task::Poll,
     };
 
-    use compio_driver::{syscall, OpCode, OpType};
+    use compio_driver::{OpCode, OpType, syscall};
     use windows_sys::Win32::System::{
-        Threading::{CreateEventW, SetEvent},
         IO::OVERLAPPED,
+        Threading::{CreateEventW, SetEvent},
     };
 
     struct WaitEvent {

--- a/compio-signal/src/linux.rs
+++ b/compio-signal/src/linux.rs
@@ -6,7 +6,7 @@ use std::{
 };
 
 use compio_buf::{BufResult, IntoInner, IoBuf, IoBufMut, SetBufInit};
-use compio_driver::{op::Recv, syscall, OwnedFd, SharedFd};
+use compio_driver::{OwnedFd, SharedFd, op::Recv, syscall};
 
 thread_local! {
     static REG_MAP: RefCell<HashMap<i32, usize>> = RefCell::new(HashMap::new());

--- a/compio-signal/src/windows.rs
+++ b/compio-signal/src/windows.rs
@@ -16,8 +16,8 @@ use slab::Slab;
 use windows_sys::Win32::{
     Foundation::BOOL,
     System::Console::{
-        SetConsoleCtrlHandler, CTRL_BREAK_EVENT, CTRL_CLOSE_EVENT, CTRL_C_EVENT, CTRL_LOGOFF_EVENT,
-        CTRL_SHUTDOWN_EVENT,
+        CTRL_BREAK_EVENT, CTRL_C_EVENT, CTRL_CLOSE_EVENT, CTRL_LOGOFF_EVENT, CTRL_SHUTDOWN_EVENT,
+        SetConsoleCtrlHandler,
     },
 };
 

--- a/compio-tls/src/adapter/mod.rs
+++ b/compio-tls/src/adapter/mod.rs
@@ -1,6 +1,6 @@
 use std::io;
 
-use compio_io::{compat::SyncStream, AsyncRead, AsyncWrite};
+use compio_io::{AsyncRead, AsyncWrite, compat::SyncStream};
 
 use crate::TlsStream;
 

--- a/compio-tls/src/adapter/rtls.rs
+++ b/compio-tls/src/adapter/rtls.rs
@@ -1,9 +1,9 @@
 use std::{io, ops::DerefMut, sync::Arc};
 
-use compio_io::{compat::SyncStream, AsyncRead, AsyncWrite};
+use compio_io::{AsyncRead, AsyncWrite, compat::SyncStream};
 use rustls::{
-    pki_types::ServerName, ClientConfig, ClientConnection, ConnectionCommon, Error, ServerConfig,
-    ServerConnection,
+    ClientConfig, ClientConnection, ConnectionCommon, Error, ServerConfig, ServerConnection,
+    pki_types::ServerName,
 };
 
 use crate::TlsStream;

--- a/compio-tls/src/stream/mod.rs
+++ b/compio-tls/src/stream/mod.rs
@@ -1,7 +1,7 @@
 use std::{borrow::Cow, io, mem::MaybeUninit};
 
 use compio_buf::{BufResult, IoBuf, IoBufMut};
-use compio_io::{compat::SyncStream, AsyncRead, AsyncWrite};
+use compio_io::{AsyncRead, AsyncWrite, compat::SyncStream};
 
 #[cfg(feature = "rustls")]
 mod rtls;

--- a/compio/benches/fs.rs
+++ b/compio/benches/fs.rs
@@ -7,9 +7,9 @@ use std::{
 
 use compio_buf::{IntoInner, IoBuf};
 use compio_io::{AsyncReadAt, AsyncWriteAt};
-use criterion::{criterion_group, criterion_main, Bencher, Criterion, Throughput};
-use futures_util::{stream::FuturesUnordered, StreamExt};
-use rand::{thread_rng, Rng, RngCore};
+use criterion::{Bencher, Criterion, Throughput, criterion_group, criterion_main};
+use futures_util::{StreamExt, stream::FuturesUnordered};
+use rand::{Rng, RngCore, thread_rng};
 use tempfile::NamedTempFile;
 use tokio::io::{AsyncReadExt, AsyncSeekExt, AsyncWriteExt};
 

--- a/compio/benches/net.rs
+++ b/compio/benches/net.rs
@@ -1,7 +1,7 @@
 use std::{net::Ipv4Addr, rc::Rc, time::Instant};
 
-use criterion::{criterion_group, criterion_main, Bencher, Criterion, Throughput};
-use rand::{thread_rng, RngCore};
+use criterion::{Bencher, Criterion, Throughput, criterion_group, criterion_main};
+use rand::{RngCore, thread_rng};
 
 #[cfg(target_os = "linux")]
 mod monoio_wrap;

--- a/compio/examples/dispatcher.rs
+++ b/compio/examples/dispatcher.rs
@@ -1,13 +1,13 @@
 use std::num::NonZeroUsize;
 
 use compio::{
+    BufResult,
     dispatcher::Dispatcher,
     io::{AsyncRead, AsyncWriteExt},
     net::{TcpListener, TcpStream},
     runtime::spawn,
-    BufResult,
 };
-use futures_util::{stream::FuturesUnordered, StreamExt};
+use futures_util::{StreamExt, stream::FuturesUnordered};
 
 #[compio::main]
 async fn main() {

--- a/compio/examples/driver.rs
+++ b/compio/examples/driver.rs
@@ -1,8 +1,8 @@
 use compio::{
-    buf::{arrayvec::ArrayVec, IntoInner},
+    buf::{IntoInner, arrayvec::ArrayVec},
     driver::{
-        op::{CloseFile, ReadAt},
         AsRawFd, OpCode, OwnedFd, Proactor, PushEntry, SharedFd,
+        op::{CloseFile, ReadAt},
     },
 };
 
@@ -13,7 +13,7 @@ fn open_file(driver: &mut Proactor) -> OwnedFd {
         io::{FromRawHandle, IntoRawHandle, OwnedHandle},
     };
 
-    use compio::{driver::op::Asyncify, BufResult};
+    use compio::{BufResult, driver::op::Asyncify};
     use windows_sys::Win32::Storage::FileSystem::FILE_FLAG_OVERLAPPED;
 
     let op = Asyncify::new(|| {

--- a/compio/examples/named_pipe.rs
+++ b/compio/examples/named_pipe.rs
@@ -1,6 +1,6 @@
 use compio::{
-    io::{AsyncReadExt, AsyncWriteExt},
     BufResult,
+    io::{AsyncReadExt, AsyncWriteExt},
 };
 
 #[compio::main]

--- a/compio/examples/resolve.rs
+++ b/compio/examples/resolve.rs
@@ -1,5 +1,5 @@
 use compio::net::ToSocketAddrsAsync;
-use futures_util::{stream::FuturesUnordered, StreamExt};
+use futures_util::{StreamExt, stream::FuturesUnordered};
 
 #[compio::main]
 async fn main() {

--- a/compio/examples/tick.rs
+++ b/compio/examples/tick.rs
@@ -1,7 +1,7 @@
 use std::time::Duration;
 
 use compio::{signal::ctrl_c, time::interval};
-use futures_util::{select, FutureExt};
+use futures_util::{FutureExt, select};
 
 #[compio::main]
 async fn main() {

--- a/compio/src/lib.rs
+++ b/compio/src/lib.rs
@@ -22,14 +22,14 @@
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 #![warn(missing_docs)]
 
+#[doc(no_inline)]
+pub use buf::BufResult;
 #[cfg(feature = "arrayvec")]
 pub use buf::arrayvec;
 #[cfg(feature = "bumpalo")]
 pub use buf::bumpalo;
 #[cfg(feature = "bytes")]
 pub use buf::bytes;
-#[doc(no_inline)]
-pub use buf::BufResult;
 #[cfg(feature = "dispatcher")]
 #[doc(inline)]
 pub use compio_dispatcher as dispatcher;

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,6 +1,6 @@
 unstable_features = true
 
-version = "Two"
+style_edition = "2021"
 
 group_imports = "StdExternalCrate"
 imports_granularity = "Crate"

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,6 +1,6 @@
 unstable_features = true
 
-style_edition = "2021"
+style_edition = "2024"
 
 group_imports = "StdExternalCrate"
 imports_granularity = "Crate"


### PR DESCRIPTION
`version = "Two"` has been deprecated and corresponds to `style_edition = "2024"`. But in that case there are around 80 files to be changed. I set the style edition to 2021 to make the changes smaller.

@George-Miao you are the provider of the config, what's your opinion?