### PR TITLE
fix(buf): track caller unwrapping

### DIFF
--- a/compio-buf/src/buf_result.rs
+++ b/compio-buf/src/buf_result.rs
@@ -84,7 +84,7 @@ impl<T, B> BufResult<T, B> {
     }
 
     /// Returns the contained [`Ok`] value, consuming the `self` value.
-    #[inline]
+    #[inline(always)]
     #[track_caller]
     pub fn unwrap(self) -> (T, B) {
         (self.0.unwrap(), self.1)

--- a/compio-buf/src/buf_result.rs
+++ b/compio-buf/src/buf_result.rs
@@ -78,12 +78,14 @@ impl<T, B> BufResult<T, B> {
 
     /// Returns the contained [`Ok`] value, consuming the `self` value.
     #[inline]
+    #[track_caller]
     pub fn expect(self, msg: &str) -> (T, B) {
         (self.0.expect(msg), self.1)
     }
 
     /// Returns the contained [`Ok`] value, consuming the `self` value.
     #[inline]
+    #[track_caller]
     pub fn unwrap(self) -> (T, B) {
         (self.0.unwrap(), self.1)
     }

--- a/compio-tls/src/stream/mod.rs
+++ b/compio-tls/src/stream/mod.rs
@@ -129,7 +129,8 @@ impl<S: AsyncRead> AsyncRead for TlsStream<S> {
         let mut f = {
             slice.fill(MaybeUninit::new(0));
             // SAFETY: The memory has been initialized
-            let slice = unsafe { std::slice::from_raw_parts_mut(slice.as_mut_ptr().cast(), slice.len()) };
+            let slice =
+                unsafe { std::slice::from_raw_parts_mut(slice.as_mut_ptr().cast(), slice.len()) };
             |s: &mut _| std::io::Read::read(s, slice)
         };
 


### PR DESCRIPTION
### Track Caller

Print the caller that calls `BufResult::unwrap()`(also, `expect()`) instead of printing `BufResult` itself.

``` rust
use std::io;
use compio::BufResult;

fn main() {
    let err = io::Result::<u8>::Err(io::Error::last_os_error());
    let result = BufResult(err, 0u8);
    result.unwrap();
}
```
>Before
>thread 'main' panicked at ~/compio-buf/src/buf_result.rs:88:17
>
>After
> thread 'main' panicked at src/main.rs:8:12

### Inline

Set to `Result::unwrap()` flavor.