### PR TITLE
feat: buffered IO implementation

### DIFF
--- a/compio-driver/src/buffer_pool/fallback.rs
+++ b/compio-driver/src/buffer_pool/fallback.rs
@@ -56,7 +56,8 @@ impl BufferPool {
     }
 
     /// Select an [`OwnedBuffer`] when the op creates.
-    pub(crate) fn get_buffer(&self, len: usize) -> io::Result<OwnedBuffer> {
+    #[doc(hidden)]
+    pub fn get_buffer(&self, len: usize) -> io::Result<OwnedBuffer> {
         let buffer = self
             .inner
             .buffers
@@ -78,7 +79,8 @@ impl BufferPool {
 
     /// ## Safety
     /// * `len` should be valid.
-    pub(crate) unsafe fn create_proxy(&self, mut slice: OwnedBuffer, len: usize) -> BorrowedBuffer {
+    #[doc(hidden)]
+    pub unsafe fn create_proxy(&self, mut slice: OwnedBuffer, len: usize) -> BorrowedBuffer {
         unsafe {
             slice.set_buf_init(len);
         }
@@ -86,7 +88,8 @@ impl BufferPool {
     }
 }
 
-pub(crate) struct OwnedBuffer {
+#[doc(hidden)]
+pub struct OwnedBuffer {
     buffer: ManuallyDrop<Slice<Vec<u8>>>,
     pool: ManuallyDrop<Rc<BufferPoolInner>>,
 }

--- a/compio-driver/src/op.rs
+++ b/compio-driver/src/op.rs
@@ -107,14 +107,14 @@ pub trait ResultTakeBuffer {
     type Buffer<'a>;
 
     /// Take the buffer from result.
-    fn take_buffer<'a>(self, pool: &'a Self::BufferPool) -> io::Result<Self::Buffer<'a>>;
+    fn take_buffer(self, pool: &Self::BufferPool) -> io::Result<Self::Buffer<'_>>;
 }
 
 impl<T: TakeBuffer> ResultTakeBuffer for (BufResult<usize, T>, u32) {
     type Buffer<'a> = T::Buffer<'a>;
     type BufferPool = T::BufferPool;
 
-    fn take_buffer<'a>(self, pool: &'a Self::BufferPool) -> io::Result<Self::Buffer<'a>> {
+    fn take_buffer(self, pool: &Self::BufferPool) -> io::Result<Self::Buffer<'_>> {
         let (BufResult(result, op), flags) = self;
         op.take_buffer(pool, result, flags)
     }

--- a/compio-driver/src/op.rs
+++ b/compio-driver/src/op.rs
@@ -4,7 +4,7 @@
 //! The operation itself doesn't perform anything.
 //! You need to pass them to [`crate::Proactor`], and poll the driver.
 
-use std::{marker::PhantomPinned, mem::ManuallyDrop, net::Shutdown};
+use std::{io, marker::PhantomPinned, mem::ManuallyDrop, net::Shutdown};
 
 use compio_buf::{BufResult, IntoInner, IoBuf, IoBufMut, SetBufInit};
 use socket2::SockAddr;
@@ -23,7 +23,7 @@ pub use crate::sys::op::{
 #[cfg(buf_ring)]
 pub use crate::sys::op::{ReadManagedAt, RecvManaged};
 use crate::{
-    OwnedFd, SharedFd,
+    OwnedFd, SharedFd, TakeBuffer,
     sys::{sockaddr_storage, socklen_t},
 };
 
@@ -96,6 +96,27 @@ impl<T> RecvResultExt for BufResult<usize, (T, sockaddr_storage, socklen_t, usiz
             },
             |(buffer, ..)| buffer,
         )
+    }
+}
+
+/// Helper trait for [`ReadManagedAt`] and [`RecvManaged`].
+pub trait ResultTakeBuffer {
+    /// The buffer pool of the op.
+    type BufferPool;
+    /// The buffer type of the op.
+    type Buffer<'a>;
+
+    /// Take the buffer from result.
+    fn take_buffer<'a>(self, pool: &'a Self::BufferPool) -> io::Result<Self::Buffer<'a>>;
+}
+
+impl<T: TakeBuffer> ResultTakeBuffer for (BufResult<usize, T>, u32) {
+    type Buffer<'a> = T::Buffer<'a>;
+    type BufferPool = T::BufferPool;
+
+    fn take_buffer<'a>(self, pool: &'a Self::BufferPool) -> io::Result<Self::Buffer<'a>> {
+        let (BufResult(result, op), flags) = self;
+        op.take_buffer(pool, result, flags)
     }
 }
 

--- a/compio-fs/src/async_fd.rs
+++ b/compio-fs/src/async_fd.rs
@@ -8,10 +8,10 @@ use std::os::windows::io::{
 
 use compio_buf::{BufResult, IntoInner, IoBuf, IoBufMut};
 use compio_driver::{
-    AsRawFd, SharedFd, ToSharedFd,
-    op::{BufResultExt, Recv, Send},
+    AsRawFd, BorrowedBuffer, BufferPool, SharedFd, ToSharedFd,
+    op::{BufResultExt, Recv, RecvManaged, ResultTakeBuffer, Send},
 };
-use compio_io::{AsyncRead, AsyncWrite};
+use compio_io::{AsyncRead, AsyncReadManaged, AsyncWrite};
 use compio_runtime::Attacher;
 #[cfg(unix)]
 use {
@@ -56,6 +56,36 @@ impl<T: AsRawFd + 'static> AsyncRead for AsyncFd<T> {
     #[inline]
     async fn read_vectored<V: IoVectoredBufMut>(&mut self, buf: V) -> BufResult<usize, V> {
         (&*self).read_vectored(buf).await
+    }
+}
+
+impl<T: AsRawFd + 'static> AsyncReadManaged for AsyncFd<T> {
+    type Buffer<'a> = BorrowedBuffer<'a>;
+    type BufferPool = BufferPool;
+
+    async fn read_managed<'a>(
+        &mut self,
+        buffer_pool: &'a Self::BufferPool,
+        len: usize,
+    ) -> io::Result<Self::Buffer<'a>> {
+        (&*self).read_managed(buffer_pool, len).await
+    }
+}
+
+impl<T: AsRawFd + 'static> AsyncReadManaged for &AsyncFd<T> {
+    type Buffer<'a> = BorrowedBuffer<'a>;
+    type BufferPool = BufferPool;
+
+    async fn read_managed<'a>(
+        &mut self,
+        buffer_pool: &'a Self::BufferPool,
+        len: usize,
+    ) -> io::Result<Self::Buffer<'a>> {
+        let fd = self.to_shared_fd();
+        let op = RecvManaged::new(fd, buffer_pool, len)?;
+        compio_runtime::submit_with_flags(op)
+            .await
+            .take_buffer(buffer_pool)
     }
 }
 

--- a/compio-fs/src/async_fd.rs
+++ b/compio-fs/src/async_fd.rs
@@ -8,11 +8,11 @@ use std::os::windows::io::{
 
 use compio_buf::{BufResult, IntoInner, IoBuf, IoBufMut};
 use compio_driver::{
-    AsRawFd, BorrowedBuffer, BufferPool, SharedFd, ToSharedFd,
+    AsRawFd, SharedFd, ToSharedFd,
     op::{BufResultExt, Recv, RecvManaged, ResultTakeBuffer, Send},
 };
 use compio_io::{AsyncRead, AsyncReadManaged, AsyncWrite};
-use compio_runtime::Attacher;
+use compio_runtime::{Attacher, BorrowedBuffer, BufferPool};
 #[cfg(unix)]
 use {
     compio_buf::{IoVectoredBuf, IoVectoredBufMut},
@@ -82,6 +82,7 @@ impl<T: AsRawFd + 'static> AsyncReadManaged for &AsyncFd<T> {
         len: usize,
     ) -> io::Result<Self::Buffer<'a>> {
         let fd = self.to_shared_fd();
+        let buffer_pool = buffer_pool.as_inner();
         let op = RecvManaged::new(fd, buffer_pool, len)?;
         compio_runtime::submit_with_flags(op)
             .await

--- a/compio-fs/src/async_fd.rs
+++ b/compio-fs/src/async_fd.rs
@@ -82,7 +82,7 @@ impl<T: AsRawFd + 'static> AsyncReadManaged for &AsyncFd<T> {
         len: usize,
     ) -> io::Result<Self::Buffer<'a>> {
         let fd = self.to_shared_fd();
-        let buffer_pool = buffer_pool.as_inner();
+        let buffer_pool = buffer_pool.try_inner()?;
         let op = RecvManaged::new(fd, buffer_pool, len)?;
         compio_runtime::submit_with_flags(op)
             .await

--- a/compio-fs/src/file.rs
+++ b/compio-fs/src/file.rs
@@ -180,7 +180,7 @@ impl AsyncReadManagedAt for File {
         len: usize,
     ) -> io::Result<Self::Buffer<'a>> {
         let fd = self.inner.to_shared_fd();
-        let buffer_pool = buffer_pool.as_inner();
+        let buffer_pool = buffer_pool.try_inner()?;
         let op = ReadManagedAt::new(fd, pos, buffer_pool, len)?;
         compio_runtime::submit_with_flags(op)
             .await

--- a/compio-fs/src/file.rs
+++ b/compio-fs/src/file.rs
@@ -4,11 +4,11 @@ use compio_buf::{BufResult, IntoInner, IoBuf, IoBufMut};
 #[cfg(unix)]
 use compio_driver::op::FileStat;
 use compio_driver::{
-    BorrowedBuffer, BufferPool, ToSharedFd, impl_raw_fd,
+    ToSharedFd, impl_raw_fd,
     op::{BufResultExt, CloseFile, ReadAt, ReadManagedAt, ResultTakeBuffer, Sync, WriteAt},
 };
 use compio_io::{AsyncReadAt, AsyncReadManagedAt, AsyncWriteAt};
-use compio_runtime::Attacher;
+use compio_runtime::{Attacher, BorrowedBuffer, BufferPool};
 #[cfg(all(unix, not(solarish)))]
 use {
     compio_buf::{IoVectoredBuf, IoVectoredBufMut},
@@ -180,6 +180,7 @@ impl AsyncReadManagedAt for File {
         len: usize,
     ) -> io::Result<Self::Buffer<'a>> {
         let fd = self.inner.to_shared_fd();
+        let buffer_pool = buffer_pool.as_inner();
         let op = ReadManagedAt::new(fd, pos, buffer_pool, len)?;
         compio_runtime::submit_with_flags(op)
             .await

--- a/compio-fs/src/file.rs
+++ b/compio-fs/src/file.rs
@@ -4,10 +4,10 @@ use compio_buf::{BufResult, IntoInner, IoBuf, IoBufMut};
 #[cfg(unix)]
 use compio_driver::op::FileStat;
 use compio_driver::{
-    ToSharedFd, impl_raw_fd,
-    op::{BufResultExt, CloseFile, ReadAt, Sync, WriteAt},
+    BorrowedBuffer, BufferPool, ToSharedFd, impl_raw_fd,
+    op::{BufResultExt, CloseFile, ReadAt, ReadManagedAt, ResultTakeBuffer, Sync, WriteAt},
 };
-use compio_io::{AsyncReadAt, AsyncWriteAt};
+use compio_io::{AsyncReadAt, AsyncReadManagedAt, AsyncWriteAt};
 use compio_runtime::Attacher;
 #[cfg(all(unix, not(solarish)))]
 use {
@@ -166,6 +166,24 @@ impl AsyncReadAt for File {
         let fd = self.inner.to_shared_fd();
         let op = ReadVectoredAt::new(fd, pos, buffer);
         compio_runtime::submit(op).await.into_inner().map_advanced()
+    }
+}
+
+impl AsyncReadManagedAt for File {
+    type Buffer<'a> = BorrowedBuffer<'a>;
+    type BufferPool = BufferPool;
+
+    async fn read_managed_at<'a>(
+        &self,
+        pos: u64,
+        buffer_pool: &'a Self::BufferPool,
+        len: usize,
+    ) -> io::Result<Self::Buffer<'a>> {
+        let fd = self.inner.to_shared_fd();
+        let op = ReadManagedAt::new(fd, pos, buffer_pool, len)?;
+        compio_runtime::submit_with_flags(op)
+            .await
+            .take_buffer(buffer_pool)
     }
 }
 

--- a/compio-fs/src/named_pipe.rs
+++ b/compio-fs/src/named_pipe.rs
@@ -8,7 +8,10 @@ use std::{ffi::OsStr, io, os::windows::io::FromRawHandle, ptr::null};
 
 use compio_buf::{BufResult, IoBuf, IoBufMut};
 use compio_driver::{AsRawFd, RawFd, ToSharedFd, impl_raw_fd, op::ConnectNamedPipe, syscall};
-use compio_io::{AsyncRead, AsyncReadAt, AsyncWrite, AsyncWriteAt};
+use compio_io::{
+    AsyncRead, AsyncReadAt, AsyncReadManaged, AsyncReadManagedAt, AsyncWrite, AsyncWriteAt,
+};
+use compio_runtime::{BorrowedBuffer, BufferPool};
 use widestring::U16CString;
 use windows_sys::Win32::{
     Storage::FileSystem::{
@@ -192,6 +195,33 @@ impl AsyncRead for &NamedPipeServer {
     }
 }
 
+impl AsyncReadManaged for NamedPipeServer {
+    type Buffer<'a> = BorrowedBuffer<'a>;
+    type BufferPool = BufferPool;
+
+    async fn read_managed<'a>(
+        &mut self,
+        buffer_pool: &'a Self::BufferPool,
+        len: usize,
+    ) -> io::Result<Self::Buffer<'a>> {
+        (&*self).read_managed(buffer_pool, len).await
+    }
+}
+
+impl AsyncReadManaged for &NamedPipeServer {
+    type Buffer<'a> = BorrowedBuffer<'a>;
+    type BufferPool = BufferPool;
+
+    async fn read_managed<'a>(
+        &mut self,
+        buffer_pool: &'a Self::BufferPool,
+        len: usize,
+    ) -> io::Result<Self::Buffer<'a>> {
+        // The position is ignored.
+        (&self.handle).read_managed(buffer_pool, len).await
+    }
+}
+
 impl AsyncWrite for NamedPipeServer {
     #[inline]
     async fn write<T: IoBuf>(&mut self, buf: T) -> BufResult<usize, T> {
@@ -309,6 +339,33 @@ impl AsyncRead for &NamedPipeClient {
     async fn read<B: IoBufMut>(&mut self, buffer: B) -> BufResult<usize, B> {
         // The position is ignored.
         self.handle.read_at(buffer, 0).await
+    }
+}
+
+impl AsyncReadManaged for NamedPipeClient {
+    type Buffer<'a> = BorrowedBuffer<'a>;
+    type BufferPool = BufferPool;
+
+    async fn read_managed<'a>(
+        &mut self,
+        buffer_pool: &'a Self::BufferPool,
+        len: usize,
+    ) -> io::Result<Self::Buffer<'a>> {
+        (&*self).read_managed(buffer_pool, len).await
+    }
+}
+
+impl AsyncReadManaged for &NamedPipeClient {
+    type Buffer<'a> = BorrowedBuffer<'a>;
+    type BufferPool = BufferPool;
+
+    async fn read_managed<'a>(
+        &mut self,
+        buffer_pool: &'a Self::BufferPool,
+        len: usize,
+    ) -> io::Result<Self::Buffer<'a>> {
+        // The position is ignored.
+        self.handle.read_managed_at(0, buffer_pool, len).await
     }
 }
 

--- a/compio-fs/src/pipe.rs
+++ b/compio-fs/src/pipe.rs
@@ -9,11 +9,12 @@ use std::{
 
 use compio_buf::{BufResult, IntoInner, IoBuf, IoBufMut, IoVectoredBuf, IoVectoredBufMut};
 use compio_driver::{
-    AsRawFd, BorrowedBuffer, BufferPool, ToSharedFd, impl_raw_fd,
+    AsRawFd, ToSharedFd, impl_raw_fd,
     op::{BufResultExt, Recv, RecvManaged, RecvVectored, ResultTakeBuffer, Send, SendVectored},
     syscall,
 };
 use compio_io::{AsyncRead, AsyncReadManaged, AsyncWrite};
+use compio_runtime::{BorrowedBuffer, BufferPool};
 
 use crate::File;
 
@@ -525,6 +526,7 @@ impl AsyncReadManaged for &Receiver {
         len: usize,
     ) -> io::Result<Self::Buffer<'a>> {
         let fd = self.to_shared_fd();
+        let buffer_pool = buffer_pool.try_inner()?;
         let op = RecvManaged::new(fd, buffer_pool, len)?;
         compio_runtime::submit_with_flags(op)
             .await

--- a/compio-fs/src/pipe.rs
+++ b/compio-fs/src/pipe.rs
@@ -9,11 +9,11 @@ use std::{
 
 use compio_buf::{BufResult, IntoInner, IoBuf, IoBufMut, IoVectoredBuf, IoVectoredBufMut};
 use compio_driver::{
-    AsRawFd, ToSharedFd, impl_raw_fd,
-    op::{BufResultExt, Recv, RecvVectored, Send, SendVectored},
+    AsRawFd, BorrowedBuffer, BufferPool, ToSharedFd, impl_raw_fd,
+    op::{BufResultExt, Recv, RecvManaged, RecvVectored, ResultTakeBuffer, Send, SendVectored},
     syscall,
 };
-use compio_io::{AsyncRead, AsyncWrite};
+use compio_io::{AsyncRead, AsyncReadManaged, AsyncWrite};
 
 use crate::File;
 
@@ -499,6 +499,36 @@ impl AsyncRead for &Receiver {
         let fd = self.to_shared_fd();
         let op = RecvVectored::new(fd, buffer);
         compio_runtime::submit(op).await.into_inner().map_advanced()
+    }
+}
+
+impl AsyncReadManaged for Receiver {
+    type Buffer<'a> = BorrowedBuffer<'a>;
+    type BufferPool = BufferPool;
+
+    async fn read_managed<'a>(
+        &mut self,
+        buffer_pool: &'a Self::BufferPool,
+        len: usize,
+    ) -> io::Result<Self::Buffer<'a>> {
+        (&*self).read_managed(buffer_pool, len).await
+    }
+}
+
+impl AsyncReadManaged for &Receiver {
+    type Buffer<'a> = BorrowedBuffer<'a>;
+    type BufferPool = BufferPool;
+
+    async fn read_managed<'a>(
+        &mut self,
+        buffer_pool: &'a Self::BufferPool,
+        len: usize,
+    ) -> io::Result<Self::Buffer<'a>> {
+        let fd = self.to_shared_fd();
+        let op = RecvManaged::new(fd, buffer_pool, len)?;
+        compio_runtime::submit_with_flags(op)
+            .await
+            .take_buffer(buffer_pool)
     }
 }
 

--- a/compio-fs/src/stdio/unix.rs
+++ b/compio-fs/src/stdio/unix.rs
@@ -1,8 +1,8 @@
 use std::io;
 
 use compio_buf::{BufResult, IoBuf, IoBufMut, IoVectoredBuf, IoVectoredBufMut};
-use compio_driver::{AsRawFd, RawFd};
-use compio_io::{AsyncRead, AsyncWrite};
+use compio_driver::{AsRawFd, BorrowedBuffer, BufferPool, RawFd};
+use compio_io::{AsyncRead, AsyncReadManaged, AsyncWrite};
 
 #[cfg(doc)]
 use super::{stderr, stdin, stdout};
@@ -38,6 +38,32 @@ impl AsyncRead for &Stdin {
 
     async fn read_vectored<V: IoVectoredBufMut>(&mut self, buf: V) -> BufResult<usize, V> {
         (&self.0).read_vectored(buf).await
+    }
+}
+
+impl AsyncReadManaged for Stdin {
+    type Buffer<'a> = BorrowedBuffer<'a>;
+    type BufferPool = BufferPool;
+
+    async fn read_managed<'a>(
+        &mut self,
+        buffer_pool: &'a Self::BufferPool,
+        len: usize,
+    ) -> io::Result<Self::Buffer<'a>> {
+        (&*self).read_managed(buffer_pool, len).await
+    }
+}
+
+impl AsyncReadManaged for &Stdin {
+    type Buffer<'a> = BorrowedBuffer<'a>;
+    type BufferPool = BufferPool;
+
+    async fn read_managed<'a>(
+        &mut self,
+        buffer_pool: &'a Self::BufferPool,
+        len: usize,
+    ) -> io::Result<Self::Buffer<'a>> {
+        (&self.0).read_managed(buffer_pool, len).await
     }
 }
 

--- a/compio-fs/src/stdio/windows.rs
+++ b/compio-fs/src/stdio/windows.rs
@@ -9,10 +9,10 @@ use std::{
 use compio_buf::{BufResult, IntoInner, IoBuf, IoBufMut};
 use compio_driver::{
     AsRawFd, OpCode, OpType, RawFd, SharedFd,
-    op::{BufResultExt, Recv, Send},
+    op::{BufResultExt, Recv, RecvManaged, ResultTakeBuffer, Send},
 };
-use compio_io::{AsyncRead, AsyncWrite};
-use compio_runtime::Runtime;
+use compio_io::{AsyncRead, AsyncReadManaged, AsyncWrite};
+use compio_runtime::{BorrowedBuffer, BufferPool, Runtime};
 use windows_sys::Win32::System::IO::OVERLAPPED;
 
 #[cfg(doc)]
@@ -133,6 +133,44 @@ impl AsyncRead for Stdin {
             compio_runtime::submit(op).await.into_inner()
         }
         .map_advanced()
+    }
+}
+
+impl AsyncReadManaged for Stdin {
+    type Buffer<'a> = BorrowedBuffer<'a>;
+    type BufferPool = BufferPool;
+
+    async fn read_managed<'a>(
+        &mut self,
+        buffer_pool: &'a Self::BufferPool,
+        len: usize,
+    ) -> io::Result<Self::Buffer<'a>> {
+        (&*self).read_managed(buffer_pool, len).await
+    }
+}
+
+impl AsyncReadManaged for &Stdin {
+    type Buffer<'a> = BorrowedBuffer<'a>;
+    type BufferPool = BufferPool;
+
+    async fn read_managed<'a>(
+        &mut self,
+        buffer_pool: &'a Self::BufferPool,
+        len: usize,
+    ) -> io::Result<Self::Buffer<'a>> {
+        let buffer_pool = buffer_pool.try_inner()?;
+        if self.isatty {
+            let buf = buffer_pool.get_buffer(len)?;
+            let op = StdRead::new(io::stdin(), buf);
+            let BufResult(res, buf) = compio_runtime::submit(op).await.into_inner();
+            let res = unsafe { buffer_pool.create_proxy(buf, res?) };
+            Ok(res)
+        } else {
+            let op = RecvManaged::new(self.fd.clone(), buffer_pool, len)?;
+            compio_runtime::submit_with_flags(op)
+                .await
+                .take_buffer(buffer_pool)
+        }
     }
 }
 

--- a/compio-fs/tests/buffer_pool.rs
+++ b/compio-fs/tests/buffer_pool.rs
@@ -1,0 +1,42 @@
+use std::io::Write;
+
+use compio_fs::File;
+#[cfg(unix)]
+use compio_fs::pipe;
+use compio_io::AsyncReadManagedAt;
+#[cfg(unix)]
+use compio_io::{AsyncReadManaged, AsyncWriteExt};
+use compio_runtime::BufferPool;
+use tempfile::NamedTempFile;
+
+const HELLO: &[u8] = b"hello world...";
+
+fn tempfile() -> NamedTempFile {
+    NamedTempFile::new().unwrap()
+}
+
+#[compio_macros::test]
+async fn test_read_file() {
+    let mut tempfile = tempfile();
+    tempfile.write_all(HELLO).unwrap();
+
+    let file = File::open(tempfile.path()).await.unwrap();
+    let buffer_pool = BufferPool::new(1, 15).unwrap();
+    let buf = file.read_managed_at(&buffer_pool, 0, 0).await.unwrap();
+
+    assert_eq!(buf.len(), HELLO.len());
+    assert_eq!(buf.as_ref(), HELLO);
+}
+
+#[cfg(unix)]
+#[compio_macros::test]
+async fn test_read_pipe() {
+    let (mut rx, mut tx) = pipe::anonymous().unwrap();
+    tx.write_all(HELLO).await.unwrap();
+
+    let buffer_pool = BufferPool::new(1, 15).unwrap();
+    let buf = rx.read_managed(&buffer_pool, 0).await.unwrap();
+
+    assert_eq!(buf.len(), HELLO.len());
+    assert_eq!(buf.as_ref(), HELLO);
+}

--- a/compio-fs/tests/buffer_pool.rs
+++ b/compio-fs/tests/buffer_pool.rs
@@ -22,7 +22,7 @@ async fn test_read_file() {
 
     let file = File::open(tempfile.path()).await.unwrap();
     let buffer_pool = BufferPool::new(1, 15).unwrap();
-    let buf = file.read_managed_at(&buffer_pool, 0, 0).await.unwrap();
+    let buf = file.read_managed_at(0, &buffer_pool, 0).await.unwrap();
 
     assert_eq!(buf.len(), HELLO.len());
     assert_eq!(buf.as_ref(), HELLO);

--- a/compio-io/src/read/managed.rs
+++ b/compio-io/src/read/managed.rs
@@ -1,6 +1,4 @@
-use std::io::Cursor;
-
-use compio_buf::IoBuf;
+use std::{io::Cursor, ops::Deref};
 
 use crate::IoResult;
 
@@ -11,18 +9,18 @@ pub trait AsyncReadManaged {
     /// Buffer pool type
     type BufferPool;
     /// Filled buffer type
-    type Buffer: IoBuf;
+    type Buffer<'a>;
 
     /// Read some bytes from this source with [`BufferPool`] and return
     /// a [`Buffer`].
     ///
     /// If `len` == 0, will use [`BufferPool`] inner buffer size as the max len,
     /// if `len` > 0, `min(len, inner buffer size)` will be the read max len
-    async fn read_managed(
+    async fn read_managed<'a>(
         &mut self,
-        buffer_pool: &Self::BufferPool,
+        buffer_pool: &'a Self::BufferPool,
         len: usize,
-    ) -> IoResult<Self::Buffer>;
+    ) -> IoResult<Self::Buffer<'a>>;
 }
 
 /// # AsyncReadAtManaged
@@ -32,36 +30,39 @@ pub trait AsyncReadManagedAt {
     /// Buffer pool type
     type BufferPool;
     /// Filled buffer type
-    type Buffer: IoBuf;
+    type Buffer<'a>;
 
     /// Read some bytes from this source at position with [`BufferPool`] and
     /// return a [`Buffer`].
     ///
     /// If `len` == 0, will use [`BufferPool`] inner buffer size as the max len,
     /// if `len` > 0, `min(len, inner buffer size)` will be the read max len
-    async fn read_managed_at(
+    async fn read_managed_at<'a>(
         &self,
         pos: u64,
-        buffer_pool: &Self::BufferPool,
+        buffer_pool: &'a Self::BufferPool,
         len: usize,
-    ) -> IoResult<Self::Buffer>;
+    ) -> IoResult<Self::Buffer<'a>>;
 }
 
-impl<A: AsyncReadManagedAt> AsyncReadManaged for Cursor<A> {
-    type Buffer = A::Buffer;
+impl<A: AsyncReadManagedAt> AsyncReadManaged for Cursor<A>
+where
+    for<'a> A::Buffer<'a>: Deref<Target = [u8]>,
+{
+    type Buffer<'a> = A::Buffer<'a>;
     type BufferPool = A::BufferPool;
 
-    async fn read_managed(
+    async fn read_managed<'a>(
         &mut self,
-        buffer_pool: &Self::BufferPool,
+        buffer_pool: &'a Self::BufferPool,
         len: usize,
-    ) -> IoResult<Self::Buffer> {
+    ) -> IoResult<Self::Buffer<'a>> {
         let pos = self.position();
         let buf = self
             .get_ref()
             .read_managed_at(pos, buffer_pool, len)
             .await?;
-        self.set_position(pos + buf.buf_len() as u64);
+        self.set_position(pos + buf.len() as u64);
         Ok(buf)
     }
 }

--- a/compio-net/src/socket.rs
+++ b/compio-net/src/socket.rs
@@ -10,13 +10,13 @@ use compio_driver::op::CreateSocket;
 use compio_driver::{
     AsRawFd, ToSharedFd, impl_raw_fd,
     op::{
-        Accept, BufResultExt, CloseSocket, Connect, Recv, RecvFrom, RecvFromVectored, RecvMsg,
-        RecvResultExt, RecvVectored, Send, SendMsg, SendTo, SendToVectored, SendVectored,
-        ShutdownSocket,
+        Accept, BufResultExt, CloseSocket, Connect, Recv, RecvFrom, RecvFromVectored, RecvManaged,
+        RecvMsg, RecvResultExt, RecvVectored, ResultTakeBuffer, Send, SendMsg, SendTo,
+        SendToVectored, SendVectored, ShutdownSocket,
     },
     syscall,
 };
-use compio_runtime::Attacher;
+use compio_runtime::{Attacher, BorrowedBuffer, BufferPool};
 use socket2::{Domain, Protocol, SockAddr, Socket as Socket2, Type};
 
 use crate::PollFd;
@@ -227,6 +227,19 @@ impl Socket {
         let fd = self.to_shared_fd();
         let op = RecvVectored::new(fd, buffer);
         compio_runtime::submit(op).await.into_inner().map_advanced()
+    }
+
+    pub async fn recv_managed<'a>(
+        &self,
+        buffer_pool: &'a BufferPool,
+        len: usize,
+    ) -> io::Result<BorrowedBuffer<'a>> {
+        let fd = self.to_shared_fd();
+        let buffer_pool = buffer_pool.try_inner()?;
+        let op = RecvManaged::new(fd, buffer_pool, len)?;
+        compio_runtime::submit_with_flags(op)
+            .await
+            .take_buffer(buffer_pool)
     }
 
     pub async fn send<T: IoBuf>(&self, buffer: T) -> BufResult<usize, T> {

--- a/compio-net/src/tcp.rs
+++ b/compio-net/src/tcp.rs
@@ -2,7 +2,8 @@ use std::{future::Future, io, net::SocketAddr};
 
 use compio_buf::{BufResult, IoBuf, IoBufMut, IoVectoredBuf, IoVectoredBufMut};
 use compio_driver::impl_raw_fd;
-use compio_io::{AsyncRead, AsyncWrite};
+use compio_io::{AsyncRead, AsyncReadManaged, AsyncWrite};
+use compio_runtime::{BorrowedBuffer, BufferPool};
 use socket2::{Protocol, SockAddr, Socket as Socket2, Type};
 
 use crate::{
@@ -273,6 +274,32 @@ impl AsyncRead for &TcpStream {
     #[inline]
     async fn read_vectored<V: IoVectoredBufMut>(&mut self, buf: V) -> BufResult<usize, V> {
         self.inner.recv_vectored(buf).await
+    }
+}
+
+impl AsyncReadManaged for TcpStream {
+    type Buffer<'a> = BorrowedBuffer<'a>;
+    type BufferPool = BufferPool;
+
+    async fn read_managed<'a>(
+        &mut self,
+        buffer_pool: &'a Self::BufferPool,
+        len: usize,
+    ) -> io::Result<Self::Buffer<'a>> {
+        (&*self).read_managed(buffer_pool, len).await
+    }
+}
+
+impl AsyncReadManaged for &TcpStream {
+    type Buffer<'a> = BorrowedBuffer<'a>;
+    type BufferPool = BufferPool;
+
+    async fn read_managed<'a>(
+        &mut self,
+        buffer_pool: &'a Self::BufferPool,
+        len: usize,
+    ) -> io::Result<Self::Buffer<'a>> {
+        self.inner.recv_managed(buffer_pool, len as _).await
     }
 }
 

--- a/compio-net/src/unix.rs
+++ b/compio-net/src/unix.rs
@@ -2,7 +2,8 @@ use std::{future::Future, io, path::Path};
 
 use compio_buf::{BufResult, IoBuf, IoBufMut, IoVectoredBuf, IoVectoredBufMut};
 use compio_driver::impl_raw_fd;
-use compio_io::{AsyncRead, AsyncWrite};
+use compio_io::{AsyncRead, AsyncReadManaged, AsyncWrite};
+use compio_runtime::{BorrowedBuffer, BufferPool};
 use socket2::{SockAddr, Socket as Socket2, Type};
 
 use crate::{OwnedReadHalf, OwnedWriteHalf, PollFd, ReadHalf, Socket, WriteHalf};
@@ -239,6 +240,32 @@ impl AsyncRead for &UnixStream {
     }
 }
 
+impl AsyncReadManaged for UnixStream {
+    type Buffer<'a> = BorrowedBuffer<'a>;
+    type BufferPool = BufferPool;
+
+    async fn read_managed<'a>(
+        &mut self,
+        buffer_pool: &'a Self::BufferPool,
+        len: usize,
+    ) -> io::Result<Self::Buffer<'a>> {
+        (&*self).read_managed(buffer_pool, len).await
+    }
+}
+
+impl AsyncReadManaged for &UnixStream {
+    type Buffer<'a> = BorrowedBuffer<'a>;
+    type BufferPool = BufferPool;
+
+    async fn read_managed<'a>(
+        &mut self,
+        buffer_pool: &'a Self::BufferPool,
+        len: usize,
+    ) -> io::Result<Self::Buffer<'a>> {
+        self.inner.recv_managed(buffer_pool, len as _).await
+    }
+}
+
 impl AsyncWrite for UnixStream {
     #[inline]
     async fn write<T: IoBuf>(&mut self, buf: T) -> BufResult<usize, T> {
@@ -294,13 +321,10 @@ fn empty_unix_socket() -> SockAddr {
     unsafe {
         SockAddr::try_init(|addr, len| {
             let addr: *mut SOCKADDR_UN = addr.cast();
-            std::ptr::write(
-                addr,
-                SOCKADDR_UN {
-                    sun_family: AF_UNIX,
-                    sun_path: [0; 108],
-                },
-            );
+            std::ptr::write(addr, SOCKADDR_UN {
+                sun_family: AF_UNIX,
+                sun_path: [0; 108],
+            });
             std::ptr::write(len, 3);
             Ok(())
         })

--- a/compio-net/tests/buffer_pool.rs
+++ b/compio-net/tests/buffer_pool.rs
@@ -1,0 +1,90 @@
+use std::net::Ipv6Addr;
+
+use compio_io::{AsyncReadManaged, AsyncWriteExt};
+use compio_net::{TcpListener, TcpStream, UdpSocket, UnixListener, UnixStream};
+use compio_runtime::BufferPool;
+
+#[compio_macros::test]
+async fn test_tcp_read_buffer_pool() {
+    let listener = TcpListener::bind((Ipv6Addr::LOCALHOST, 0)).await.unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    compio_runtime::spawn(async move {
+        let mut stream = listener.accept().await.unwrap().0;
+        stream.write_all(b"test").await.unwrap();
+    })
+    .detach();
+
+    let buffer_pool = BufferPool::new(1, 4).unwrap();
+    let mut stream = TcpStream::connect(addr).await.unwrap();
+
+    assert_eq!(
+        stream.read_managed(&buffer_pool, 0).await.unwrap().as_ref(),
+        b"test"
+    );
+
+    assert!(
+        stream
+            .read_managed(&buffer_pool, 0)
+            .await
+            .unwrap()
+            .is_empty()
+    );
+}
+
+#[compio_macros::test]
+async fn test_udp_read_buffer_pool() {
+    let listener = UdpSocket::bind((Ipv6Addr::LOCALHOST, 0)).await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let connected = UdpSocket::bind((Ipv6Addr::LOCALHOST, 0)).await.unwrap();
+    connected.connect(addr).await.unwrap();
+    let addr = connected.local_addr().unwrap();
+
+    compio_runtime::spawn(async move {
+        listener.send_to(b"test", addr).await.unwrap();
+    })
+    .detach();
+
+    let buffer_pool = BufferPool::new(1, 4).unwrap();
+
+    assert_eq!(
+        connected
+            .recv_managed(&buffer_pool, 0)
+            .await
+            .unwrap()
+            .as_ref(),
+        b"test"
+    );
+}
+
+#[compio_macros::test]
+async fn test_uds_recv_buffer_pool() {
+    let dir = tempfile::Builder::new()
+        .prefix("compio-uds-buffer-pool-tests")
+        .tempdir()
+        .unwrap();
+    let sock_path = dir.path().join("connect.sock");
+
+    let listener = UnixListener::bind(&sock_path).await.unwrap();
+
+    let (mut client, (mut server, _)) =
+        futures_util::try_join!(UnixStream::connect(&sock_path), listener.accept()).unwrap();
+
+    client.write_all("test").await.unwrap();
+    drop(client);
+
+    let buffer_pool = BufferPool::new(1, 4).unwrap();
+
+    assert_eq!(
+        server.read_managed(&buffer_pool, 0).await.unwrap().as_ref(),
+        b"test"
+    );
+
+    assert!(
+        server
+            .read_managed(&buffer_pool, 0)
+            .await
+            .unwrap()
+            .is_empty()
+    );
+}

--- a/compio-process/src/unix.rs
+++ b/compio-process/src/unix.rs
@@ -3,9 +3,10 @@ use std::{io, panic::resume_unwind, process};
 use compio_buf::{BufResult, IntoInner, IoBuf, IoBufMut};
 use compio_driver::{
     AsRawFd, RawFd, SharedFd, ToSharedFd,
-    op::{BufResultExt, Recv, Send},
+    op::{BufResultExt, Recv, RecvManaged, ResultTakeBuffer, Send},
 };
-use compio_io::{AsyncRead, AsyncWrite};
+use compio_io::{AsyncRead, AsyncReadManaged, AsyncWrite};
+use compio_runtime::{BorrowedBuffer, BufferPool};
 
 use crate::{ChildStderr, ChildStdin, ChildStdout};
 
@@ -35,6 +36,24 @@ impl AsyncRead for ChildStdout {
     }
 }
 
+impl AsyncReadManaged for ChildStdout {
+    type Buffer<'a> = BorrowedBuffer<'a>;
+    type BufferPool = BufferPool;
+
+    async fn read_managed<'a>(
+        &mut self,
+        buffer_pool: &'a Self::BufferPool,
+        len: usize,
+    ) -> io::Result<Self::Buffer<'a>> {
+        let fd = self.to_shared_fd();
+        let buffer_pool = buffer_pool.try_inner()?;
+        let op = RecvManaged::new(fd, buffer_pool, len)?;
+        compio_runtime::submit_with_flags(op)
+            .await
+            .take_buffer(buffer_pool)
+    }
+}
+
 impl AsRawFd for ChildStderr {
     fn as_raw_fd(&self) -> RawFd {
         self.0.as_raw_fd()
@@ -52,6 +71,24 @@ impl AsyncRead for ChildStderr {
         let fd = self.to_shared_fd();
         let op = Recv::new(fd, buffer);
         compio_runtime::submit(op).await.into_inner().map_advanced()
+    }
+}
+
+impl AsyncReadManaged for ChildStderr {
+    type Buffer<'a> = BorrowedBuffer<'a>;
+    type BufferPool = BufferPool;
+
+    async fn read_managed<'a>(
+        &mut self,
+        buffer_pool: &'a Self::BufferPool,
+        len: usize,
+    ) -> io::Result<Self::Buffer<'a>> {
+        let fd = self.to_shared_fd();
+        let buffer_pool = buffer_pool.try_inner()?;
+        let op = RecvManaged::new(fd, buffer_pool, len)?;
+        compio_runtime::submit_with_flags(op)
+            .await
+            .take_buffer(buffer_pool)
     }
 }
 

--- a/compio-process/src/windows.rs
+++ b/compio-process/src/windows.rs
@@ -9,10 +9,11 @@ use std::{
 use compio_buf::{BufResult, IntoInner, IoBuf, IoBufMut};
 use compio_driver::{
     AsRawFd, OpCode, OpType, RawFd, SharedFd, ToSharedFd,
-    op::{BufResultExt, Recv, Send},
+    op::{BufResultExt, Recv, RecvManaged, ResultTakeBuffer, Send},
     syscall,
 };
-use compio_io::{AsyncRead, AsyncWrite};
+use compio_io::{AsyncRead, AsyncReadManaged, AsyncWrite};
+use compio_runtime::{BorrowedBuffer, BufferPool};
 use windows_sys::Win32::System::{IO::OVERLAPPED, Threading::GetExitCodeProcess};
 
 use crate::{ChildStderr, ChildStdin, ChildStdout};
@@ -68,6 +69,24 @@ impl AsyncRead for ChildStdout {
     }
 }
 
+impl AsyncReadManaged for ChildStdout {
+    type Buffer<'a> = BorrowedBuffer<'a>;
+    type BufferPool = BufferPool;
+
+    async fn read_managed<'a>(
+        &mut self,
+        buffer_pool: &'a Self::BufferPool,
+        len: usize,
+    ) -> io::Result<Self::Buffer<'a>> {
+        let fd = self.to_shared_fd();
+        let buffer_pool = buffer_pool.try_inner()?;
+        let op = RecvManaged::new(fd, buffer_pool, len)?;
+        compio_runtime::submit_with_flags(op)
+            .await
+            .take_buffer(buffer_pool)
+    }
+}
+
 impl AsRawFd for ChildStderr {
     fn as_raw_fd(&self) -> RawFd {
         self.0.as_raw_fd()
@@ -85,6 +104,24 @@ impl AsyncRead for ChildStderr {
         let fd = self.to_shared_fd();
         let op = Recv::new(fd, buffer);
         compio_runtime::submit(op).await.into_inner().map_advanced()
+    }
+}
+
+impl AsyncReadManaged for ChildStderr {
+    type Buffer<'a> = BorrowedBuffer<'a>;
+    type BufferPool = BufferPool;
+
+    async fn read_managed<'a>(
+        &mut self,
+        buffer_pool: &'a Self::BufferPool,
+        len: usize,
+    ) -> io::Result<Self::Buffer<'a>> {
+        let fd = self.to_shared_fd();
+        let buffer_pool = buffer_pool.try_inner()?;
+        let op = RecvManaged::new(fd, buffer_pool, len)?;
+        compio_runtime::submit_with_flags(op)
+            .await
+            .take_buffer(buffer_pool)
     }
 }
 

--- a/compio-runtime/src/lib.rs
+++ b/compio-runtime/src/lib.rs
@@ -23,5 +23,6 @@ pub use async_task::Task;
 pub use attacher::*;
 use compio_buf::BufResult;
 pub use runtime::{
-    JoinHandle, Runtime, RuntimeBuilder, spawn, spawn_blocking, submit, submit_with_flags,
+    BorrowedBuffer, BufferPool, JoinHandle, Runtime, RuntimeBuilder, spawn, spawn_blocking, submit,
+    submit_with_flags,
 };

--- a/compio-runtime/src/runtime/buffer_pool.rs
+++ b/compio-runtime/src/runtime/buffer_pool.rs
@@ -1,0 +1,83 @@
+//! Buffer pool
+
+use std::{io, marker::PhantomData, mem::ManuallyDrop};
+
+pub use compio_driver::BorrowedBuffer;
+
+use crate::Runtime;
+
+/// Buffer pool
+///
+/// A buffer pool to allow user no need to specify a specific buffer to do the
+/// IO operation
+///
+/// Drop the `BufferPool` will release the buffer pool automatically
+#[derive(Debug)]
+pub struct BufferPool {
+    inner: ManuallyDrop<compio_driver::BufferPool>,
+    runtime_id: u64,
+
+    // make it !Send and !Sync, to prevent user send the buffer pool to other thread
+    _marker: PhantomData<*const ()>,
+}
+
+impl BufferPool {
+    /// Create buffer pool with given `buffer_size` and `buffer_len`
+    ///
+    /// # Notes
+    ///
+    /// If `buffer_len` is not power of 2, it will be upward with
+    /// [`u16::next_power_of_two`]
+    pub fn new(buffer_len: u16, buffer_size: usize) -> io::Result<Self> {
+        let (inner, runtime_id) = Runtime::with_current(|runtime| {
+            let buffer_pool = runtime.create_buffer_pool(buffer_len, buffer_size)?;
+            let runtime_id = runtime.id();
+
+            io::Result::Ok((buffer_pool, runtime_id))
+        })?;
+
+        Ok(Self::inner_new(inner, runtime_id))
+    }
+
+    fn inner_new(inner: compio_driver::BufferPool, runtime_id: u64) -> Self {
+        Self {
+            inner: ManuallyDrop::new(inner),
+            runtime_id,
+            _marker: Default::default(),
+        }
+    }
+
+    /// Get the inner driver buffer pool reference
+    ///
+    /// # Notes
+    ///
+    /// You should not use this method unless you are writing your own IO opcode
+    ///
+    /// # Panic
+    ///
+    /// If call this method in incorrect runtime, will panic
+    pub fn as_inner(&self) -> &compio_driver::BufferPool {
+        let current_runtime_id = Runtime::with_current(|runtime| runtime.id());
+        assert_eq!(current_runtime_id, self.runtime_id);
+
+        &self.inner
+    }
+}
+
+impl Drop for BufferPool {
+    fn drop(&mut self) {
+        let _ = Runtime::try_with_current(|runtime| {
+            if self.runtime_id != runtime.id() {
+                return;
+            }
+
+            unsafe {
+                // Safety: we own the inner
+                let inner = ManuallyDrop::take(&mut self.inner);
+
+                // Safety: the buffer pool is created by current thread runtime
+                let _ = runtime.release_buffer_pool(inner);
+            }
+        });
+    }
+}


### PR DESCRIPTION
I have to modify the traits in `compio-io` to match the signature of trait `TakeBuffer` in `compio-driver. A disadvantage is that `BorrowedBuffer` could not impl `IoBuf`.

Some other ideas that will be fixed in future PRs:
* `RecvManaged::new` and `ReadManagedAt::new` should not return `Result`.
* Adjust the parameter order of `read_managed_at`?