### PR TITLE
feat(driver): make thread safety optional

### DIFF
--- a/compio-driver/src/iocp/mod.rs
+++ b/compio-driver/src/iocp/mod.rs
@@ -44,6 +44,17 @@ pub enum OwnedFd {
     Socket(OwnedSocket),
 }
 
+impl OwnedFd {
+    /// Creates a new [`OwnedFd`] instance that shares the same underlying
+    /// object as the existing [`OwnedFd`] instance.
+    pub fn try_clone(&self) -> io::Result<Self> {
+        match self {
+            Self::File(fd) => fd.try_clone().map(OwnedFd::File),
+            Self::Socket(s) => s.try_clone().map(OwnedFd::Socket),
+        }
+    }
+}
+
 impl AsRawFd for OwnedFd {
     fn as_raw_fd(&self) -> RawFd {
         match self {
@@ -150,6 +161,17 @@ pub enum BorrowedFd<'a> {
     File(BorrowedHandle<'a>),
     /// Windows socket handle.
     Socket(BorrowedSocket<'a>),
+}
+
+impl<'a> BorrowedFd<'a> {
+    /// Creates a new [`OwnedFd`] instance that shares the same underlying
+    /// object as the existing [`BorrowedFd`] instance.
+    pub fn try_clone_to_owned(&self) -> io::Result<OwnedFd> {
+        match self {
+            Self::File(fd) => fd.try_clone_to_owned().map(OwnedFd::File),
+            Self::Socket(s) => s.try_clone_to_owned().map(OwnedFd::Socket),
+        }
+    }
 }
 
 impl AsRawFd for BorrowedFd<'_> {

--- a/compio-fs/src/async_fd.rs
+++ b/compio-fs/src/async_fd.rs
@@ -44,6 +44,18 @@ impl<T: AsFd> AsyncFd<T> {
             inner: Attacher::new_unchecked(source),
         }
     }
+
+    /// Create [`AsyncFd`] from a shared file descriptor without attaching
+    /// the source.
+    ///
+    /// # Safety
+    ///
+    /// See [`AsyncFd::new_unchecked`].
+    pub unsafe fn from_shared_fd_unchecked(fd: SharedFd<T>) -> Self {
+        Self {
+            inner: Attacher::from_shared_fd_unchecked(fd),
+        }
+    }
 }
 
 impl<T: AsFd + 'static> AsyncRead for AsyncFd<T> {

--- a/compio-quic/src/incoming.rs
+++ b/compio-quic/src/incoming.rs
@@ -2,7 +2,7 @@ use std::{
     future::{Future, IntoFuture},
     net::{IpAddr, SocketAddr},
     pin::Pin,
-    sync::Arc,
+    rc::Rc,
     task::{Context, Poll},
 };
 
@@ -15,7 +15,7 @@ use crate::{Connecting, Connection, ConnectionError, EndpointInner};
 #[derive(Debug)]
 pub(crate) struct IncomingInner {
     pub(crate) incoming: quinn_proto::Incoming,
-    pub(crate) endpoint: Arc<EndpointInner>,
+    pub(crate) endpoint: Rc<EndpointInner>,
 }
 
 /// An incoming connection for which the server has not yet begun its part
@@ -24,7 +24,7 @@ pub(crate) struct IncomingInner {
 pub struct Incoming(Option<IncomingInner>);
 
 impl Incoming {
-    pub(crate) fn new(incoming: quinn_proto::Incoming, endpoint: Arc<EndpointInner>) -> Self {
+    pub(crate) fn new(incoming: quinn_proto::Incoming, endpoint: Rc<EndpointInner>) -> Self {
         Self(Some(IncomingInner { incoming, endpoint }))
     }
 

--- a/compio-quic/src/recv_stream.rs
+++ b/compio-quic/src/recv_stream.rs
@@ -1,7 +1,7 @@
 use std::{
     collections::BTreeMap,
     io,
-    sync::Arc,
+    rc::Rc,
     task::{Context, Poll},
 };
 
@@ -54,7 +54,7 @@ use crate::{ConnectionError, ConnectionInner, StoppedError};
 /// [`Connection::accept_bi`]: crate::Connection::accept_bi
 #[derive(Debug)]
 pub struct RecvStream {
-    conn: Arc<ConnectionInner>,
+    conn: Rc<ConnectionInner>,
     stream: StreamId,
     is_0rtt: bool,
     all_data_read: bool,
@@ -62,7 +62,7 @@ pub struct RecvStream {
 }
 
 impl RecvStream {
-    pub(crate) fn new(conn: Arc<ConnectionInner>, stream: StreamId, is_0rtt: bool) -> Self {
+    pub(crate) fn new(conn: Rc<ConnectionInner>, stream: StreamId, is_0rtt: bool) -> Self {
         Self {
             conn,
             stream,

--- a/compio-quic/src/send_stream.rs
+++ b/compio-quic/src/send_stream.rs
@@ -1,6 +1,6 @@
 use std::{
     io,
-    sync::Arc,
+    rc::Rc,
     task::{Context, Poll},
 };
 
@@ -31,13 +31,13 @@ use crate::{ConnectionError, ConnectionInner, StoppedError};
 /// [`finish()`]: SendStream::finish
 #[derive(Debug)]
 pub struct SendStream {
-    conn: Arc<ConnectionInner>,
+    conn: Rc<ConnectionInner>,
     stream: StreamId,
     is_0rtt: bool,
 }
 
 impl SendStream {
-    pub(crate) fn new(conn: Arc<ConnectionInner>, stream: StreamId, is_0rtt: bool) -> Self {
+    pub(crate) fn new(conn: Rc<ConnectionInner>, stream: StreamId, is_0rtt: bool) -> Self {
         Self {
             conn,
             stream,
@@ -396,7 +396,7 @@ pub(crate) mod h3_impl {
     }
 
     impl<B> SendStream<B> {
-        pub(crate) fn new(conn: Arc<ConnectionInner>, stream: StreamId, is_0rtt: bool) -> Self {
+        pub(crate) fn new(conn: Rc<ConnectionInner>, stream: StreamId, is_0rtt: bool) -> Self {
             Self {
                 inner: super::SendStream::new(conn, stream, is_0rtt),
                 buf: None,

--- a/compio-quic/src/socket.rs
+++ b/compio-quic/src/socket.rs
@@ -550,7 +550,7 @@ impl Clone for Socket {
             max_gso_segments: self.max_gso_segments,
             has_gso_error: AtomicBool::new(self.has_gso_error.load(Ordering::Relaxed)),
             #[cfg(freebsd)]
-            encode_src_ip_v4: self.encode_src_ip_v4.clone(),
+            encode_src_ip_v4: self.encode_src_ip_v4,
         }
     }
 }


### PR DESCRIPTION
This PR turns `Arc` to `Rc` in `SharedFd`. Some problems are still remain unsolved.

* How to send the fds to other threads? Here I introduce method `try_clone` here to dup the fd to a sync version.
  * Should `SyncFile`, `SyncTcpStream`, etc. also implement `Async*` traits?
* The types in `compio-quic` becomes single-threaded, and very complex to use them in a dispatcher.
  * Should we also add `try_clone` to the connections, endpoints, streams?
  * Or, should we use the `SyncUdpSocket` directly?

The benchmark shows about 10% performance improvement.