### PR TITLE
refactor(driver,poll): remove event in on_event

### DIFF
--- a/compio-driver/src/fusion/op.rs
+++ b/compio-driver/src/fusion/op.rs
@@ -74,9 +74,8 @@ macro_rules! op {
 
             fn on_event(
                 self: std::pin::Pin<&mut Self>,
-                event: &polling::Event,
             ) -> std::task::Poll<std::io::Result<usize>> {
-                unsafe { self.map_unchecked_mut(|x| x.inner.poll() ) }.on_event(event)
+                unsafe { self.map_unchecked_mut(|x| x.inner.poll() ) }.on_event()
             }
         }
 

--- a/compio-driver/src/fusion/op.rs
+++ b/compio-driver/src/fusion/op.rs
@@ -72,10 +72,10 @@ macro_rules! op {
                 unsafe { self.map_unchecked_mut(|x| x.inner.poll() ) }.pre_submit()
             }
 
-            fn on_event(
+            fn operate(
                 self: std::pin::Pin<&mut Self>,
             ) -> std::task::Poll<std::io::Result<usize>> {
-                unsafe { self.map_unchecked_mut(|x| x.inner.poll() ) }.on_event()
+                unsafe { self.map_unchecked_mut(|x| x.inner.poll() ) }.operate()
             }
         }
 

--- a/compio-driver/src/poll/op.rs
+++ b/compio-driver/src/poll/op.rs
@@ -18,7 +18,6 @@ use libc::open64 as open;
 use libc::{pread, preadv, pwrite, pwritev};
 #[cfg(any(target_os = "linux", target_os = "android", target_os = "hurd"))]
 use libc::{pread64 as pread, preadv64 as preadv, pwrite64 as pwrite, pwritev64 as pwritev};
-use polling::Event;
 use socket2::SockAddr;
 
 use super::{AsRawFd, Decision, OpCode, sockaddr_storage, socklen_t, syscall};
@@ -31,10 +30,10 @@ impl<
 > OpCode for Asyncify<F, D>
 {
     fn pre_submit(self: Pin<&mut Self>) -> io::Result<Decision> {
-        Ok(Decision::blocking_dummy())
+        Ok(Decision::Blocking)
     }
 
-    fn on_event(self: Pin<&mut Self>, _: &Event) -> Poll<io::Result<usize>> {
+    fn on_event(self: Pin<&mut Self>) -> Poll<io::Result<usize>> {
         // Safety: self won't be moved
         let this = unsafe { self.get_unchecked_mut() };
         let f = this
@@ -49,10 +48,10 @@ impl<
 
 impl OpCode for OpenFile {
     fn pre_submit(self: Pin<&mut Self>) -> io::Result<Decision> {
-        Ok(Decision::blocking_dummy())
+        Ok(Decision::Blocking)
     }
 
-    fn on_event(self: Pin<&mut Self>, _: &Event) -> Poll<io::Result<usize>> {
+    fn on_event(self: Pin<&mut Self>) -> Poll<io::Result<usize>> {
         Poll::Ready(Ok(syscall!(open(
             self.path.as_ptr(),
             self.flags,
@@ -63,10 +62,10 @@ impl OpCode for OpenFile {
 
 impl OpCode for CloseFile {
     fn pre_submit(self: Pin<&mut Self>) -> io::Result<Decision> {
-        Ok(Decision::blocking_dummy())
+        Ok(Decision::Blocking)
     }
 
-    fn on_event(self: Pin<&mut Self>, _: &Event) -> Poll<io::Result<usize>> {
+    fn on_event(self: Pin<&mut Self>) -> Poll<io::Result<usize>> {
         Poll::Ready(Ok(syscall!(libc::close(self.fd.as_raw_fd()))? as _))
     }
 }
@@ -89,10 +88,10 @@ impl<S> FileStat<S> {
 
 impl<S: AsRawFd> OpCode for FileStat<S> {
     fn pre_submit(self: Pin<&mut Self>) -> io::Result<Decision> {
-        Ok(Decision::blocking_dummy())
+        Ok(Decision::Blocking)
     }
 
-    fn on_event(mut self: Pin<&mut Self>, _: &Event) -> Poll<io::Result<usize>> {
+    fn on_event(mut self: Pin<&mut Self>) -> Poll<io::Result<usize>> {
         #[cfg(all(target_os = "linux", target_env = "gnu"))]
         {
             let mut s: libc::statx = unsafe { std::mem::zeroed() };
@@ -144,10 +143,10 @@ impl PathStat {
 
 impl OpCode for PathStat {
     fn pre_submit(self: Pin<&mut Self>) -> io::Result<Decision> {
-        Ok(Decision::blocking_dummy())
+        Ok(Decision::Blocking)
     }
 
-    fn on_event(mut self: Pin<&mut Self>, _: &Event) -> Poll<io::Result<usize>> {
+    fn on_event(mut self: Pin<&mut Self>) -> Poll<io::Result<usize>> {
         #[cfg(all(target_os = "linux", target_env = "gnu"))]
         {
             let mut flags = libc::AT_EMPTY_PATH;
@@ -187,12 +186,10 @@ impl IntoInner for PathStat {
 
 impl<T: IoBufMut, S: AsRawFd> OpCode for ReadAt<T, S> {
     fn pre_submit(self: Pin<&mut Self>) -> io::Result<Decision> {
-        Ok(Decision::blocking_readable(self.fd.as_raw_fd()))
+        Ok(Decision::Blocking)
     }
 
-    fn on_event(self: Pin<&mut Self>, event: &Event) -> Poll<io::Result<usize>> {
-        debug_assert!(event.readable);
-
+    fn on_event(self: Pin<&mut Self>) -> Poll<io::Result<usize>> {
         let fd = self.fd.as_raw_fd();
         let offset = self.offset;
         let slice = unsafe { self.get_unchecked_mut() }.buffer.as_mut_slice();
@@ -202,12 +199,10 @@ impl<T: IoBufMut, S: AsRawFd> OpCode for ReadAt<T, S> {
 
 impl<T: IoVectoredBufMut, S: AsRawFd> OpCode for ReadVectoredAt<T, S> {
     fn pre_submit(self: Pin<&mut Self>) -> io::Result<Decision> {
-        Ok(Decision::blocking_readable(self.fd.as_raw_fd()))
+        Ok(Decision::Blocking)
     }
 
-    fn on_event(self: Pin<&mut Self>, event: &Event) -> Poll<io::Result<usize>> {
-        debug_assert!(event.readable);
-
+    fn on_event(self: Pin<&mut Self>) -> Poll<io::Result<usize>> {
         let this = unsafe { self.get_unchecked_mut() };
         this.slices = unsafe { this.buffer.io_slices_mut() };
         syscall!(
@@ -223,12 +218,10 @@ impl<T: IoVectoredBufMut, S: AsRawFd> OpCode for ReadVectoredAt<T, S> {
 
 impl<T: IoBuf, S: AsRawFd> OpCode for WriteAt<T, S> {
     fn pre_submit(self: Pin<&mut Self>) -> io::Result<Decision> {
-        Ok(Decision::blocking_writable(self.fd.as_raw_fd()))
+        Ok(Decision::Blocking)
     }
 
-    fn on_event(self: Pin<&mut Self>, event: &Event) -> Poll<io::Result<usize>> {
-        debug_assert!(event.writable);
-
+    fn on_event(self: Pin<&mut Self>) -> Poll<io::Result<usize>> {
         let slice = self.buffer.as_slice();
         syscall!(
             break pwrite(
@@ -243,12 +236,10 @@ impl<T: IoBuf, S: AsRawFd> OpCode for WriteAt<T, S> {
 
 impl<T: IoVectoredBuf, S: AsRawFd> OpCode for WriteVectoredAt<T, S> {
     fn pre_submit(self: Pin<&mut Self>) -> io::Result<Decision> {
-        Ok(Decision::blocking_writable(self.fd.as_raw_fd()))
+        Ok(Decision::Blocking)
     }
 
-    fn on_event(self: Pin<&mut Self>, event: &Event) -> Poll<io::Result<usize>> {
-        debug_assert!(event.writable);
-
+    fn on_event(self: Pin<&mut Self>) -> Poll<io::Result<usize>> {
         let this = unsafe { self.get_unchecked_mut() };
         this.slices = unsafe { this.buffer.io_slices() };
         syscall!(
@@ -264,10 +255,10 @@ impl<T: IoVectoredBuf, S: AsRawFd> OpCode for WriteVectoredAt<T, S> {
 
 impl<S: AsRawFd> OpCode for Sync<S> {
     fn pre_submit(self: Pin<&mut Self>) -> io::Result<Decision> {
-        Ok(Decision::blocking_dummy())
+        Ok(Decision::Blocking)
     }
 
-    fn on_event(self: Pin<&mut Self>, _: &Event) -> Poll<io::Result<usize>> {
+    fn on_event(self: Pin<&mut Self>) -> Poll<io::Result<usize>> {
         #[cfg(any(
             target_os = "android",
             target_os = "freebsd",
@@ -299,10 +290,10 @@ impl<S: AsRawFd> OpCode for Sync<S> {
 
 impl OpCode for Unlink {
     fn pre_submit(self: Pin<&mut Self>) -> io::Result<Decision> {
-        Ok(Decision::blocking_dummy())
+        Ok(Decision::Blocking)
     }
 
-    fn on_event(self: Pin<&mut Self>, _: &Event) -> Poll<io::Result<usize>> {
+    fn on_event(self: Pin<&mut Self>) -> Poll<io::Result<usize>> {
         if self.dir {
             syscall!(libc::rmdir(self.path.as_ptr()))?;
         } else {
@@ -314,10 +305,10 @@ impl OpCode for Unlink {
 
 impl OpCode for CreateDir {
     fn pre_submit(self: Pin<&mut Self>) -> io::Result<Decision> {
-        Ok(Decision::blocking_dummy())
+        Ok(Decision::Blocking)
     }
 
-    fn on_event(self: Pin<&mut Self>, _: &Event) -> Poll<io::Result<usize>> {
+    fn on_event(self: Pin<&mut Self>) -> Poll<io::Result<usize>> {
         syscall!(libc::mkdir(self.path.as_ptr(), self.mode))?;
         Poll::Ready(Ok(0))
     }
@@ -325,10 +316,10 @@ impl OpCode for CreateDir {
 
 impl OpCode for Rename {
     fn pre_submit(self: Pin<&mut Self>) -> io::Result<Decision> {
-        Ok(Decision::blocking_dummy())
+        Ok(Decision::Blocking)
     }
 
-    fn on_event(self: Pin<&mut Self>, _: &Event) -> Poll<io::Result<usize>> {
+    fn on_event(self: Pin<&mut Self>) -> Poll<io::Result<usize>> {
         syscall!(libc::rename(self.old_path.as_ptr(), self.new_path.as_ptr()))?;
         Poll::Ready(Ok(0))
     }
@@ -336,10 +327,10 @@ impl OpCode for Rename {
 
 impl OpCode for Symlink {
     fn pre_submit(self: Pin<&mut Self>) -> io::Result<Decision> {
-        Ok(Decision::blocking_dummy())
+        Ok(Decision::Blocking)
     }
 
-    fn on_event(self: Pin<&mut Self>, _: &Event) -> Poll<io::Result<usize>> {
+    fn on_event(self: Pin<&mut Self>) -> Poll<io::Result<usize>> {
         syscall!(libc::symlink(self.source.as_ptr(), self.target.as_ptr()))?;
         Poll::Ready(Ok(0))
     }
@@ -347,10 +338,10 @@ impl OpCode for Symlink {
 
 impl OpCode for HardLink {
     fn pre_submit(self: Pin<&mut Self>) -> io::Result<Decision> {
-        Ok(Decision::blocking_dummy())
+        Ok(Decision::Blocking)
     }
 
-    fn on_event(self: Pin<&mut Self>, _: &Event) -> Poll<io::Result<usize>> {
+    fn on_event(self: Pin<&mut Self>) -> Poll<io::Result<usize>> {
         syscall!(libc::link(self.source.as_ptr(), self.target.as_ptr()))?;
         Poll::Ready(Ok(0))
     }
@@ -358,10 +349,10 @@ impl OpCode for HardLink {
 
 impl OpCode for CreateSocket {
     fn pre_submit(self: Pin<&mut Self>) -> io::Result<Decision> {
-        Ok(Decision::blocking_dummy())
+        Ok(Decision::Blocking)
     }
 
-    fn on_event(self: Pin<&mut Self>, _: &Event) -> Poll<io::Result<usize>> {
+    fn on_event(self: Pin<&mut Self>) -> Poll<io::Result<usize>> {
         Poll::Ready(Ok(
             syscall!(libc::socket(self.domain, self.socket_type, self.protocol))? as _,
         ))
@@ -370,10 +361,10 @@ impl OpCode for CreateSocket {
 
 impl<S: AsRawFd> OpCode for ShutdownSocket<S> {
     fn pre_submit(self: Pin<&mut Self>) -> io::Result<Decision> {
-        Ok(Decision::blocking_dummy())
+        Ok(Decision::Blocking)
     }
 
-    fn on_event(self: Pin<&mut Self>, _: &Event) -> Poll<io::Result<usize>> {
+    fn on_event(self: Pin<&mut Self>) -> Poll<io::Result<usize>> {
         Poll::Ready(Ok(
             syscall!(libc::shutdown(self.fd.as_raw_fd(), self.how()))? as _,
         ))
@@ -382,10 +373,10 @@ impl<S: AsRawFd> OpCode for ShutdownSocket<S> {
 
 impl OpCode for CloseSocket {
     fn pre_submit(self: Pin<&mut Self>) -> io::Result<Decision> {
-        Ok(Decision::blocking_dummy())
+        Ok(Decision::Blocking)
     }
 
-    fn on_event(self: Pin<&mut Self>, _: &Event) -> Poll<io::Result<usize>> {
+    fn on_event(self: Pin<&mut Self>) -> Poll<io::Result<usize>> {
         Poll::Ready(Ok(syscall!(libc::close(self.fd.as_raw_fd()))? as _))
     }
 }
@@ -407,9 +398,7 @@ impl<S: AsRawFd> OpCode for Accept<S> {
         syscall!(self.as_mut().call(), wait_readable(fd))
     }
 
-    fn on_event(mut self: Pin<&mut Self>, event: &Event) -> Poll<io::Result<usize>> {
-        debug_assert!(event.readable);
-
+    fn on_event(mut self: Pin<&mut Self>) -> Poll<io::Result<usize>> {
         let res = syscall!(break self.as_mut().call());
         if let Poll::Ready(Ok(fd)) = res {
             unsafe {
@@ -428,9 +417,7 @@ impl<S: AsRawFd> OpCode for Connect<S> {
         )
     }
 
-    fn on_event(self: Pin<&mut Self>, event: &Event) -> Poll<io::Result<usize>> {
-        debug_assert!(event.writable);
-
+    fn on_event(self: Pin<&mut Self>) -> Poll<io::Result<usize>> {
         let mut err: libc::c_int = 0;
         let mut err_len = std::mem::size_of::<libc::c_int>() as libc::socklen_t;
 
@@ -456,9 +443,7 @@ impl<T: IoBufMut, S: AsRawFd> OpCode for Recv<T, S> {
         Ok(Decision::wait_readable(self.fd.as_raw_fd()))
     }
 
-    fn on_event(self: Pin<&mut Self>, event: &Event) -> Poll<io::Result<usize>> {
-        debug_assert!(event.readable);
-
+    fn on_event(self: Pin<&mut Self>) -> Poll<io::Result<usize>> {
         let fd = self.fd.as_raw_fd();
         let slice = unsafe { self.get_unchecked_mut() }.buffer.as_mut_slice();
         syscall!(break libc::read(fd, slice.as_mut_ptr() as _, slice.len()))
@@ -470,9 +455,7 @@ impl<T: IoVectoredBufMut, S: AsRawFd> OpCode for RecvVectored<T, S> {
         Ok(Decision::wait_readable(self.fd.as_raw_fd()))
     }
 
-    fn on_event(self: Pin<&mut Self>, event: &Event) -> Poll<io::Result<usize>> {
-        debug_assert!(event.readable);
-
+    fn on_event(self: Pin<&mut Self>) -> Poll<io::Result<usize>> {
         let this = unsafe { self.get_unchecked_mut() };
         this.slices = unsafe { this.buffer.io_slices_mut() };
         syscall!(
@@ -490,9 +473,7 @@ impl<T: IoBuf, S: AsRawFd> OpCode for Send<T, S> {
         Ok(Decision::wait_writable(self.fd.as_raw_fd()))
     }
 
-    fn on_event(self: Pin<&mut Self>, event: &Event) -> Poll<io::Result<usize>> {
-        debug_assert!(event.writable);
-
+    fn on_event(self: Pin<&mut Self>) -> Poll<io::Result<usize>> {
         let slice = self.buffer.as_slice();
         syscall!(break libc::write(self.fd.as_raw_fd(), slice.as_ptr() as _, slice.len()))
     }
@@ -503,9 +484,7 @@ impl<T: IoVectoredBuf, S: AsRawFd> OpCode for SendVectored<T, S> {
         Ok(Decision::wait_writable(self.fd.as_raw_fd()))
     }
 
-    fn on_event(self: Pin<&mut Self>, event: &Event) -> Poll<io::Result<usize>> {
-        debug_assert!(event.writable);
-
+    fn on_event(self: Pin<&mut Self>) -> Poll<io::Result<usize>> {
         let this = unsafe { self.get_unchecked_mut() };
         this.slices = unsafe { this.buffer.io_slices() };
         syscall!(
@@ -562,9 +541,7 @@ impl<T: IoBufMut, S: AsRawFd> OpCode for RecvFrom<T, S> {
         syscall!(self.as_mut().call(), wait_readable(fd))
     }
 
-    fn on_event(mut self: Pin<&mut Self>, event: &Event) -> Poll<io::Result<usize>> {
-        debug_assert!(event.readable);
-
+    fn on_event(mut self: Pin<&mut Self>) -> Poll<io::Result<usize>> {
         syscall!(break self.as_mut().call())
     }
 }
@@ -627,9 +604,7 @@ impl<T: IoVectoredBufMut, S: AsRawFd> OpCode for RecvFromVectored<T, S> {
         syscall!(this.call(), wait_readable(this.fd.as_raw_fd()))
     }
 
-    fn on_event(self: Pin<&mut Self>, event: &Event) -> Poll<io::Result<usize>> {
-        debug_assert!(event.readable);
-
+    fn on_event(self: Pin<&mut Self>) -> Poll<io::Result<usize>> {
         let this = unsafe { self.get_unchecked_mut() };
         syscall!(break this.call())
     }
@@ -682,9 +657,7 @@ impl<T: IoBuf, S: AsRawFd> OpCode for SendTo<T, S> {
         syscall!(self.call(), wait_writable(self.fd.as_raw_fd()))
     }
 
-    fn on_event(self: Pin<&mut Self>, event: &Event) -> Poll<io::Result<usize>> {
-        debug_assert!(event.writable);
-
+    fn on_event(self: Pin<&mut Self>) -> Poll<io::Result<usize>> {
         syscall!(break self.call())
     }
 }
@@ -747,9 +720,7 @@ impl<T: IoVectoredBuf, S: AsRawFd> OpCode for SendToVectored<T, S> {
         syscall!(this.call(), wait_writable(this.fd.as_raw_fd()))
     }
 
-    fn on_event(self: Pin<&mut Self>, event: &Event) -> Poll<io::Result<usize>> {
-        debug_assert!(event.writable);
-
+    fn on_event(self: Pin<&mut Self>) -> Poll<io::Result<usize>> {
         syscall!(break self.call())
     }
 }
@@ -775,9 +746,7 @@ impl<T: IoVectoredBufMut, C: IoBufMut, S: AsRawFd> OpCode for RecvMsg<T, C, S> {
         syscall!(this.call(), wait_readable(this.fd.as_raw_fd()))
     }
 
-    fn on_event(self: Pin<&mut Self>, event: &Event) -> Poll<io::Result<usize>> {
-        debug_assert!(event.readable);
-
+    fn on_event(self: Pin<&mut Self>) -> Poll<io::Result<usize>> {
         let this = unsafe { self.get_unchecked_mut() };
         syscall!(break this.call())
     }
@@ -796,9 +765,7 @@ impl<T: IoVectoredBuf, C: IoBuf, S: AsRawFd> OpCode for SendMsg<T, C, S> {
         syscall!(this.call(), wait_writable(this.fd.as_raw_fd()))
     }
 
-    fn on_event(self: Pin<&mut Self>, event: &Event) -> Poll<io::Result<usize>> {
-        debug_assert!(event.writable);
-
+    fn on_event(self: Pin<&mut Self>) -> Poll<io::Result<usize>> {
         syscall!(break self.call())
     }
 }
@@ -808,12 +775,7 @@ impl<S: AsRawFd> OpCode for PollOnce<S> {
         Ok(Decision::wait_for(self.fd.as_raw_fd(), self.interest))
     }
 
-    fn on_event(self: Pin<&mut Self>, event: &Event) -> Poll<io::Result<usize>> {
-        match self.interest {
-            Interest::Readable => debug_assert!(event.readable),
-            Interest::Writable => debug_assert!(event.writable),
-        }
-
+    fn on_event(self: Pin<&mut Self>) -> Poll<io::Result<usize>> {
         Poll::Ready(Ok(0))
     }
 }


### PR DESCRIPTION
This is the first part of #310 . `event: Event` is a useless param in `on_event` now.