### PR TITLE
fix(dispatcher): replace event with oneshot channel

### DIFF
--- a/compio-dispatcher/Cargo.toml
+++ b/compio-dispatcher/Cargo.toml
@@ -17,7 +17,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 [dependencies]
 # Workspace dependencies
 compio-driver = { workspace = true }
-compio-runtime = { workspace = true, features = ["event", "time"] }
+compio-runtime = { workspace = true }
 
 flume = { workspace = true }
 futures-channel = { workspace = true }

--- a/compio-dispatcher/src/lib.rs
+++ b/compio-dispatcher/src/lib.rs
@@ -198,7 +198,7 @@ impl Dispatcher {
                     .into_iter()
                     .map(|thread| thread.join())
                     .collect();
-                tx.send(results).unwrap();
+                tx.send(results).ok();
             }
         }) {
             std::thread::spawn(f.0);


### PR DESCRIPTION
We can just use oneshot channel here.