### PR TITLE
fix(driver,poll,iour): use Arc::clone instead of try_clone

### DIFF
--- a/compio-driver/Cargo.toml
+++ b/compio-driver/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "compio-driver"
-version = "0.5.0"
+version = "0.5.1"
 description = "Low-level driver for compio"
 categories = ["asynchronous"]
 keywords = ["async", "iocp", "io-uring"]

--- a/compio-net/src/cmsg/mod.rs
+++ b/compio-net/src/cmsg/mod.rs
@@ -13,7 +13,7 @@ cfg_if::cfg_if! {
 /// Reference to a control message.
 pub struct CMsgRef<'a>(sys::CMsgRef<'a>);
 
-impl<'a> CMsgRef<'a> {
+impl CMsgRef<'_> {
     /// Returns the level of the control message.
     pub fn level(&self) -> i32 {
         self.0.level()

--- a/compio-net/src/cmsg/unix.rs
+++ b/compio-net/src/cmsg/unix.rs
@@ -2,7 +2,7 @@ use libc::{CMSG_DATA, CMSG_FIRSTHDR, CMSG_LEN, CMSG_NXTHDR, CMSG_SPACE, c_int, c
 
 pub(crate) struct CMsgRef<'a>(&'a cmsghdr);
 
-impl<'a> CMsgRef<'a> {
+impl CMsgRef<'_> {
     pub(crate) fn level(&self) -> c_int {
         self.0.cmsg_level
     }
@@ -23,7 +23,7 @@ impl<'a> CMsgRef<'a> {
 
 pub(crate) struct CMsgMut<'a>(&'a mut cmsghdr);
 
-impl<'a> CMsgMut<'a> {
+impl CMsgMut<'_> {
     pub(crate) fn set_level(&mut self, level: c_int) {
         self.0.cmsg_level = level;
     }

--- a/compio-net/src/cmsg/windows.rs
+++ b/compio-net/src/cmsg/windows.rs
@@ -55,7 +55,7 @@ const fn wsa_cmsg_len(length: usize) -> usize {
 
 pub struct CMsgRef<'a>(&'a CMSGHDR);
 
-impl<'a> CMsgRef<'a> {
+impl CMsgRef<'_> {
     pub fn level(&self) -> i32 {
         self.0.cmsg_level
     }
@@ -76,7 +76,7 @@ impl<'a> CMsgRef<'a> {
 
 pub(crate) struct CMsgMut<'a>(&'a mut CMSGHDR);
 
-impl<'a> CMsgMut<'a> {
+impl CMsgMut<'_> {
     pub(crate) fn set_level(&mut self, level: i32) {
         self.0.cmsg_level = level;
     }

--- a/compio-tls/tests/connect.rs
+++ b/compio-tls/tests/connect.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use compio_io::{AsyncReadExt, AsyncWrite, AsyncWriteExt};
 use compio_net::TcpStream;
 use compio_tls::TlsConnector;
@@ -33,7 +31,7 @@ async fn rtls() {
         store.add(cert).unwrap();
     }
 
-    let connector = TlsConnector::from(Arc::new(
+    let connector = TlsConnector::from(std::sync::Arc::new(
         rustls::ClientConfig::builder()
             .with_root_certificates(store)
             .with_no_client_auth(),


### PR DESCRIPTION
Closes #305 

Some other changes are made to make clippy happy.