### PR TITLE
refactor(runtime): simplify `TimerRuntime`

### DIFF
--- a/compio-runtime/src/runtime/mod.rs
+++ b/compio-runtime/src/runtime/mod.rs
@@ -290,7 +290,7 @@ impl Runtime {
     pub(crate) fn poll_timer(&self, cx: &mut Context, key: &TimerKey) -> Poll<()> {
         instrument!(compio_log::Level::DEBUG, "poll_timer", ?cx, ?key);
         let mut timer_runtime = self.timer_runtime.borrow_mut();
-        if timer_runtime.remove_completed(key) {
+        if timer_runtime.is_completed(key) {
             debug!("ready");
             Poll::Ready(())
         } else {


### PR DESCRIPTION
## Background

I borrowed the implementation of compio's `TimerRuntime` in one of my projects. It has now been suggested that this implementation could be simplified (https://github.com/Starry-OS/arceos/pull/20). Since I wasn't sure, I moved his simplified implementation back to compio so that the original author could take a look at it to see if there were any problems.

Related commits:
- https://github.com/compio-rs/compio/commit/094d35d5db85926be814c02a7bf566784d0048e5