### PR TITLE
fix(runtime): forget op if no current runtime

### DIFF
--- a/compio-runtime/Cargo.toml
+++ b/compio-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "compio-runtime"
-version = "0.6.0"
+version = "0.6.1"
 description = "High-level runtime for compio"
 categories = ["asynchronous"]
 keywords = ["async", "runtime"]

--- a/compio-runtime/src/runtime/op.rs
+++ b/compio-runtime/src/runtime/op.rs
@@ -38,7 +38,8 @@ impl<T: OpCode> Future for OpFlagsFuture<T> {
 impl<T: OpCode> Drop for OpFlagsFuture<T> {
     fn drop(&mut self) {
         if let Some(key) = self.key.take() {
-            Runtime::with_current(|r| r.cancel_op(key))
+            // If there's no runtime, it's OK to forget it.
+            Runtime::try_with_current(|r| r.cancel_op(key)).ok();
         }
     }
 }

--- a/compio-runtime/src/runtime/time.rs
+++ b/compio-runtime/src/runtime/time.rs
@@ -144,7 +144,8 @@ impl Future for TimerFuture {
 
 impl Drop for TimerFuture {
     fn drop(&mut self) {
-        Runtime::with_current(|r| r.cancel_timer(self.key));
+        // If there's no runtime, it's OK to forget it.
+        Runtime::try_with_current(|r| r.cancel_timer(self.key)).ok();
     }
 }
 


### PR DESCRIPTION
Reported from cyper.