### PR TITLE
feat(runtime): add "notify-always" feature

### DIFF
--- a/compio-runtime/Cargo.toml
+++ b/compio-runtime/Cargo.toml
@@ -65,6 +65,9 @@ time = ["dep:slab"]
 io-uring = ["compio-driver/io-uring"]
 polling = ["compio-driver/polling"]
 
+# Enable it to always notify the driver when a task schedules.
+notify-always = []
+
 [[test]]
 name = "event"
 required-features = ["event"]

--- a/compio-runtime/src/runtime/mod.rs
+++ b/compio-runtime/src/runtime/mod.rs
@@ -57,6 +57,8 @@ impl RunnableQueue {
     pub fn schedule(&self, runnable: Runnable, handle: &NotifyHandle) {
         if let Some(runnables) = self.local_runnables.get() {
             runnables.borrow_mut().push_back(runnable);
+            #[cfg(feature = "notify-always")]
+            handle.notify().ok();
         } else {
             self.sync_runnables.push(runnable);
             handle.notify().ok();


### PR DESCRIPTION
This PR is for a corner-case support: the driver fd might be polled in another thread, while the main thread is controlled by another event loop, e.g., WinUI dispatcher.