### PR TITLE
refactor(driver): remove one Result usage

### DIFF
--- a/compio-driver/src/fusion/mod.rs
+++ b/compio-driver/src/fusion/mod.rs
@@ -84,12 +84,12 @@ impl Driver {
         }
     }
 
-    pub fn handle(&self) -> io::Result<NotifyHandle> {
+    pub fn handle(&self) -> NotifyHandle {
         let fuse = match &self.fuse {
-            FuseDriver::Poll(driver) => FuseNotifyHandle::Poll(driver.handle()?),
-            FuseDriver::IoUring(driver) => FuseNotifyHandle::IoUring(driver.handle()?),
+            FuseDriver::Poll(driver) => FuseNotifyHandle::Poll(driver.handle()),
+            FuseDriver::IoUring(driver) => FuseNotifyHandle::IoUring(driver.handle()),
         };
-        Ok(NotifyHandle::from_fuse(fuse))
+        NotifyHandle::from_fuse(fuse)
     }
 }
 

--- a/compio-driver/src/iocp/mod.rs
+++ b/compio-driver/src/iocp/mod.rs
@@ -322,11 +322,8 @@ impl Driver {
         Ok(())
     }
 
-    pub fn handle(&self) -> io::Result<NotifyHandle> {
-        Ok(NotifyHandle::new(
-            self.port.handle(),
-            self.notify_overlapped.clone(),
-        ))
+    pub fn handle(&self) -> NotifyHandle {
+        NotifyHandle::new(self.port.handle(), self.notify_overlapped.clone())
     }
 }
 

--- a/compio-driver/src/iour/mod.rs
+++ b/compio-driver/src/iour/mod.rs
@@ -290,7 +290,7 @@ impl Driver {
         Ok(())
     }
 
-    pub fn handle(&self) -> io::Result<NotifyHandle> {
+    pub fn handle(&self) -> NotifyHandle {
         self.notifier.handle()
     }
 }
@@ -360,8 +360,8 @@ impl Notifier {
         }
     }
 
-    pub fn handle(&self) -> io::Result<NotifyHandle> {
-        Ok(NotifyHandle::new(self.fd.clone()))
+    pub fn handle(&self) -> NotifyHandle {
+        NotifyHandle::new(self.fd.clone())
     }
 }
 

--- a/compio-driver/src/lib.rs
+++ b/compio-driver/src/lib.rs
@@ -311,7 +311,7 @@ impl Proactor {
     }
 
     /// Create a notify handle to interrupt the inner driver.
-    pub fn handle(&self) -> io::Result<NotifyHandle> {
+    pub fn handle(&self) -> NotifyHandle {
         self.driver.handle()
     }
 }

--- a/compio-driver/src/poll/mod.rs
+++ b/compio-driver/src/poll/mod.rs
@@ -438,8 +438,8 @@ impl Driver {
         Ok(())
     }
 
-    pub fn handle(&self) -> io::Result<NotifyHandle> {
-        Ok(NotifyHandle::new(self.poll.clone()))
+    pub fn handle(&self) -> NotifyHandle {
+        NotifyHandle::new(self.poll.clone())
     }
 }
 

--- a/compio-driver/tests/file.rs
+++ b/compio-driver/tests/file.rs
@@ -100,7 +100,7 @@ fn register_multiple() {
 fn notify() {
     let mut driver = Proactor::new().unwrap();
 
-    let handle = driver.handle().unwrap();
+    let handle = driver.handle();
 
     let thread = std::thread::spawn(move || {
         std::thread::sleep(Duration::from_secs(1));

--- a/compio-runtime/src/runtime/mod.rs
+++ b/compio-runtime/src/runtime/mod.rs
@@ -159,11 +159,7 @@ impl Runtime {
     /// The caller should ensure the captured lifetime long enough.
     pub unsafe fn spawn_unchecked<F: Future>(&self, future: F) -> Task<F::Output> {
         let runnables = self.runnables.clone();
-        let handle = self
-            .driver
-            .borrow()
-            .handle()
-            .expect("cannot create notify handle of the proactor");
+        let handle = self.driver.borrow().handle();
         let schedule = move |runnable| {
             runnables.schedule(runnable, &handle);
         };


### PR DESCRIPTION
I'm not sure whether we will change the implementation in the future, but it doesn't need to return `Result` now.