### PR TITLE
refactor: deprecate aws-lc-rs

### DIFF
--- a/compio-quic/Cargo.toml
+++ b/compio-quic/Cargo.toml
@@ -70,8 +70,10 @@ native-certs = ["dep:rustls-native-certs"]
 webpki-roots = ["dep:webpki-roots"]
 h3 = ["dep:h3", "dep:h3-datagram"]
 ring = ["quinn-proto/rustls-ring"]
-aws-lc-rs = ["quinn-proto/rustls-aws-lc-rs"]
-aws-lc-rs-fips = ["aws-lc-rs", "quinn-proto/rustls-aws-lc-rs-fips"]
+
+# Deprecated Features
+aws-lc-rs = []
+aws-lc-rs-fips = []
 
 [[example]]
 name = "http3-client"

--- a/compio-quic/build.rs
+++ b/compio-quic/build.rs
@@ -11,6 +11,6 @@ fn main() {
         bsd: { any(freebsd, non_freebsd) },
         solarish: { any(target_os = "illumos", target_os = "solaris") },
         apple: { target_vendor = "apple" },
-        rustls: { any(feature = "aws-lc-rs", feature = "ring") }
+        rustls: { any(feature = "ring") }
     }
 }

--- a/compio-quic/src/builder.rs
+++ b/compio-quic/src/builder.rs
@@ -239,9 +239,7 @@ mod verifier {
                 rustls::crypto::CryptoProvider::get_default()
                     .map(|provider| provider.signature_verification_algorithms)
                     .unwrap_or_else(|| {
-                        #[cfg(feature = "aws-lc-rs")]
-                        use rustls::crypto::aws_lc_rs::default_provider;
-                        #[cfg(all(not(feature = "aws-lc-rs"), feature = "ring"))]
+                        #[cfg(feature = "ring")]
                         use rustls::crypto::ring::default_provider;
                         default_provider().signature_verification_algorithms
                     }),

--- a/compio-tls/Cargo.toml
+++ b/compio-tls/Cargo.toml
@@ -49,8 +49,10 @@ all = ["native-tls", "rustls"]
 rustls = ["dep:rustls", "dep:futures-rustls", "dep:futures-util"]
 
 ring = ["rustls", "rustls/ring", "futures-rustls/ring"]
-aws-lc-rs = ["rustls", "rustls/aws-lc-rs", "futures-rustls/aws-lc-rs"]
-aws-lc-rs-fips = ["aws-lc-rs", "rustls/fips", "futures-rustls/fips"]
 
 read_buf = ["compio-buf/read_buf", "compio-io/read_buf", "rustls?/read_buf"]
 nightly = ["read_buf"]
+
+# Deprecated Features
+aws-lc-rs = []
+aws-lc-rs-fips = []

--- a/compio-ws/Cargo.toml
+++ b/compio-ws/Cargo.toml
@@ -36,13 +36,14 @@ tracing-subscriber = { workspace = true, features = ["env-filter"] }
 
 [features]
 default = []
-# Deprecated
-connect = []
 native-tls = ["compio-tls/native-tls", "tungstenite/native-tls"]
 rustls = ["compio-tls/rustls", "tungstenite/__rustls-tls"]
 rustls-platform-verifier = ["rustls", "dep:rustls-platform-verifier"]
 rustls-native-certs = ["rustls", "dep:rustls-native-certs"]
 webpki-roots = ["rustls", "dep:webpki-roots"]
 ring = ["compio-tls/ring"]
-aws-lc-rs = ["compio-tls/aws-lc-rs"]
-aws-lc-rs-fips = ["compio-tls/aws-lc-rs-fips"]
+
+# Deprecated Features
+connect = []
+aws-lc-rs = []
+aws-lc-rs-fips = []

--- a/compio/Cargo.toml
+++ b/compio/Cargo.toml
@@ -118,16 +118,10 @@ criterion = ["compio-runtime?/criterion"]
 enable_log = ["compio-log/enable_log"]
 
 ring = ["compio-tls?/ring", "compio-quic?/ring", "compio-ws?/ring"]
-aws-lc-rs = [
-    "compio-tls?/aws-lc-rs",
-    "compio-quic?/aws-lc-rs",
-    "compio-ws?/aws-lc-rs",
-]
-aws-lc-rs-fips = [
-    "compio-tls?/aws-lc-rs-fips",
-    "compio-quic?/aws-lc-rs-fips",
-    "compio-ws?/aws-lc-rs-fips",
-]
+
+# Deprecated Features
+aws-lc-rs = []
+aws-lc-rs-fips = []
 
 # Nightly features
 allocator_api = ["compio-buf/allocator_api", "compio-io?/allocator_api"]


### PR DESCRIPTION
Due to compilation difficulty \[[1](https://github.com/aws/aws-lc-rs/issues/716)]\[[2](https://github.com/aws/aws-lc-rs/issues/569)\] and lack of usage (AFAWK), we have decided to deprecate `aws-lc-rs` support.