### PR TITLE
refactor(runtime): Rename `OpFlagsFuture` back to `OpFuture`

### DIFF
--- a/compio-runtime/src/runtime/mod.rs
+++ b/compio-runtime/src/runtime/mod.rs
@@ -29,7 +29,7 @@ use send_wrapper::SendWrapper;
 
 #[cfg(feature = "time")]
 use crate::runtime::time::{TimerFuture, TimerRuntime};
-use crate::{BufResult, runtime::op::OpFlagsFuture};
+use crate::{BufResult, runtime::op::OpFuture};
 
 scoped_tls::scoped_thread_local!(static CURRENT_RUNTIME: Runtime);
 
@@ -280,7 +280,7 @@ impl Runtime {
         op: T,
     ) -> impl Future<Output = (BufResult<usize, T>, u32)> {
         match self.submit_raw(op) {
-            PushEntry::Pending(user_data) => Either::Left(OpFlagsFuture::new(user_data)),
+            PushEntry::Pending(user_data) => Either::Left(OpFuture::new(user_data)),
             PushEntry::Ready(res) => {
                 // submit_flags won't be ready immediately, if ready, it must be error without
                 // flags

--- a/compio-runtime/src/runtime/op.rs
+++ b/compio-runtime/src/runtime/op.rs
@@ -10,17 +10,17 @@ use compio_driver::{Key, OpCode, PushEntry};
 use crate::runtime::Runtime;
 
 #[derive(Debug)]
-pub struct OpFlagsFuture<T: OpCode> {
+pub struct OpFuture<T: OpCode> {
     key: Option<Key<T>>,
 }
 
-impl<T: OpCode> OpFlagsFuture<T> {
+impl<T: OpCode> OpFuture<T> {
     pub fn new(key: Key<T>) -> Self {
         Self { key: Some(key) }
     }
 }
 
-impl<T: OpCode> Future for OpFlagsFuture<T> {
+impl<T: OpCode> Future for OpFuture<T> {
     type Output = (BufResult<usize, T>, u32);
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
@@ -35,7 +35,7 @@ impl<T: OpCode> Future for OpFlagsFuture<T> {
     }
 }
 
-impl<T: OpCode> Drop for OpFlagsFuture<T> {
+impl<T: OpCode> Drop for OpFuture<T> {
     fn drop(&mut self) {
         if let Some(key) = self.key.take() {
             // If there's no runtime, it's OK to forget it.


### PR DESCRIPTION
Original `OpFuture` was renamed to `OpFlagsFuture` in #272 for addition of flag. But I think the rename is unnecessary and `OpFlagsFuture` looks tedious, so I'd like to rename it back. Besides it's not a public API so such renaming will not be a breaking change.
