### PR TITLE
feat: bump version for release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
     "compio-tls",
     "compio-ws",
 ]
-resolver = "2"
+resolver = "3"
 
 [workspace.package]
 edition = "2024"
@@ -26,25 +26,25 @@ license = "MIT"
 repository = "https://github.com/compio-rs/compio"
 
 [workspace.dependencies]
-compio-buf = { path = "./compio-buf", version = "0.7.0" }
-compio-driver = { path = "./compio-driver", version = "0.9.3", default-features = false }
-compio-runtime = { path = "./compio-runtime", version = "0.9.5" }
+compio-buf = { path = "./compio-buf", version = "0.7.1" }
+compio-driver = { path = "./compio-driver", version = "0.10.0", default-features = false }
+compio-runtime = { path = "./compio-runtime", version = "0.10.0" }
 compio-macros = { path = "./compio-macros", version = "0.1.2" }
-compio-fs = { path = "./compio-fs", version = "0.9.0" }
-compio-io = { path = "./compio-io", version = "0.8.3" }
-compio-net = { path = "./compio-net", version = "0.9.0" }
-compio-signal = { path = "./compio-signal", version = "0.7.0" }
-compio-dispatcher = { path = "./compio-dispatcher", version = "0.8.1" }
+compio-fs = { path = "./compio-fs", version = "0.10.0" }
+compio-io = { path = "./compio-io", version = "0.8.4" }
+compio-net = { path = "./compio-net", version = "0.10.0" }
+compio-signal = { path = "./compio-signal", version = "0.8.0" }
+compio-dispatcher = { path = "./compio-dispatcher", version = "0.9.0" }
 compio-log = { path = "./compio-log", version = "0.1.0" }
 compio-tls = { path = "./compio-tls", version = "0.8.0", default-features = false }
-compio-process = { path = "./compio-process", version = "0.6.0" }
+compio-process = { path = "./compio-process", version = "0.7.0" }
 compio-quic = { path = "./compio-quic", version = "0.6.0", default-features = false }
 compio-ws = { path = "./compio-ws", version = "0.2.0", default-features = false }
 
 bytes = "1.7.1"
 cfg_aliases = "0.2.1"
 cfg-if = "1.0.0"
-criterion = "0.7.0"
+criterion = "0.8.0"
 crossbeam-queue = "0.3.8"
 flume = { version = "0.11.0", default-features = false }
 futures-channel = "0.3.29"

--- a/compio-buf/Cargo.toml
+++ b/compio-buf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "compio-buf"
-version = "0.7.0"
+version = "0.7.1"
 description = "Buffer trait for completion based async IO"
 categories = ["asynchronous"]
 keywords = ["async"]

--- a/compio-dispatcher/Cargo.toml
+++ b/compio-dispatcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "compio-dispatcher"
-version = "0.8.1"
+version = "0.9.0"
 description = "Multithreading dispatcher for compio"
 categories = ["asynchronous"]
 keywords = ["async", "runtime"]

--- a/compio-driver/Cargo.toml
+++ b/compio-driver/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "compio-driver"
-version = "0.9.3"
+version = "0.10.0"
 description = "Low-level driver for compio"
 categories = ["asynchronous"]
 keywords = ["async", "iocp", "io-uring"]

--- a/compio-fs/Cargo.toml
+++ b/compio-fs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "compio-fs"
-version = "0.9.0"
+version = "0.10.0"
 description = "Filesystem IO for compio"
 categories = ["asynchronous", "filesystem"]
 keywords = ["async", "fs"]

--- a/compio-io/Cargo.toml
+++ b/compio-io/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "compio-io"
-version = "0.8.3"
+version = "0.8.4"
 description = "IO traits for completion based async IO"
 categories = ["asynchronous"]
 keywords = ["async", "io"]

--- a/compio-net/Cargo.toml
+++ b/compio-net/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "compio-net"
-version = "0.9.0"
+version = "0.10.0"
 description = "Networking IO for compio"
 categories = ["asynchronous", "network-programming"]
 keywords = ["async", "net"]

--- a/compio-process/Cargo.toml
+++ b/compio-process/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "compio-process"
-version = "0.6.0"
+version = "0.7.0"
 description = "Processes for compio"
 categories = ["asynchronous"]
 keywords = ["async", "process"]

--- a/compio-runtime/Cargo.toml
+++ b/compio-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "compio-runtime"
-version = "0.9.5"
+version = "0.10.0"
 description = "High-level runtime for compio"
 categories = ["asynchronous"]
 keywords = ["async", "runtime"]

--- a/compio-signal/Cargo.toml
+++ b/compio-signal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "compio-signal"
-version = "0.7.0"
+version = "0.8.0"
 description = "Signal handling for compio"
 categories = ["asynchronous"]
 keywords = ["async", "signal"]


### PR DESCRIPTION
Closes #531 

* Major bump for most crates. `compio-quic`, `compio-tls` and `compio-ws` have been bumped before.
* Minor bump for `compio-buf` and `compio-io` as it's only an edition update.
* No bump for `compio-log` and `compio-macros`.