### PR TITLE
build: bump patch version for compio-quic

### DIFF
--- a/compio-quic/Cargo.toml
+++ b/compio-quic/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "compio-quic"
-version = "0.3.0"
+version = "0.3.1"
 description = "QUIC for compio"
 categories = ["asynchronous", "network-programming"]
 keywords = ["async", "net", "quic"]


### PR DESCRIPTION
`compio-quic` released on [crates.io](https://crates.io/crates/compio-quic) (and also `compio` it self with `quic` feature) does not work with fresh `Cargo.lock` due to semver-incompatible changes introduced in `quinn-proto` (see #389). A patch release should fix this issue.