### PR TITLE
fix(driver): erase op type in driver

### DIFF
--- a/compio-driver/src/fusion/mod.rs
+++ b/compio-driver/src/fusion/mod.rs
@@ -63,14 +63,14 @@ impl Driver {
         }
     }
 
-    pub fn cancel<T: OpCode>(&mut self, op: Key<T>) {
+    pub fn cancel(&mut self, op: &mut Key<dyn OpCode>) {
         match &mut self.fuse {
             FuseDriver::Poll(driver) => driver.cancel(op),
             FuseDriver::IoUring(driver) => driver.cancel(op),
         }
     }
 
-    pub fn push<T: OpCode + 'static>(&mut self, op: &mut Key<T>) -> Poll<io::Result<usize>> {
+    pub fn push(&mut self, op: &mut Key<dyn OpCode>) -> Poll<io::Result<usize>> {
         match &mut self.fuse {
             FuseDriver::Poll(driver) => driver.push(op),
             FuseDriver::IoUring(driver) => driver.push(op),

--- a/compio-driver/src/iocp/mod.rs
+++ b/compio-driver/src/iocp/mod.rs
@@ -223,7 +223,7 @@ impl Driver {
         self.port.attach(fd)
     }
 
-    pub fn cancel<T: OpCode>(&mut self, mut op: Key<T>) {
+    pub fn cancel(&mut self, op: &mut Key<dyn OpCode>) {
         instrument!(compio_log::Level::TRACE, "cancel", ?op);
         trace!("cancel RawOp");
         let overlapped_ptr = op.as_mut_ptr();
@@ -240,7 +240,7 @@ impl Driver {
         unsafe { op.cancel(overlapped_ptr.cast()) }.ok();
     }
 
-    pub fn push<T: OpCode + 'static>(&mut self, op: &mut Key<T>) -> Poll<io::Result<usize>> {
+    pub fn push(&mut self, op: &mut Key<dyn OpCode>) -> Poll<io::Result<usize>> {
         instrument!(compio_log::Level::TRACE, "push", ?op);
         let user_data = op.user_data();
         trace!("push RawOp");

--- a/compio-driver/src/iocp/wait/packet.rs
+++ b/compio-driver/src/iocp/wait/packet.rs
@@ -10,7 +10,7 @@ use windows_sys::Win32::Foundation::{
     STATUS_SUCCESS,
 };
 
-use crate::{Key, RawFd, sys::cp};
+use crate::{Key, OpCode, RawFd, sys::cp};
 
 extern "system" {
     fn NtCreateWaitCompletionPacket(
@@ -52,7 +52,7 @@ fn check_status(status: NTSTATUS) -> io::Result<()> {
 }
 
 impl Wait {
-    pub fn new<T>(port: &cp::Port, event: RawFd, op: &mut Key<T>) -> io::Result<Self> {
+    pub fn new(port: &cp::Port, event: RawFd, op: &mut Key<dyn OpCode>) -> io::Result<Self> {
         let mut handle = 0;
         check_status(unsafe {
             NtCreateWaitCompletionPacket(&mut handle, GENERIC_READ | GENERIC_WRITE, null_mut())

--- a/compio-driver/src/iocp/wait/thread_pool.rs
+++ b/compio-driver/src/iocp/wait/thread_pool.rs
@@ -18,7 +18,7 @@ pub struct Wait {
 }
 
 impl Wait {
-    pub fn new<T>(port: &cp::Port, event: RawFd, op: &mut Key<T>) -> io::Result<Self> {
+    pub fn new(port: &cp::Port, event: RawFd, op: &mut Key<dyn OpCode>) -> io::Result<Self> {
         let port = port.handle();
         let mut context = Box::new(WinThreadpoolWaitContext {
             port,

--- a/compio-driver/src/iour/mod.rs
+++ b/compio-driver/src/iour/mod.rs
@@ -189,7 +189,7 @@ impl Driver {
         Ok(())
     }
 
-    pub fn cancel<T>(&mut self, op: Key<T>) {
+    pub fn cancel(&mut self, op: &mut Key<dyn crate::sys::OpCode>) {
         instrument!(compio_log::Level::TRACE, "cancel", ?op);
         trace!("cancel RawOp");
         unsafe {
@@ -235,10 +235,7 @@ impl Driver {
         }
     }
 
-    pub fn push<T: crate::sys::OpCode + 'static>(
-        &mut self,
-        op: &mut Key<T>,
-    ) -> Poll<io::Result<usize>> {
+    pub fn push(&mut self, op: &mut Key<dyn crate::sys::OpCode>) -> Poll<io::Result<usize>> {
         instrument!(compio_log::Level::TRACE, "push", ?op);
         let user_data = op.user_data();
         let op_pin = op.as_op_pin();

--- a/compio-driver/src/poll/mod.rs
+++ b/compio-driver/src/poll/mod.rs
@@ -219,11 +219,10 @@ impl Driver {
         Ok(())
     }
 
-    pub fn cancel<T: crate::sys::OpCode>(&mut self, op: Key<T>) {
+    pub fn cancel(&mut self, op: &mut Key<dyn crate::sys::OpCode>) {
         self.cancelled.insert(op.user_data());
         #[cfg(aio)]
         {
-            let mut op = op;
             let op = op.as_op_pin();
             if let Some(OpType::Aio(aiocbp)) = op.op_type() {
                 let aiocb = unsafe { aiocbp.as_ref() };
@@ -233,10 +232,7 @@ impl Driver {
         }
     }
 
-    pub fn push<T: crate::sys::OpCode + 'static>(
-        &mut self,
-        op: &mut Key<T>,
-    ) -> Poll<io::Result<usize>> {
+    pub fn push(&mut self, op: &mut Key<dyn crate::sys::OpCode>) -> Poll<io::Result<usize>> {
         instrument!(compio_log::Level::TRACE, "push", ?op);
         let user_data = op.user_data();
         let op_pin = op.as_op_pin();


### PR DESCRIPTION
It would benefit the binary size, but I don't know if it would benefit the performance.