### PR TITLE
feat(driver): warn if thread pool limit is set to 0

### DIFF
--- a/compio-driver/src/lib.rs
+++ b/compio-driver/src/lib.rs
@@ -489,7 +489,15 @@ impl ProactorBuilder {
     /// default value is 256.
     ///
     /// It will be ignored if `reuse_thread_pool` is set.
+    ///
+    /// Warning: some operations don't work if the limit is set to zero:
+    /// * `Asyncify` needs thread pool.
+    /// * Operations except `Recv*`, `Send*`, `Connect`, `Accept` may need
+    ///   thread pool.
     pub fn thread_pool_limit(&mut self, value: usize) -> &mut Self {
+        if value == 0 {
+            compio_log::warn!("Some operations don't work if the limit is set to zero.");
+        }
         if let ThreadPoolBuilder::Create { limit, .. } = &mut self.pool_builder {
             *limit = value;
         }


### PR DESCRIPTION
Closes #446 

I don't think `panic` is a good idea. However, the doc needs update to warn about that.