### PR TITLE
fix(driver): downgrade polling to 3.7

### DIFF
--- a/compio-driver/Cargo.toml
+++ b/compio-driver/Cargo.toml
@@ -36,7 +36,7 @@ compio-log = { workspace = true }
 cfg-if = { workspace = true }
 crossbeam-channel = { workspace = true }
 futures-util = { workspace = true }
-socket2 = { workspace = true }
+socket2 = { workspace = true, features = ["all"] }
 
 # Windows specific dependencies
 [target.'cfg(windows)'.dependencies]
@@ -59,13 +59,13 @@ windows-sys = { workspace = true, features = [
 [target.'cfg(target_os = "linux")'.dependencies]
 io-uring = { version = "0.7.0", optional = true }
 io_uring_buf_ring = { version = "0.2.0", optional = true }
-polling = { version = "3.3.0", optional = true }
+polling = { version = "~3.7.4", optional = true }
 paste = { workspace = true }
 slab = { workspace = true, optional = true }
 
 # Other platform dependencies
 [target.'cfg(all(not(target_os = "linux"), unix))'.dependencies]
-polling = "3.3.0"
+polling = "~3.7.4"
 
 [target.'cfg(unix)'.dependencies]
 crossbeam-channel = { workspace = true }

--- a/compio-net/Cargo.toml
+++ b/compio-net/Cargo.toml
@@ -24,7 +24,7 @@ compio-runtime = { workspace = true, features = ["event"] }
 cfg-if = { workspace = true }
 either = "1.9.0"
 once_cell = { workspace = true }
-socket2 = { workspace = true, features = ["all"] }
+socket2 = { workspace = true }
 
 [target.'cfg(windows)'.dependencies]
 widestring = { workspace = true }


### PR DESCRIPTION
Temporarily downgrade `polling` to 3.7 to make it work properly.

There seem to be many problems.

By the way, moved the `socket2/all` feature gate to `compio-driver`. Forgot to update this in #403.