### PR TITLE
chore(ci): remove setup for aws-lc-fips-sys

### DIFF
--- a/.github/workflows/ci_check.yml
+++ b/.github/workflows/ci_check.yml
@@ -27,15 +27,6 @@ jobs:
         run: |
           rustup default nightly
           rustup component add clippy
-      - uses: actions/setup-go@v4
-        with:
-          go-version: '>=1.18'
-      - name: Install NASM on Windows
-        if: runner.os == 'Windows'
-        uses: ilammy/setup-nasm@v1
-      - name: Install ninja-build tool on Windows
-        if: runner.os == 'Windows'
-        uses: seanmiddleditch/gha-setup-ninja@v4
       - name: Check clippy
         shell: bash
         run: |

--- a/.github/workflows/ci_check_minimal.yml
+++ b/.github/workflows/ci_check_minimal.yml
@@ -28,15 +28,6 @@ jobs:
           rustup default nightly
           rustup component add clippy
       - uses: taiki-e/install-action@cargo-no-dev-deps
-      - uses: actions/setup-go@v4
-        with:
-          go-version: '>=1.18'
-      - name: Install NASM on Windows
-        if: runner.os == 'Windows'
-        uses: ilammy/setup-nasm@v1
-      - name: Install ninja-build tool on Windows
-        if: runner.os == 'Windows'
-        uses: seanmiddleditch/gha-setup-ninja@v4
       - name: Check clippy
         shell: bash
         run: |

--- a/.github/workflows/ci_check_minimal.yml
+++ b/.github/workflows/ci_check_minimal.yml
@@ -1,4 +1,4 @@
-name: Check
+name: Check (Minimal Versions)
 
 on:
   push:

--- a/flake.nix
+++ b/flake.nix
@@ -29,14 +29,11 @@
               glib
               openssl
               pkg-config
-              llvmPackages.clangUseLLVM
               (rust-bin.selectLatestNightlyWith (toolchain:
                 toolchain.default.override {
                   extensions = ["rust-src"];
                 }))
             ];
-
-            AWS_LC_FIPS_SYS_CC = "${llvmPackages.clangUseLLVM}/bin/cc";
           };
         }
     );


### PR DESCRIPTION
These were introduced in https://github.com/compio-rs/compio/pull/333 to support aws-lc-rs. Since aws-lc-rs was removed in https://github.com/compio-rs/compio/pull/521, they are now useless.