### PR TITLE
refactor: cleanup features

### DIFF
--- a/compio-dispatcher/Cargo.toml
+++ b/compio-dispatcher/Cargo.toml
@@ -29,7 +29,3 @@ compio-net = { workspace = true }
 compio-macros = { workspace = true }
 
 futures-util = { workspace = true }
-
-[features]
-io-uring = ["compio-runtime/io-uring"]
-polling = ["compio-runtime/polling"]

--- a/compio-fs/Cargo.toml
+++ b/compio-fs/Cargo.toml
@@ -62,9 +62,6 @@ windows-sys = { workspace = true, features = ["Win32_Security_Authorization"] }
 nix = { workspace = true, features = ["fs"] }
 
 [features]
-io-uring = ["compio-runtime/io-uring"]
-polling = ["compio-runtime/polling"]
-
 read_buf = ["compio-buf/read_buf", "compio-io/read_buf"]
 windows_by_handle = []
 nightly = ["read_buf", "windows_by_handle"]

--- a/compio-fs/src/pipe.rs
+++ b/compio-fs/src/pipe.rs
@@ -545,9 +545,7 @@ async fn is_fifo(file: &File) -> io::Result<bool> {
 
 /// Sets file's flags with O_NONBLOCK by fcntl.
 fn set_nonblocking(file: &impl AsRawFd) -> io::Result<()> {
-    if cfg!(not(all(target_os = "linux", feature = "io-uring")))
-        || compio_driver::DriverType::is_polling()
-    {
+    if compio_driver::DriverType::is_polling() {
         let fd = file.as_raw_fd();
         let current_flags = syscall!(libc::fcntl(fd, libc::F_GETFL))?;
         let flags = current_flags | libc::O_NONBLOCK;

--- a/compio-net/Cargo.toml
+++ b/compio-net/Cargo.toml
@@ -44,9 +44,6 @@ futures-util = { workspace = true }
 tempfile = { workspace = true }
 
 [features]
-io-uring = ["compio-runtime/io-uring"]
-polling = ["compio-runtime/polling"]
-
 # Nightly features
 once_cell_try = []
 nightly = ["once_cell_try"]

--- a/compio-process/Cargo.toml
+++ b/compio-process/Cargo.toml
@@ -30,8 +30,5 @@ windows-sys = { workspace = true }
 compio-macros = { workspace = true }
 
 [features]
-io-uring = ["compio-runtime/io-uring"]
-polling = ["compio-runtime/polling"]
-
 linux_pidfd = []
 nightly = ["linux_pidfd"]

--- a/compio-quic/Cargo.toml
+++ b/compio-quic/Cargo.toml
@@ -64,8 +64,6 @@ tracing-subscriber = { workspace = true, features = ["env-filter"] }
 
 [features]
 default = ["ring"]
-io-uring = ["compio-runtime/io-uring"]
-polling = ["compio-runtime/polling"]
 io-compat = ["futures-util/io"]
 platform-verifier = ["dep:rustls-platform-verifier"]
 native-certs = ["dep:rustls-native-certs"]

--- a/compio-runtime/Cargo.toml
+++ b/compio-runtime/Cargo.toml
@@ -62,9 +62,6 @@ block2 = "0.6.0"
 event = ["dep:cfg-if", "compio-buf/arrayvec"]
 time = ["dep:slab"]
 
-io-uring = ["compio-driver/io-uring"]
-polling = ["compio-driver/polling"]
-
 # Enable it to always notify the driver when a task schedules.
 notify-always = []
 

--- a/compio-signal/Cargo.toml
+++ b/compio-signal/Cargo.toml
@@ -43,8 +43,6 @@ os_pipe = { workspace = true }
 slab = { workspace = true }
 
 [features]
-io-uring = ["compio-runtime/io-uring"]
-polling = ["compio-runtime/polling"]
 # Nightly features
 lazy_cell = []
 once_cell_try = []

--- a/compio-signal/src/linux.rs
+++ b/compio-signal/src/linux.rs
@@ -57,7 +57,7 @@ impl SignalFd {
     fn new(sig: i32) -> io::Result<Self> {
         let set = register_signal(sig)?;
         let mut flag = libc::SFD_CLOEXEC;
-        if cfg!(not(feature = "io-uring")) || compio_driver::DriverType::is_polling() {
+        if compio_driver::DriverType::is_polling() {
             flag |= libc::SFD_NONBLOCK;
         }
         let fd = syscall!(libc::signalfd(-1, &set, flag))?;

--- a/compio/Cargo.toml
+++ b/compio/Cargo.toml
@@ -77,26 +77,8 @@ monoio = { version = "0.2.2", default-features = false, features = ["iouring"] }
 
 [features]
 default = ["runtime", "io-uring"]
-io-uring = [
-    "compio-driver/io-uring",
-    "compio-runtime?/io-uring",
-    "compio-fs?/io-uring",
-    "compio-net?/io-uring",
-    "compio-signal?/io-uring",
-    "compio-quic?/io-uring",
-    "compio-process?/io-uring",
-    "compio-dispatcher?/io-uring",
-]
-polling = [
-    "compio-driver/polling",
-    "compio-runtime?/polling",
-    "compio-fs?/polling",
-    "compio-net?/polling",
-    "compio-signal?/polling",
-    "compio-quic?/polling",
-    "compio-process?/polling",
-    "compio-dispatcher?/polling",
-]
+io-uring = ["compio-driver/io-uring"]
+polling = ["compio-driver/polling"]
 io = ["dep:compio-io"]
 io-compat = ["io", "compio-io/compat", "compio-quic?/io-compat"]
 runtime = ["dep:compio-runtime", "dep:compio-fs", "dep:compio-net", "io"]


### PR DESCRIPTION
I don't remember why we added so many useless features to these subcrates. Anyway we can determine the driver type on run time, and hope that rustc will optimize them.