### PR TITLE
chore: rewrite compio-quic bench

### DIFF
--- a/compio-quic/benches/quic.rs
+++ b/compio-quic/benches/quic.rs
@@ -1,193 +1,234 @@
 use std::{
-    net::{IpAddr, Ipv4Addr, SocketAddr},
+    net::{Ipv4Addr, SocketAddr},
     sync::Arc,
-    time::Instant,
+    time::{Duration, Instant},
 };
 
 use compio_buf::bytes::Bytes;
-use criterion::{Bencher, BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use criterion::{BenchmarkId, Criterion, Throughput};
 use futures_util::{StreamExt, stream::FuturesUnordered};
 use rand::{RngCore, rng};
 
-criterion_group!(quic, echo);
-criterion_main!(quic);
-
-fn gen_cert() -> (
-    rustls::pki_types::CertificateDer<'static>,
-    rustls::pki_types::PrivateKeyDer<'static>,
-) {
-    let rcgen::CertifiedKey { cert, key_pair } =
-        rcgen::generate_simple_self_signed(vec!["localhost".into()]).unwrap();
-    let cert = cert.der().clone();
-    let key_der = key_pair.serialize_der().try_into().unwrap();
-    (cert, key_der)
-}
-
-macro_rules! echo_impl {
-    ($send:ident, $recv:ident) => {
-        loop {
-            // These are 32 buffers, for reading approximately 32kB at once
-            let mut bufs: [Bytes; 32] = std::array::from_fn(|_| Bytes::new());
-
-            match $recv.read_chunks(&mut bufs).await.unwrap() {
-                Some(n) => {
-                    $send.write_all_chunks(&mut bufs[..n]).await.unwrap();
-                }
-                None => break,
-            }
-        }
-
-        let _ = $send.finish();
+macro_rules! compio_spawn {
+    ($fut:expr) => {
+        compio_runtime::spawn($fut).detach()
     };
 }
 
-fn echo_compio_quic(b: &mut Bencher, content: &[u8], streams: usize) {
-    use compio_quic::{ClientBuilder, ServerBuilder};
-
-    let runtime = compio_runtime::Runtime::new().unwrap();
-    b.to_async(runtime).iter_custom(|iter| async move {
-        let (cert, key_der) = gen_cert();
-        let server = ServerBuilder::new_with_single_cert(vec![cert.clone()], key_der)
-            .unwrap()
-            .bind("127.0.0.1:0")
-            .await
-            .unwrap();
-        let client = ClientBuilder::new_with_empty_roots()
-            .with_custom_certificate(cert)
-            .unwrap()
-            .with_no_crls()
-            .bind("127.0.0.1:0")
-            .await
-            .unwrap();
-        let addr = server.local_addr().unwrap();
-
-        let (client_conn, server_conn) = futures_util::join!(
-            async move {
-                client
-                    .connect(addr, "localhost", None)
-                    .unwrap()
-                    .await
-                    .unwrap()
-            },
-            async move { server.wait_incoming().await.unwrap().await.unwrap() }
-        );
-
-        let start = Instant::now();
-        let handle = compio_runtime::spawn(async move {
-            while let Ok((mut send, mut recv)) = server_conn.accept_bi().await {
-                compio_runtime::spawn(async move {
-                    echo_impl!(send, recv);
-                })
-                .detach();
-            }
-        });
-        for _i in 0..iter {
-            let mut futures = (0..streams)
-                .map(|_| async {
-                    let (mut send, mut recv) = client_conn.open_bi_wait().await.unwrap();
-                    futures_util::join!(
-                        async {
-                            send.write_all(content).await.unwrap();
-                            send.finish().unwrap();
-                        },
-                        async {
-                            let mut buf = vec![];
-                            recv.read_to_end(&mut buf).await.unwrap();
-                        }
-                    );
-                })
-                .collect::<FuturesUnordered<_>>();
-            while futures.next().await.is_some() {}
-        }
-        drop(handle);
-        start.elapsed()
-    })
+macro_rules! tokio_spawn {
+    ($fut:expr) => {
+        tokio::spawn($fut)
+    };
 }
 
-fn echo_quinn(b: &mut Bencher, content: &[u8], streams: usize) {
-    use quinn::{ClientConfig, Endpoint, ServerConfig};
+macro_rules! echo_server_impl {
+    ($spawn:ident, $incoming:expr) => {
+        let Ok(conn) = $incoming.await else {
+            continue;
+        };
+        $spawn!(async move {
+            while let Ok((mut send, mut recv)) = conn.accept_bi().await {
+                $spawn!(async move {
+                    loop {
+                        // These are 32 buffers, for reading approximately 32kB at once
+                        let mut bufs: [Bytes; 32] = std::array::from_fn(|_| Bytes::new());
 
-    let runtime = tokio::runtime::Builder::new_current_thread()
-        .enable_all()
-        .build()
-        .unwrap();
-    b.to_async(&runtime).iter_custom(|iter| async move {
-        let (cert, key_der) = gen_cert();
-        let server_config = ServerConfig::with_single_cert(vec![cert.clone()], key_der).unwrap();
-        let mut roots = rustls::RootCertStore::empty();
-        roots.add(cert).unwrap();
-        let client_config = ClientConfig::with_root_certificates(Arc::new(roots)).unwrap();
-        let server = Endpoint::server(
-            server_config,
-            SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0),
-        )
-        .unwrap();
-        let mut client =
-            Endpoint::client(SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0)).unwrap();
-        client.set_default_client_config(client_config);
-        let addr = server.local_addr().unwrap();
+                        if let Ok(Some(n)) = recv.read_chunks(&mut bufs).await {
+                            if send.write_all_chunks(&mut bufs[..n]).await.is_err() {
+                                break;
+                            }
+                        } else {
+                            break;
+                        }
+                    }
 
-        let (client_conn, server_conn) = tokio::join!(
-            async move { client.connect(addr, "localhost").unwrap().await.unwrap() },
-            async move { server.accept().await.unwrap().await.unwrap() }
-        );
-
-        let start = Instant::now();
-        let handle = tokio::spawn(async move {
-            while let Ok((mut send, mut recv)) = server_conn.accept_bi().await {
-                tokio::spawn(async move {
-                    echo_impl!(send, recv);
+                    send.finish().ok();
                 });
             }
         });
-        for _i in 0..iter {
-            let mut futures = (0..streams)
-                .map(|_| async {
-                    let (mut send, mut recv) = client_conn.open_bi().await.unwrap();
-                    tokio::join!(
-                        async {
-                            send.write_all(content).await.unwrap();
-                            send.finish().unwrap();
-                        },
-                        async {
-                            recv.read_to_end(usize::MAX).await.unwrap();
-                        }
-                    );
-                })
-                .collect::<FuturesUnordered<_>>();
-            while futures.next().await.is_some() {}
-        }
-        handle.abort();
-        start.elapsed()
-    });
+    };
 }
 
-const DATA_SIZES: &[usize] = &[1, 10, 1024, 1200, 1024 * 16, 1024 * 128];
-const STREAMS: &[usize] = &[1, 10, 100];
+fn start_compio_quic_server(
+    cert: rustls::pki_types::CertificateDer<'static>,
+    key_der: rustls::pki_types::PrivateKeyDer<'static>,
+) -> SocketAddr {
+    let (tx, rx) = flume::bounded(0);
 
-fn echo(c: &mut Criterion) {
+    std::thread::spawn(move || {
+        compio_runtime::Runtime::new().unwrap().block_on(async {
+            let server = compio_quic::ServerBuilder::new_with_single_cert(vec![cert], key_der)
+                .unwrap()
+                .bind((Ipv4Addr::LOCALHOST, 0))
+                .await
+                .unwrap();
+
+            tx.send(server.local_addr().unwrap()).unwrap();
+
+            while let Some(incoming) = server.wait_incoming().await {
+                echo_server_impl!(compio_spawn, incoming);
+            }
+        });
+    });
+
+    rx.recv().unwrap()
+}
+
+fn start_quinn_server(
+    cert: rustls::pki_types::CertificateDer<'static>,
+    key_der: rustls::pki_types::PrivateKeyDer<'static>,
+) -> SocketAddr {
+    let (tx, rx) = flume::bounded(0);
+
+    std::thread::spawn(move || {
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap()
+            .block_on(async {
+                let server_config =
+                    quinn::ServerConfig::with_single_cert(vec![cert], key_der).unwrap();
+                let server =
+                    quinn::Endpoint::server(server_config, (Ipv4Addr::LOCALHOST, 0).into())
+                        .unwrap();
+
+                tx.send(server.local_addr().unwrap()).unwrap();
+
+                while let Some(incoming) = server.accept().await {
+                    echo_server_impl!(tokio_spawn, incoming);
+                }
+            });
+    });
+
+    rx.recv().unwrap()
+}
+
+async fn compio_quic_echo_client(
+    client: &compio_quic::Endpoint,
+    remote: SocketAddr,
+    data: &[u8],
+    iters: u64,
+) -> Duration {
+    let start = Instant::now();
+
+    let conn = client
+        .connect(remote, "localhost", None)
+        .unwrap()
+        .await
+        .unwrap();
+
+    let mut futures = (0..iters)
+        .map(|_| async {
+            let (mut send, mut recv) = conn.open_bi_wait().await.unwrap();
+            futures_util::join!(
+                async {
+                    send.write_all(data).await.unwrap();
+                    send.finish().unwrap();
+                },
+                async {
+                    let mut buf = vec![];
+                    recv.read_to_end(&mut buf).await.unwrap();
+                }
+            );
+        })
+        .collect::<FuturesUnordered<_>>();
+    while futures.next().await.is_some() {}
+
+    let elapsed = start.elapsed();
+
+    conn.close(0u32.into(), b"done");
+    conn.closed().await;
+
+    elapsed
+}
+
+async fn quinn_echo_client(
+    client: &quinn::Endpoint,
+    remote: SocketAddr,
+    data: &[u8],
+    iters: u64,
+) -> Duration {
+    let start = Instant::now();
+
+    let conn = client.connect(remote, "localhost").unwrap().await.unwrap();
+
+    let mut futures = (0..iters)
+        .map(|_| async {
+            let (mut send, mut recv) = conn.open_bi().await.unwrap();
+            futures_util::join!(
+                async {
+                    send.write_all(data).await.unwrap();
+                    send.finish().unwrap();
+                },
+                async {
+                    recv.read_to_end(usize::MAX).await.unwrap();
+                }
+            );
+        })
+        .collect::<FuturesUnordered<_>>();
+    while futures.next().await.is_some() {}
+
+    // FIXME: wait for the connection to be fully closed
+    start.elapsed()
+}
+
+fn main() {
+    let mut c = Criterion::default().configure_from_args();
+
+    let rcgen::CertifiedKey { cert, key_pair } =
+        rcgen::generate_simple_self_signed(vec!["localhost".into()]).unwrap();
+    let cert = cert.der().clone();
+    let key_der: rustls::pki_types::PrivateKeyDer = key_pair.serialize_der().try_into().unwrap();
+
+    let compio_quic_server = start_compio_quic_server(cert.clone(), key_der.clone_key());
+    let quinn_server = start_quinn_server(cert.clone(), key_der);
+
+    let compio_rt = compio_runtime::Runtime::new().unwrap();
+    let compio_quic_client = compio_rt.block_on(async {
+        compio_quic::ClientBuilder::new_with_empty_roots()
+            .with_custom_certificate(cert.clone())
+            .unwrap()
+            .with_no_crls()
+            .bind((Ipv4Addr::LOCALHOST, 0))
+            .await
+            .unwrap()
+    });
+
+    let tokio_rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    let quinn_client = tokio_rt.block_on(async {
+        let mut roots = rustls::RootCertStore::empty();
+        roots.add(cert).unwrap();
+        let client_config = quinn::ClientConfig::with_root_certificates(Arc::new(roots)).unwrap();
+        let mut client = quinn::Endpoint::client((Ipv4Addr::LOCALHOST, 0).into()).unwrap();
+        client.set_default_client_config(client_config);
+        client
+    });
+
+    const DATA_SIZE: usize = 1024 * 1024;
+
     let mut rng = rng();
-
-    let mut data = vec![0u8; *DATA_SIZES.last().unwrap()];
+    let mut data = vec![0u8; DATA_SIZE];
     rng.fill_bytes(&mut data);
 
-    let mut group = c.benchmark_group("echo");
-    for &size in DATA_SIZES {
-        let data = &data[..size];
-        for &streams in STREAMS {
-            group.throughput(Throughput::Bytes((data.len() * streams * 2) as u64));
+    let mut g = c.benchmark_group("quic-echo");
+    g.throughput(Throughput::Bytes((DATA_SIZE * 2) as u64));
 
-            group.bench_with_input(
-                BenchmarkId::new("compio-quic", format!("{streams}-streams-{size}-bytes")),
-                &(),
-                |b, _| echo_compio_quic(b, data, streams),
-            );
-            group.bench_with_input(
-                BenchmarkId::new("quinn", format!("{streams}-streams-{size}-bytes")),
-                &(),
-                |b, _| echo_quinn(b, data, streams),
-            );
-        }
+    for (server_name, remote) in [("compio-quic", compio_quic_server), ("quinn", quinn_server)] {
+        g.bench_function(BenchmarkId::new("compio-quic", server_name), |b| {
+            b.to_async(&compio_rt).iter_custom(|iters| {
+                compio_quic_echo_client(&compio_quic_client, remote, &data, iters)
+            });
+        });
+
+        g.bench_function(BenchmarkId::new("quinn", server_name), |b| {
+            b.to_async(&tokio_rt)
+                .iter_custom(|iters| quinn_echo_client(&quinn_client, remote, &data, iters));
+        });
     }
-    group.finish();
+    g.finish();
+
+    c.final_summary();
 }


### PR DESCRIPTION
- Reuse endpoints (fix #393)
- Remove unnecessary parameters
- Improve concurrency
- Cross test with quinn as server or client

Example result (Linux, io_uring):
```
quic-echo/compio-quic/compio-quic
                        time:   [2.4146 ms 2.4912 ms 2.5750 ms]
                        thrpt:  [776.70 MiB/s 802.83 MiB/s 828.29 MiB/s]
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild
Benchmarking quic-echo/quinn/compio-quic: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 8.6s, enable flat sampling, or reduce sample count to 50.
quic-echo/quinn/compio-quic
                        time:   [1.4626 ms 1.4850 ms 1.5125 ms]
                        thrpt:  [1.2914 GiB/s 1.3153 GiB/s 1.3354 GiB/s]
Found 10 outliers among 100 measurements (10.00%)
  1 (1.00%) high mild
  9 (9.00%) high severe
quic-echo/compio-quic/quinn
                        time:   [2.4185 ms 2.4908 ms 2.5658 ms]
                        thrpt:  [779.50 MiB/s 802.94 MiB/s 826.96 MiB/s]
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high severe
Benchmarking quic-echo/quinn/quinn: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 7.1s, enable flat sampling, or reduce sample count to 50.
quic-echo/quinn/quinn   time:   [1.5014 ms 1.6702 ms 1.8712 ms]
                        thrpt:  [1.0438 GiB/s 1.1694 GiB/s 1.3009 GiB/s]
Found 15 outliers among 100 measurements (15.00%)
  7 (7.00%) high mild
  8 (8.00%) high severe
```