### PR TITLE
RFC: Add support for heterogeneous vectored IO

### DIFF
--- a/compio-driver/src/op.rs
+++ b/compio-driver/src/op.rs
@@ -11,7 +11,7 @@ use socket2::{SockAddr, SockAddrStorage, socklen_t};
 
 pub use crate::sys::op::{
     Accept, Recv, RecvFrom, RecvFromVectored, RecvMsg, RecvVectored, Send, SendMsg, SendTo,
-    SendToVectored, SendVectored,
+    SendToVectored, SendToVectored2, SendVectored,
 };
 #[cfg(windows)]
 pub use crate::sys::op::{ConnectNamedPipe, DeviceIoControl};

--- a/compio-net/src/socket.rs
+++ b/compio-net/src/socket.rs
@@ -4,7 +4,7 @@ use std::{
     mem::{ManuallyDrop, MaybeUninit},
 };
 
-use compio_buf::{BufResult, IntoInner, IoBuf, IoBufMut, IoVectoredBuf, IoVectoredBufMut};
+use compio_buf::{BufResult, IntoInner, IoBuf, IoBufMut, IoVectoredBuf, IoVectoredBuf2, IoVectoredBufMut};
 #[cfg(unix)]
 use compio_driver::op::CreateSocket;
 use compio_driver::{
@@ -12,7 +12,7 @@ use compio_driver::{
     op::{
         Accept, BufResultExt, CloseSocket, Connect, Recv, RecvFrom, RecvFromVectored, RecvManaged,
         RecvMsg, RecvResultExt, RecvVectored, ResultTakeBuffer, Send, SendMsg, SendTo,
-        SendToVectored, SendVectored, ShutdownSocket,
+        SendToVectored, SendToVectored2, SendVectored, ShutdownSocket,
     },
     syscall,
 };
@@ -257,6 +257,16 @@ impl Socket {
     ) -> BufResult<usize, T> {
         let fd = self.to_shared_fd();
         let op = SendToVectored::new(fd, buffer, addr.clone());
+        compio_runtime::submit(op).await.into_inner()
+    }
+
+    pub async fn send_to_vectored2<T: IoVectoredBuf2>(
+        &self,
+        buffer: T,
+        addr: &SockAddr,
+    ) -> BufResult<usize, T> {
+        let fd = self.to_shared_fd();
+        let op = SendToVectored2::new(fd, buffer, addr.clone());
         compio_runtime::submit(op).await.into_inner()
     }
 

--- a/compio-net/src/udp.rs
+++ b/compio-net/src/udp.rs
@@ -1,6 +1,6 @@
 use std::{future::Future, io, net::SocketAddr};
 
-use compio_buf::{BufResult, IoBuf, IoBufMut, IoVectoredBuf, IoVectoredBufMut};
+use compio_buf::{BufResult, IoBuf, IoBufMut, IoVectoredBuf, IoVectoredBuf2, IoVectoredBufMut};
 use compio_driver::impl_raw_fd;
 use compio_runtime::{BorrowedBuffer, BufferPool};
 use socket2::{Protocol, SockAddr, Socket as Socket2, Type};
@@ -292,6 +292,21 @@ impl UdpSocket {
         super::first_addr_buf(addr, buffer, |addr, buffer| async move {
             self.inner
                 .send_to_vectored(buffer, &SockAddr::from(addr))
+                .await
+        })
+        .await
+    }
+
+    /// Sends data on the socket to the given address. On success, returns the
+    /// number of bytes sent.
+    pub async fn send_to_vectored2<T: IoVectoredBuf2>(
+        &self,
+        buffer: T,
+        addr: impl ToSocketAddrsAsync,
+    ) -> BufResult<usize, T> {
+        super::first_addr_buf(addr, buffer, |addr, buffer| async move {
+            self.inner
+                .send_to_vectored2(buffer, &SockAddr::from(addr))
                 .await
         })
         .await


### PR DESCRIPTION
This PR serves as a RFC for introducing support for heterogeneous vectored IO.

As an example, a use case for heterogeneous vectored IO can be: one part of the data to be written might be a statically allocated array (fixed header for a network packet), another a Vec (dynamic data of the network packet).

Conceptually, I thought about representing this as nested tuples `(buffer1, (buffer2, ())` and use it with a vectored write operation. I've run into the problem that for IoVectoredBuf all items must be of the same type. Therefore, this PR introduces a `IoVectoredBuf2` which overcomes this limitation and can be implemented for all types that `IoVectoredBuf` is implemented as well as nested tuples like `(buffer1, (buffer2, ())` where buffer1 and buffer2 implement IoBuf but can be of different types.

Currently, this PR only implements a `send_to_vectored` for windows using iocp as an example.