### PR TITLE
fix(driver,poll): clear events before poll

### DIFF
--- a/compio-driver/src/poll/mod.rs
+++ b/compio-driver/src/poll/mod.rs
@@ -367,6 +367,7 @@ impl Driver {
         if self.poll_blocking() {
             return Ok(());
         }
+        self.events.clear();
         self.poll.wait(&mut self.events, timeout)?;
         if self.events.is_empty() && timeout.is_some() {
             return Err(io::Error::from_raw_os_error(libc::ETIMEDOUT));


### PR DESCRIPTION
Closes #410 