### PR TITLE
build: add required dependencies to flake.nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -24,6 +24,8 @@
         with pkgs; {
           devShells.default = mkShell {
             buildInputs = [
+              go
+              cmake
               glib
               openssl
               pkg-config


### PR DESCRIPTION
go and cmake is required to build `aws-lc-fips-sys` (used by compio-quic)