### PR TITLE
Modify devShells.default buildInputs in flake.nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -29,11 +29,14 @@
               glib
               openssl
               pkg-config
+              llvmPackages.clangUseLLVM
               (rust-bin.selectLatestNightlyWith (toolchain:
                 toolchain.default.override {
                   extensions = ["rust-src"];
                 }))
             ];
+            
+            AWS_LC_FIPS_SYS_CC = "${llvmPackages.clangUseLLVM}/bin/cc";
           };
         }
     );


### PR DESCRIPTION
Updated the devShells.default buildInputs to include llvmPackages.clangUseLLVM and set AWS_LC_FIPS_SYS_CC.