### PR TITLE
chore(quic): re-enable quinn on solarish

### DIFF
--- a/compio-quic/Cargo.toml
+++ b/compio-quic/Cargo.toml
@@ -54,16 +54,12 @@ compio-runtime = { workspace = true, features = ["criterion"] }
 
 criterion = { workspace = true, features = ["async_tokio"] }
 http = "1.1.0"
+quinn = "0.11.6"
 rand = { workspace = true }
 rcgen = "0.13.1"
 socket2 = { workspace = true, features = ["all"] }
 tokio = { workspace = true, features = ["rt", "macros"] }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
-
-[target.'cfg(not(any(target_os = "illumos", target_os = "solaris")))'.dev-dependencies]
-quinn = { version = "0.11.6", default-features = false, features = [
-    "rustls-ring",
-] }
 
 [features]
 default = ["ring"]

--- a/compio-quic/benches/quic.rs
+++ b/compio-quic/benches/quic.rs
@@ -1,8 +1,7 @@
-use std::time::Instant;
-#[cfg(not(solarish))]
 use std::{
     net::{IpAddr, Ipv4Addr, SocketAddr},
     sync::Arc,
+    time::Instant,
 };
 
 use compio_buf::bytes::Bytes;
@@ -105,7 +104,6 @@ fn echo_compio_quic(b: &mut Bencher, content: &[u8], streams: usize) {
     })
 }
 
-#[cfg(not(solarish))]
 fn echo_quinn(b: &mut Bencher, content: &[u8], streams: usize) {
     use quinn::{ClientConfig, Endpoint, ServerConfig};
 
@@ -184,7 +182,6 @@ fn echo(c: &mut Criterion) {
                 &(),
                 |b, _| echo_compio_quic(b, data, streams),
             );
-            #[cfg(not(solarish))]
             group.bench_with_input(
                 BenchmarkId::new("quinn", format!("{}-streams-{}-bytes", streams, size)),
                 &(),


### PR DESCRIPTION
Quinn added illumos support since [quinn-udp-0.5.8](https://github.com/quinn-rs/quinn/releases/tag/quinn-udp-0.5.8).