### PR TITLE
Add Debug Print for aiocb ReadAt and WriteAt for illumos

### DIFF
--- a/compio-driver/src/op.rs
+++ b/compio-driver/src/op.rs
@@ -4,7 +4,7 @@
 //! The operation itself doesn't perform anything.
 //! You need to pass them to [`crate::Proactor`], and poll the driver.
 
-use std::{io, marker::PhantomPinned, mem::ManuallyDrop, net::Shutdown};
+use std::{io, fmt, marker::PhantomPinned, mem::ManuallyDrop, net::Shutdown};
 
 use compio_buf::{BufResult, IntoInner, IoBuf, IoBufMut, SetBufInit};
 use socket2::SockAddr;
@@ -161,7 +161,7 @@ impl CloseFile {
 }
 
 /// Read a file at specified position into specified buffer.
-#[derive(Debug)]
+#[derive(Clone)]
 pub struct ReadAt<T: IoBufMut, S> {
     pub(crate) fd: S,
     pub(crate) offset: u64,
@@ -193,8 +193,28 @@ impl<T: IoBufMut, S> IntoInner for ReadAt<T, S> {
     }
 }
 
+#[cfg(aio)]
+impl<T: fmt::Debug + compio_buf::IoBufMut, S: fmt::Debug> fmt::Debug for ReadAt<T, S> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let aiocb_debug = format!(
+            "aiocb {{ aio_fildes: {:?}, aio_buf: {:?}, aio_bytes: {:?}, aio_offset: {:?} }}",
+            self.aiocb.aio_fildes,
+            self.aiocb.aio_buf as usize, // Casting to usize for safer display
+            self.aiocb.aio_nbytes,
+            self.aiocb.aio_offset,
+        );
+
+        f.debug_struct("ReadAt")
+            .field("fd", &self.fd)
+            .field("offset", &self.offset)
+            .field("buffer", &self.buffer)
+            .field("aiocb", &aiocb_debug)
+            .finish()
+    }
+}
+
 /// Write a file at specified position from specified buffer.
-#[derive(Debug)]
+#[derive(Clone)]
 pub struct WriteAt<T: IoBuf, S> {
     pub(crate) fd: S,
     pub(crate) offset: u64,
@@ -215,6 +235,26 @@ impl<T: IoBuf, S> WriteAt<T, S> {
             aiocb: unsafe { std::mem::zeroed() },
             _p: PhantomPinned,
         }
+    }
+}
+
+#[cfg(aio)]
+impl<T: fmt::Debug + compio_buf::IoBuf, S: fmt::Debug> fmt::Debug for WriteAt<T, S> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let aiocb_debug = format!(
+            "aiocb {{ aio_fildes: {:?}, aio_buf: {:?}, aio_bytes: {:?}, aio_offset: {:?} }}",
+            self.aiocb.aio_fildes,
+            self.aiocb.aio_buf as usize, // Casting to usize for safer display
+            self.aiocb.aio_nbytes,
+            self.aiocb.aio_offset,
+        );
+
+        f.debug_struct("WriteAt")
+            .field("fd", &self.fd)
+            .field("offset", &self.offset)
+            .field("buffer", &self.buffer)
+            .field("aiocb", &aiocb_debug)
+            .finish()
     }
 }
 


### PR DESCRIPTION
Although compio compiles, runs and tested great on Illumos, it was only possible after resolving a rust print debug issue for aiocb.

In this solution, we added a fmt::Debug impl for both ReadAt and WriteAt.

This probably isn't the best long term solution, but it worked in a pinch.

Note, I had an unexplained difference between my recent github pull, and this up to date fork. The important changes are obvious even if some line numbers have changed to protect the innocent.
