### PR TITLE
fix(fs): timeout read test

### DIFF
--- a/compio-buf/src/buf_result.rs
+++ b/compio-buf/src/buf_result.rs
@@ -14,6 +14,7 @@ use crate::IntoInner;
 /// completes, the buffer is returned no matter if the operation completed
 /// successfully.
 #[must_use]
+#[derive(Debug)]
 pub struct BufResult<T, B>(pub io::Result<T>, pub B);
 
 impl<T, B> BufResult<T, B> {

--- a/compio-driver/src/fusion/op.rs
+++ b/compio-driver/src/fusion/op.rs
@@ -28,7 +28,7 @@ macro_rules! op {
                             self.poll()
                         },
                         Self::Poll(op) => op,
-                        Self::IoUring(_) => unreachable!("Current driver is not `io-uring`"),
+                        Self::IoUring(_) => unreachable!("Current driver is not `polling`"),
                     }
                 }
 
@@ -44,7 +44,7 @@ macro_rules! op {
                             self.iour()
                         },
                         Self::IoUring(op) => op,
-                        Self::Poll(_) => unreachable!("Current driver is not `polling`"),
+                        Self::Poll(_) => unreachable!("Current driver is not `io-uring`"),
                     }
                 }
             }


### PR DESCRIPTION
`timeout_read` test failed randomly several times. This PR fixed it by replacing files with pipes.