### PR TITLE
feat: bump version for release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,8 +27,8 @@ repository = "https://github.com/compio-rs/compio"
 
 [workspace.dependencies]
 compio-buf = { path = "./compio-buf", version = "0.7.0" }
-compio-driver = { path = "./compio-driver", version = "0.9.2", default-features = false }
-compio-runtime = { path = "./compio-runtime", version = "0.9.4" }
+compio-driver = { path = "./compio-driver", version = "0.9.3", default-features = false }
+compio-runtime = { path = "./compio-runtime", version = "0.9.5" }
 compio-macros = { path = "./compio-macros", version = "0.1.2" }
 compio-fs = { path = "./compio-fs", version = "0.9.0" }
 compio-io = { path = "./compio-io", version = "0.8.3" }
@@ -36,9 +36,9 @@ compio-net = { path = "./compio-net", version = "0.9.0" }
 compio-signal = { path = "./compio-signal", version = "0.7.0" }
 compio-dispatcher = { path = "./compio-dispatcher", version = "0.8.1" }
 compio-log = { path = "./compio-log", version = "0.1.0" }
-compio-tls = { path = "./compio-tls", version = "0.7.2", default-features = false }
+compio-tls = { path = "./compio-tls", version = "0.8.0", default-features = false }
 compio-process = { path = "./compio-process", version = "0.6.0" }
-compio-quic = { path = "./compio-quic", version = "0.5.1", default-features = false }
+compio-quic = { path = "./compio-quic", version = "0.6.0", default-features = false }
 compio-ws = { path = "./compio-ws", version = "0.2.0", default-features = false }
 
 bytes = "1.7.1"

--- a/compio-driver/Cargo.toml
+++ b/compio-driver/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "compio-driver"
-version = "0.9.2"
+version = "0.9.3"
 description = "Low-level driver for compio"
 categories = ["asynchronous"]
 keywords = ["async", "iocp", "io-uring"]

--- a/compio-quic/Cargo.toml
+++ b/compio-quic/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "compio-quic"
-version = "0.5.1"
+version = "0.6.0"
 description = "QUIC for compio"
 categories = ["asynchronous", "network-programming"]
 keywords = ["async", "net", "quic"]
@@ -70,10 +70,6 @@ native-certs = ["dep:rustls-native-certs"]
 webpki-roots = ["dep:webpki-roots"]
 h3 = ["dep:h3", "dep:h3-datagram"]
 ring = ["quinn-proto/rustls-ring"]
-
-# Deprecated Features
-aws-lc-rs = []
-aws-lc-rs-fips = []
 
 [[example]]
 name = "http3-client"

--- a/compio-tls/Cargo.toml
+++ b/compio-tls/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "compio-tls"
-version = "0.7.2"
+version = "0.8.0"
 description = "TLS adaptor with compio"
 categories = ["asynchronous", "network-programming"]
 keywords = ["async", "net", "tls"]
@@ -52,7 +52,3 @@ ring = ["rustls", "rustls/ring", "futures-rustls/ring"]
 
 read_buf = ["compio-buf/read_buf", "compio-io/read_buf", "rustls?/read_buf"]
 nightly = ["read_buf"]
-
-# Deprecated Features
-aws-lc-rs = []
-aws-lc-rs-fips = []

--- a/compio-ws/Cargo.toml
+++ b/compio-ws/Cargo.toml
@@ -42,8 +42,3 @@ rustls-platform-verifier = ["rustls", "dep:rustls-platform-verifier"]
 rustls-native-certs = ["rustls", "dep:rustls-native-certs"]
 webpki-roots = ["rustls", "dep:webpki-roots"]
 ring = ["compio-tls/ring"]
-
-# Deprecated Features
-connect = []
-aws-lc-rs = []
-aws-lc-rs-fips = []

--- a/compio/Cargo.toml
+++ b/compio/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "compio"
-version = "0.16.2"
+version = "0.17.0"
 description = "Completion based async runtime"
 categories = ["asynchronous", "filesystem", "network-programming"]
 keywords = ["async", "fs", "iocp", "io-uring", "net"]
@@ -95,7 +95,6 @@ process = ["dep:compio-process"]
 quic = ["dep:compio-quic"]
 h3 = ["quic", "compio-quic/h3"]
 ws = ["dep:compio-ws"]
-ws-connect = ["ws", "compio-ws/connect"]
 all = [
     "time",
     "macros",
@@ -107,7 +106,6 @@ all = [
     "quic",
     "h3",
     "ws",
-    "ws-connect",
 ]
 
 arrayvec = ["compio-buf/arrayvec"]
@@ -118,10 +116,6 @@ criterion = ["compio-runtime?/criterion"]
 enable_log = ["compio-log/enable_log"]
 
 ring = ["compio-tls?/ring", "compio-quic?/ring", "compio-ws?/ring"]
-
-# Deprecated Features
-aws-lc-rs = []
-aws-lc-rs-fips = []
 
 # Nightly features
 allocator_api = ["compio-buf/allocator_api", "compio-io?/allocator_api"]


### PR DESCRIPTION
As `compio-ws` introduces breaking changes, we have to bump `compio` to 0.17. We can happily remove the `aws-lc` related features then.

Although this is a new minor (major?) release, I don't want to bump the versions of all creates. `compio-driver` and `compio-runtime` still keep the compatibility so that the user won't need to download the unchanged dependencies again.