### PR TITLE
fix(quic): usages of `#[doc(hidden)] pub`

### DIFF
--- a/compio-quic/Cargo.toml
+++ b/compio-quic/Cargo.toml
@@ -22,7 +22,7 @@ compio-log = { workspace = true }
 compio-net = { workspace = true }
 compio-runtime = { workspace = true, features = ["time"] }
 
-quinn-proto = { version = "0.11.9", default-features = false }
+quinn-proto = { version = "0.11.10", default-features = false }
 rustls = { workspace = true }
 rustls-platform-verifier = { version = "0.5.0", optional = true }
 rustls-native-certs = { workspace = true, optional = true }

--- a/compio-quic/src/recv_stream.rs
+++ b/compio-quic/src/recv_stream.rs
@@ -569,7 +569,7 @@ pub(crate) mod h3_impl {
         }
 
         fn recv_id(&self) -> quic::StreamId {
-            self.stream.0.try_into().unwrap()
+            u64::from(self.stream).try_into().unwrap()
         }
     }
 }

--- a/compio-quic/src/send_stream.rs
+++ b/compio-quic/src/send_stream.rs
@@ -73,7 +73,7 @@ impl SendStream {
                 state.wake();
                 Ok(())
             }
-            Err(FinishError::ClosedStream) => Err(ClosedStream::new()),
+            Err(FinishError::ClosedStream) => Err(ClosedStream::default()),
             // Harmless. If the application needs to know about stopped streams at this point,
             // it should call `stopped`.
             Err(FinishError::Stopped(_)) => Ok(()),
@@ -443,7 +443,7 @@ pub(crate) mod h3_impl {
         }
 
         fn send_id(&self) -> quic::StreamId {
-            self.inner.stream.0.try_into().unwrap()
+            u64::from(self.inner.stream).try_into().unwrap()
         }
     }
 


### PR DESCRIPTION
We were previously using some `#[doc(hidden)] pub` of `quinn-proto`. In their latest release [0.11.10](https://github.com/quinn-rs/quinn/releases/tag/quinn-proto-0.11.10) they introduced some breaking changes about this.

See:
- https://github.com/quinn-rs/quinn/pull/2103
- https://github.com/quinn-rs/quinn/issues/2175
- https://github.com/hyperium/h3/pull/290