### PR TITLE
feat(driver): stablize aliases of OpCode

### DIFF
--- a/compio-driver/src/sys/fusion/mod.rs
+++ b/compio-driver/src/sys/fusion/mod.rs
@@ -9,8 +9,8 @@ use std::{
 };
 
 use compio_log::warn;
-pub use iour::{Extra, OpCode as IourOpCode, OpEntry};
-pub use poll::{Decision, OpCode as PollOpCode, OpType};
+pub use iour::{Extra, IourOpCode, OpEntry};
+pub use poll::{Decision, OpType, PollOpCode};
 
 pub(crate) use super::iour::is_op_supported;
 use super::{iour, poll};

--- a/compio-driver/src/sys/iour/mod.rs
+++ b/compio-driver/src/sys/iour/mod.rs
@@ -130,6 +130,8 @@ pub trait OpCode {
     unsafe fn set_result(self: Pin<&mut Self>, _: usize) {}
 }
 
+pub use OpCode as IourOpCode;
+
 /// Low-level driver of io-uring.
 pub(crate) struct Driver {
     inner: IoUring<SEntry, CEntry>,

--- a/compio-driver/src/sys/poll/mod.rs
+++ b/compio-driver/src/sys/poll/mod.rs
@@ -54,6 +54,8 @@ pub trait OpCode {
     fn operate(self: Pin<&mut Self>) -> Poll<io::Result<usize>>;
 }
 
+pub use OpCode as PollOpCode;
+
 /// Result of [`OpCode::pre_submit`].
 #[non_exhaustive]
 pub enum Decision {


### PR DESCRIPTION
This PR helps users of `compio-driver` to derive their own OpCode. They don't need to check the features with complex `cfg`s anymore. Just impl `PollOpCode` and `IourOpCode` instead, and guard the impls with their own features.