### PR TITLE
fix: move socket2/all feature gate from compio-net to compio-driver

### DIFF
--- a/compio-driver/Cargo.toml
+++ b/compio-driver/Cargo.toml
@@ -36,7 +36,7 @@ compio-log = { workspace = true }
 cfg-if = { workspace = true }
 crossbeam-channel = { workspace = true }
 futures-util = { workspace = true }
-socket2 = { workspace = true }
+socket2 = { workspace = true, features = ["all"] }
 
 # Windows specific dependencies
 [target.'cfg(windows)'.dependencies]

--- a/compio-net/Cargo.toml
+++ b/compio-net/Cargo.toml
@@ -24,7 +24,7 @@ compio-runtime = { workspace = true, features = ["event"] }
 cfg-if = { workspace = true }
 either = "1.9.0"
 once_cell = { workspace = true }
-socket2 = { workspace = true, features = ["all"] }
+socket2 = { workspace = true }
 
 [target.'cfg(windows)'.dependencies]
 widestring = { workspace = true }


### PR DESCRIPTION
In #403, several `socket2` function calls that require the `all` feature were moved from `compio-net` to `compio-driver`, but the feature gate was forgotten to move. These functions include:
- `set_cloexec`
- `set_nosigpipe`