### PR TITLE
fix(runtime): drop runnables manually

### DIFF
--- a/compio-runtime/Cargo.toml
+++ b/compio-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "compio-runtime"
-version = "0.6.1"
+version = "0.6.2"
 description = "High-level runtime for compio"
 categories = ["asynchronous"]
 keywords = ["async", "runtime"]

--- a/compio-runtime/src/runtime/op.rs
+++ b/compio-runtime/src/runtime/op.rs
@@ -38,8 +38,7 @@ impl<T: OpCode> Future for OpFuture<T> {
 impl<T: OpCode> Drop for OpFuture<T> {
     fn drop(&mut self) {
         if let Some(key) = self.key.take() {
-            // If there's no runtime, it's OK to forget it.
-            Runtime::try_with_current(|r| r.cancel_op(key)).ok();
+            Runtime::with_current(|r| r.cancel_op(key));
         }
     }
 }

--- a/compio-runtime/src/runtime/time.rs
+++ b/compio-runtime/src/runtime/time.rs
@@ -144,8 +144,7 @@ impl Future for TimerFuture {
 
 impl Drop for TimerFuture {
     fn drop(&mut self) {
-        // If there's no runtime, it's OK to forget it.
-        Runtime::try_with_current(|r| r.cancel_timer(self.key)).ok();
+        Runtime::with_current(|r| r.cancel_timer(self.key));
     }
 }
 


### PR DESCRIPTION
Closes #349 

I have to revert the changes of Arc -> Box. To avoid ref cycle, the runnables are popped manually on drop.

`self.enter` is used to make sure `OpFuture` and `TimerFuture` find the correct current runtime on drop.