### PR TITLE
refactor(net,iocp): move WSAStartup

### DIFF
--- a/compio-net/Cargo.toml
+++ b/compio-net/Cargo.toml
@@ -23,6 +23,7 @@ compio-runtime = { workspace = true, features = ["event"] }
 
 cfg-if = { workspace = true }
 either = "1.9.0"
+once_cell = { workspace = true }
 socket2 = { workspace = true, features = ["all"] }
 
 [target.'cfg(windows)'.dependencies]
@@ -45,3 +46,7 @@ tempfile = { workspace = true }
 [features]
 default = []
 io-uring = ["compio-driver/io-uring"]
+
+# Nightly features
+once_cell_try = []
+nightly = ["once_cell_try"]

--- a/compio-net/src/lib.rs
+++ b/compio-net/src/lib.rs
@@ -3,6 +3,7 @@
 //! Currently, TCP/UDP/Unix socket are implemented.
 
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+#![cfg_attr(feature = "once_cell_try", feature(once_cell_try))]
 #![warn(missing_docs)]
 
 mod cmsg;

--- a/compio/Cargo.toml
+++ b/compio/Cargo.toml
@@ -121,7 +121,11 @@ enable_log = ["compio-log/enable_log"]
 allocator_api = ["compio-buf/allocator_api", "compio-io?/allocator_api"]
 lazy_cell = ["compio-signal?/lazy_cell"]
 linux_pidfd = ["compio-process?/linux_pidfd"]
-once_cell_try = ["compio-driver/once_cell_try", "compio-signal?/once_cell_try"]
+once_cell_try = [
+    "compio-driver/once_cell_try",
+    "compio-net?/once_cell_try",
+    "compio-signal?/once_cell_try",
+]
 read_buf = [
     "compio-buf/read_buf",
     "compio-io?/read_buf",


### PR DESCRIPTION
Only in async resolve is `WSAStartup` needed. In other cases, `socket2` helps us.

This change will benefit the users who don't use sockets at all. They won't need to load WS2_32.dll at startup.