### PR TITLE
fix(net,iour,poll): fix accept leak

### DIFF
--- a/compio-driver/src/iour/mod.rs
+++ b/compio-driver/src/iour/mod.rs
@@ -65,6 +65,15 @@ pub trait OpCode {
     fn call_blocking(self: Pin<&mut Self>) -> io::Result<usize> {
         unreachable!("this operation is asynchronous")
     }
+
+    /// Set the result when it successfully completes.
+    /// The operation stores the result and is responsible to release it if the
+    /// operation is cancelled.
+    ///
+    /// # Safety
+    ///
+    /// Users should not call it.
+    unsafe fn set_result(self: Pin<&mut Self>, _: usize) {}
 }
 
 /// Low-level driver of io-uring.

--- a/compio-driver/src/iour/op.rs
+++ b/compio-driver/src/iour/op.rs
@@ -1,4 +1,10 @@
-use std::{ffi::CString, io, marker::PhantomPinned, os::fd::AsRawFd, pin::Pin};
+use std::{
+    ffi::CString,
+    io,
+    marker::PhantomPinned,
+    os::fd::{AsRawFd, FromRawFd, OwnedFd},
+    pin::Pin,
+};
 
 use compio_buf::{
     BufResult, IntoInner, IoBuf, IoBufMut, IoSlice, IoSliceMut, IoVectoredBuf, IoVectoredBufMut,
@@ -294,6 +300,10 @@ impl<S: AsRawFd> OpCode for Accept<S> {
         )
         .build()
         .into()
+    }
+
+    unsafe fn set_result(self: Pin<&mut Self>, fd: usize) {
+        self.get_unchecked_mut().accepted_fd = Some(OwnedFd::from_raw_fd(fd as _));
     }
 }
 

--- a/compio-net/src/socket.rs
+++ b/compio-net/src/socket.rs
@@ -162,6 +162,7 @@ impl Socket {
 
         let op = Accept::new(self.to_shared_fd());
         let BufResult(res, op) = compio_runtime::submit(op).await;
+        let addr = op.into_addr();
         let accept_sock = unsafe { Socket2::from_raw_fd(res? as _) };
         if cfg!(all(
             unix,
@@ -170,7 +171,6 @@ impl Socket {
             accept_sock.set_nonblocking(true)?;
         }
         let accept_sock = Self::from_socket2(accept_sock)?;
-        let addr = op.into_addr();
         Ok((accept_sock, addr))
     }
 


### PR DESCRIPTION
On Unix, the accept operation may be cancelled after completed. In that case the accepted fd is leaked and the client may stuck. This PR fixes the issue by temporarily storing the fd in the op.

The issue doesn't affect IOCP.