### PR TITLE
fix(driver): `new_with_flags` does not exist

### DIFF
--- a/compio-driver/Cargo.toml
+++ b/compio-driver/Cargo.toml
@@ -57,7 +57,7 @@ windows-sys = { workspace = true, features = [
 # Linux specific dependencies
 [target.'cfg(target_os = "linux")'.dependencies]
 io-uring = { version = "0.7.0", optional = true }
-io_uring_buf_ring = { version = "0.2.0", optional = true }
+io_uring_buf_ring = { version = "0.2.2", optional = true }
 once_cell = { workspace = true, optional = true }
 polling = { version = "3.3.0", optional = true }
 paste = { workspace = true }


### PR DESCRIPTION
#506 relys on `new_with_flags`, which is introduced in `io_uring_buf_ring` v0.2.2. Earlier version of `io_uring_buf_ring` won't compile.