### PR TITLE
fix(runtime): store active task's `Waker` in `Scheduler`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,7 @@ nix = "0.30.1"
 once_cell = "1.18.0"
 os_pipe = "1.1.4"
 paste = "1.0.14"
+pin-project-lite = "0.2.16"
 rand = "0.9.0"
 rustls = { version = "0.23.1", default-features = false }
 rustls-native-certs = "0.8.0"

--- a/compio-io/Cargo.toml
+++ b/compio-io/Cargo.toml
@@ -15,7 +15,7 @@ compio-buf = { workspace = true, features = ["arrayvec", "bytes"] }
 futures-util = { workspace = true, features = ["sink"] }
 paste = { workspace = true }
 thiserror = { workspace = true, optional = true }
-pin-project-lite = { version = "0.2.14", optional = true }
+pin-project-lite = { workspace = true, optional = true }
 serde = { version = "1.0.219", optional = true }
 serde_json = { version = "1.0.140", optional = true }
 

--- a/compio-runtime/Cargo.toml
+++ b/compio-runtime/Cargo.toml
@@ -41,8 +41,9 @@ crossbeam-queue = { workspace = true }
 futures-util = { workspace = true }
 once_cell = { workspace = true }
 scoped-tls = "1.0.1"
-slab = { workspace = true, optional = true }
+slab = { workspace = true }
 socket2 = { workspace = true }
+pin-project-lite = { workspace = true }
 
 # Windows specific dependencies
 [target.'cfg(windows)'.dependencies]
@@ -61,11 +62,19 @@ block2 = "0.6.0"
 
 [features]
 event = ["dep:cfg-if", "compio-buf/arrayvec"]
-time = ["dep:slab"]
+time = []
 
 # Enable it to always notify the driver when a task schedules.
 notify-always = []
 
 [[test]]
+name = "custom_loop"
+required-features = ["event", "time"]
+
+[[test]]
 name = "event"
 required-features = ["event"]
+
+[[test]]
+name = "drop"
+required-features = ["time"]

--- a/compio-runtime/src/runtime/scheduler/drop_hook.rs
+++ b/compio-runtime/src/runtime/scheduler/drop_hook.rs
@@ -1,0 +1,43 @@
+use std::{
+    future::Future,
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+use pin_project_lite::pin_project;
+
+/// Calls a function when dropped.
+struct Defer<F: FnMut()>(F);
+
+impl<F: FnMut()> Drop for Defer<F> {
+    fn drop(&mut self) {
+        (self.0)();
+    }
+}
+
+pin_project! {
+    /// A future wrapper that runs a hook when dropped.
+    pub(crate) struct DropHook<Fut, Hook: FnMut()> {
+        #[pin]
+        future: Fut,
+        _hook: Defer<Hook>,
+    }
+}
+
+impl<Fut, Hook: FnMut()> DropHook<Fut, Hook> {
+    /// Creates a new [`DropHook`].
+    pub(crate) fn new(future: Fut, hook: Hook) -> Self {
+        Self {
+            future,
+            _hook: Defer(hook),
+        }
+    }
+}
+
+impl<Fut: Future, Hook: FnMut()> Future for DropHook<Fut, Hook> {
+    type Output = Fut::Output;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        self.project().future.poll(cx)
+    }
+}

--- a/compio-runtime/tests/drop.rs
+++ b/compio-runtime/tests/drop.rs
@@ -1,0 +1,89 @@
+use futures_util::task::AtomicWaker;
+use std::{
+    future::Future,
+    pin::Pin,
+    sync::Arc,
+    task::{Context, Poll},
+    thread::{self, ThreadId},
+};
+
+struct DropWatcher {
+    waker: Arc<AtomicWaker>,
+    thread_id: ThreadId,
+}
+
+impl DropWatcher {
+    fn new(waker: Arc<AtomicWaker>) -> Self {
+        Self {
+            waker,
+            thread_id: thread::current().id(),
+        }
+    }
+}
+
+impl Future for DropWatcher {
+    type Output = ();
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<()> {
+        self.waker.register(cx.waker());
+        Poll::Pending
+    }
+}
+
+impl Drop for DropWatcher {
+    fn drop(&mut self) {
+        if self.thread_id != thread::current().id() {
+            panic!("DropWatcher dropped on a different thread!!!");
+        }
+    }
+}
+
+#[test]
+fn test_drop_with_timer() {
+    compio_runtime::Runtime::new().unwrap().block_on(async {
+        compio_runtime::spawn(async {
+            loop {
+                compio_runtime::time::sleep(std::time::Duration::from_secs(1)).await;
+            }
+        })
+        .detach();
+    })
+}
+
+#[test]
+fn test_wake_after_runtime_drop() {
+    let waker = Arc::new(AtomicWaker::new());
+    let waker_clone = waker.clone();
+
+    let rt = compio_runtime::Runtime::new().unwrap();
+
+    rt.block_on(async move {
+        compio_runtime::spawn(DropWatcher::new(waker_clone)).detach();
+    });
+
+    drop(rt);
+
+    // Use `unwrap()` to ensure there is a waker stored.
+    waker.take().unwrap().wake();
+}
+
+#[test]
+fn test_wake_from_another_thread_after_runtime_drop() {
+    let waker = Arc::new(AtomicWaker::new());
+    let waker_clone = waker.clone();
+
+    let rt = compio_runtime::Runtime::new().unwrap();
+
+    rt.block_on(async move {
+        compio_runtime::spawn(DropWatcher::new(waker_clone)).detach();
+    });
+
+    drop(rt);
+
+    thread::spawn(move || {
+        // Use `unwrap()` to ensure there is a waker stored.
+        waker.take().unwrap().wake();
+    })
+    .join()
+    .unwrap();
+}


### PR DESCRIPTION
Fixed the issue where a future could be dropped on another thread, and ensured that futures are always dropped within the runtime context, because dropping a future may require access to the context.

Inspired by the implementation of `async-executor::LocalExecutor`. 

Supersedes #493