### PR TITLE
fix(fs,net,signal): check driver type on runtime

### DIFF
--- a/compio-fs/src/pipe.rs
+++ b/compio-fs/src/pipe.rs
@@ -513,7 +513,7 @@ async fn is_fifo(file: &File) -> io::Result<bool> {
 
 /// Sets file's flags with O_NONBLOCK by fcntl.
 fn set_nonblocking(file: &impl AsRawFd) -> io::Result<()> {
-    if cfg!(not(all(target_os = "linux", feature = "io-uring"))) {
+    if compio_driver::DriverType::is_polling() {
         let fd = file.as_raw_fd();
         let current_flags = syscall!(libc::fcntl(fd, libc::F_GETFL))?;
         let flags = current_flags | libc::O_NONBLOCK;

--- a/compio-fs/src/pipe.rs
+++ b/compio-fs/src/pipe.rs
@@ -513,7 +513,9 @@ async fn is_fifo(file: &File) -> io::Result<bool> {
 
 /// Sets file's flags with O_NONBLOCK by fcntl.
 fn set_nonblocking(file: &impl AsRawFd) -> io::Result<()> {
-    if compio_driver::DriverType::is_polling() {
+    if cfg!(not(all(target_os = "linux", feature = "io-uring")))
+        || compio_driver::DriverType::is_polling()
+    {
         let fd = file.as_raw_fd();
         let current_flags = syscall!(libc::fcntl(fd, libc::F_GETFL))?;
         let flags = current_flags | libc::O_NONBLOCK;

--- a/compio-net/src/socket.rs
+++ b/compio-net/src/socket.rs
@@ -56,7 +56,9 @@ impl Socket {
             // non blocking socket when there is no connections in listen queue
             //
             // https://patchwork.kernel.org/project/linux-block/patch/f999615b-205c-49b7-b272-c4e42e45e09d@kernel.dk/#22949861
-            if compio_driver::DriverType::is_polling() {
+            if cfg!(not(all(target_os = "linux", feature = "io-uring")))
+                || compio_driver::DriverType::is_polling()
+            {
                 socket.set_nonblocking(true)?;
             }
         }
@@ -161,7 +163,9 @@ impl Socket {
         let BufResult(res, op) = compio_runtime::submit(op).await;
         let addr = op.into_addr();
         let accept_sock = unsafe { Socket2::from_raw_fd(res? as _) };
-        if compio_driver::DriverType::is_polling() {
+        if cfg!(not(all(target_os = "linux", feature = "io-uring")))
+            || compio_driver::DriverType::is_polling()
+        {
             accept_sock.set_nonblocking(true)?;
         }
         let accept_sock = Self::from_socket2(accept_sock)?;

--- a/compio-net/src/socket.rs
+++ b/compio-net/src/socket.rs
@@ -56,10 +56,7 @@ impl Socket {
             // non blocking socket when there is no connections in listen queue
             //
             // https://patchwork.kernel.org/project/linux-block/patch/f999615b-205c-49b7-b272-c4e42e45e09d@kernel.dk/#22949861
-            if cfg!(all(
-                unix,
-                not(all(target_os = "linux", feature = "io-uring"))
-            )) {
+            if compio_driver::DriverType::is_polling() {
                 socket.set_nonblocking(true)?;
             }
         }
@@ -164,10 +161,7 @@ impl Socket {
         let BufResult(res, op) = compio_runtime::submit(op).await;
         let addr = op.into_addr();
         let accept_sock = unsafe { Socket2::from_raw_fd(res? as _) };
-        if cfg!(all(
-            unix,
-            not(all(target_os = "linux", feature = "io-uring"))
-        )) {
+        if compio_driver::DriverType::is_polling() {
             accept_sock.set_nonblocking(true)?;
         }
         let accept_sock = Self::from_socket2(accept_sock)?;

--- a/compio-signal/src/linux.rs
+++ b/compio-signal/src/linux.rs
@@ -57,7 +57,7 @@ impl SignalFd {
     fn new(sig: i32) -> io::Result<Self> {
         let set = register_signal(sig)?;
         let mut flag = libc::SFD_CLOEXEC;
-        if compio_driver::DriverType::is_polling() {
+        if cfg!(not(feature = "io-uring")) || compio_driver::DriverType::is_polling() {
             flag |= libc::SFD_NONBLOCK;
         }
         let fd = syscall!(libc::signalfd(-1, &set, flag))?;

--- a/compio-signal/src/linux.rs
+++ b/compio-signal/src/linux.rs
@@ -57,7 +57,7 @@ impl SignalFd {
     fn new(sig: i32) -> io::Result<Self> {
         let set = register_signal(sig)?;
         let mut flag = libc::SFD_CLOEXEC;
-        if cfg!(not(feature = "io-uring")) {
+        if compio_driver::DriverType::is_polling() {
             flag |= libc::SFD_NONBLOCK;
         }
         let fd = syscall!(libc::signalfd(-1, &set, flag))?;


### PR DESCRIPTION
If fusion driver enabled, we can only check the driver type on runtime.