### PR TITLE
fix(ws): initialize `SyncStream` with 128 KB capacity to match tungstenite's default size.

### DIFF
--- a/compio-ws/src/lib.rs
+++ b/compio-ws/src/lib.rs
@@ -186,7 +186,7 @@ where
     S: AsyncRead + AsyncWrite,
     C: Callback,
 {
-    let sync_stream = SyncStream::new(stream);
+    let sync_stream = SyncStream::with_capacity(128 * 1024, stream);
     let mut handshake_result = tungstenite::accept_hdr_with_config(sync_stream, callback, config);
 
     loop {
@@ -250,7 +250,7 @@ where
     R: IntoClientRequest,
     S: AsyncRead + AsyncWrite,
 {
-    let sync_stream = SyncStream::new(stream);
+    let sync_stream = SyncStream::with_capacity(128 * 1024, stream);
     let mut handshake_result =
         tungstenite::client::client_with_config(request, sync_stream, config);
 


### PR DESCRIPTION
Increasing this to `128KB` made the benchmarks twice as fast as when the buffer size was `8KB` buffer size.

Documentation for tungstenite buffer size being 128KB: [here](https://docs.rs/tungstenite/latest/tungstenite/protocol/struct.WebSocketConfig.html#:~:text=For%20high%20read%20load%20scenarios%20a%20larger%20buffer%2C%20e.g.%20128%20KiB%2C%20improves%20performance.) 