### PR TITLE
fix(net): set reuseaddr when binding

### DIFF
--- a/compio-net/src/socket.rs
+++ b/compio-net/src/socket.rs
@@ -23,7 +23,7 @@ use crate::PollFd;
 
 #[derive(Debug, Clone)]
 pub struct Socket {
-    socket: Attacher<Socket2>,
+    pub(crate) socket: Attacher<Socket2>,
 }
 
 impl Socket {

--- a/compio-net/src/tcp.rs
+++ b/compio-net/src/tcp.rs
@@ -56,8 +56,10 @@ impl TcpListener {
     /// to this listener.
     pub async fn bind(addr: impl ToSocketAddrsAsync) -> io::Result<Self> {
         super::each_addr(addr, |addr| async move {
-            let socket =
-                Socket::bind(&SockAddr::from(addr), Type::STREAM, Some(Protocol::TCP)).await?;
+            let sa = SockAddr::from(addr);
+            let socket = Socket::new(sa.domain(), Type::STREAM, Some(Protocol::TCP)).await?;
+            socket.socket.set_reuse_address(true)?;
+            socket.socket.bind(&sa)?;
             socket.listen(128)?;
             Ok(Self { inner: socket })
         })


### PR DESCRIPTION
Didn't test, but I happened to see address in use errors when developing my app.