### PR TITLE
fix(runtime): drop the runnables manually, and forget them on other threads

### DIFF
--- a/compio-runtime/src/runtime/mod.rs
+++ b/compio-runtime/src/runtime/mod.rs
@@ -348,6 +348,15 @@ impl Runtime {
     }
 }
 
+impl Drop for Runtime {
+    fn drop(&mut self) {
+        self.enter(|| {
+            self.timer_runtime.borrow_mut().clear();
+            self.scheduler.clear();
+        })
+    }
+}
+
 impl AsRawFd for Runtime {
     fn as_raw_fd(&self) -> RawFd {
         self.driver.borrow().as_raw_fd()

--- a/compio-runtime/src/runtime/time.rs
+++ b/compio-runtime/src/runtime/time.rs
@@ -109,6 +109,10 @@ impl TimerRuntime {
                 }
             });
     }
+
+    pub fn clear(&mut self) {
+        self.wheel.clear();
+    }
 }
 
 pub struct TimerFuture(TimerKey);

--- a/compio-runtime/tests/drop.rs
+++ b/compio-runtime/tests/drop.rs
@@ -1,0 +1,11 @@
+#[test]
+fn test_drop() {
+    compio_runtime::Runtime::new().unwrap().block_on(async {
+        compio_runtime::spawn(async {
+            loop {
+                compio_runtime::time::sleep(std::time::Duration::from_secs(1)).await;
+            }
+        })
+        .detach();
+    })
+}


### PR DESCRIPTION
cc: @Paraworker

The timer runtime is cleared before the scheduler, to drop the remaining wakers. All runnables are dropped in the context of current runtime.

The runnable will be forgotten, if the runtime has been dropped, and the waker is waked on another thread.