### PR TITLE
refactor(io): revise vectored methods

### DIFF
--- a/compio-fs/tests/file.rs
+++ b/compio-fs/tests/file.rs
@@ -59,12 +59,7 @@ async fn writev() {
     let mut file = File::create(tempfile.path()).await.unwrap();
 
     let (write, _) = file.write_vectored_at([HELLO, HELLO], 0).await.unwrap();
-    assert_eq!(write, HELLO.len() * 2);
-    file.sync_all().await.unwrap();
-
-    let file = std::fs::read(tempfile.path()).unwrap();
-    assert_eq!(&file[..HELLO.len()], HELLO);
-    assert_eq!(&file[HELLO.len()..], HELLO);
+    assert!(write > 0);
 }
 
 #[compio_macros::test]

--- a/compio-io/src/read/mod.rs
+++ b/compio-io/src/read/mod.rs
@@ -96,7 +96,10 @@ impl AsyncRead for &[u8] {
             }
         }
 
-        BufResult(Ok(self.len() - this.len()), buf)
+        let len = self.len() - this.len();
+        *self = this;
+
+        BufResult(Ok(len), buf)
     }
 }
 

--- a/compio-io/src/write/ext.rs
+++ b/compio-io/src/write/ext.rs
@@ -75,17 +75,15 @@ macro_rules! loop_write_vectored {
 
         loop {
             let len = $iter.buf_len();
-            if len == 0 {
-                continue;
+            if len > 0 {
+                match $read_expr.await {
+                    BufResult(Ok(()), ret) => {
+                        $iter = ret;
+                        $tracker += len as $tracker_ty;
+                    }
+                    BufResult(Err(e), $iter) => return BufResult(Err(e), $iter.into_inner()),
+                };
             }
-
-            match $read_expr.await {
-                BufResult(Ok(()), ret) => {
-                    $iter = ret;
-                    $tracker += len as $tracker_ty;
-                }
-                BufResult(Err(e), $iter) => return BufResult(Err(e), $iter.into_inner()),
-            };
 
             match $iter.next() {
                 Ok(next) => $iter = next,
@@ -93,42 +91,22 @@ macro_rules! loop_write_vectored {
             }
         }
     }};
-    (
-        $buf:ident,
-        $tracker:ident :
-        $tracker_ty:ty,
-        $res:ident,
-        $iter:ident,loop
-        $read_expr:expr,break
-        $judge_expr:expr
-    ) => {{
+    ($buf:ident, $iter:ident, $read_expr:expr) => {{
         use ::compio_buf::OwnedIterator;
 
         let mut $iter = match $buf.owned_iter() {
             Ok(buf) => buf,
             Err(buf) => return BufResult(Ok(0), buf),
         };
-        let mut $tracker: $tracker_ty = 0;
 
         loop {
-            if $iter.buf_len() == 0 {
-                continue;
+            if $iter.buf_len() > 0 {
+                return $read_expr.await.into_inner();
             }
-
-            match $read_expr.await {
-                BufResult(Ok($res), ret) => {
-                    $iter = ret;
-                    $tracker += $res as $tracker_ty;
-                    if let Some(res) = $judge_expr {
-                        return BufResult(res, $iter.into_inner());
-                    }
-                }
-                BufResult(Err(e), $iter) => return BufResult(Err(e), $iter.into_inner()),
-            };
 
             match $iter.next() {
                 Ok(next) => $iter = next,
-                Err(buf) => return BufResult(Ok($tracker as usize), buf),
+                Err(buf) => return BufResult(Ok(0), buf),
             }
         }
     }};

--- a/compio-io/tests/io.rs
+++ b/compio-io/tests/io.rs
@@ -150,6 +150,16 @@ fn writev() {
 
         assert_eq!(len, 10);
         assert_eq!(dst.into_inner(), [1, 1, 4, 5, 1, 4, 1, 9, 1, 9]);
+
+        let mut dst = vec![];
+        let (len, _) = dst
+            .write_vectored([vec![1, 1, 4], vec![5, 1, 4]])
+            .await
+            .unwrap();
+
+        assert_eq!(len, 6);
+        assert_eq!(dst.len(), 6);
+        assert_eq!(dst, [1, 1, 4, 5, 1, 4]);
     })
 }
 
@@ -198,6 +208,16 @@ fn writev_at() {
 
         assert_eq!(len, 3);
         assert_eq!(dst, [0, 0, 1, 1, 4]);
+
+        let mut dst = vec![0u8; 5];
+        let (len, _) = dst
+            .write_vectored_at([vec![1, 1, 4], vec![5, 1, 4]], 2)
+            .await
+            .unwrap();
+
+        assert_eq!(len, 6);
+        assert_eq!(dst.len(), 8);
+        assert_eq!(dst, [0, 0, 1, 1, 4, 5, 1, 4]);
     })
 }
 


### PR DESCRIPTION
This is a refactor of vectored methods.

* Don't loop in fallback methods.
* More vectored methods for slices and vectors.