### PR TITLE
fix(net,quic): init with uninit data for CMsgBuilder

### DIFF
--- a/compio-net/src/cmsg/mod.rs
+++ b/compio-net/src/cmsg/mod.rs
@@ -1,4 +1,4 @@
-use std::marker::PhantomData;
+use std::{marker::PhantomData, mem::MaybeUninit};
 
 cfg_if::cfg_if! {
     if #[cfg(windows)] {
@@ -93,10 +93,11 @@ impl<'a> CMsgBuilder<'a> {
     ///
     /// This function will panic if the buffer is too short or not properly
     /// aligned.
-    pub fn new(buffer: &'a mut [u8]) -> Self {
-        buffer.fill(0);
+    pub fn new(buffer: &'a mut [MaybeUninit<u8>]) -> Self {
+        // TODO: optimize zeroing
+        buffer.fill(MaybeUninit::new(0));
         Self {
-            inner: sys::CMsgIter::new(buffer.as_ptr(), buffer.len()),
+            inner: sys::CMsgIter::new(buffer.as_ptr().cast(), buffer.len()),
             len: 0,
             _p: PhantomData,
         }

--- a/compio-net/tests/cmsg.rs
+++ b/compio-net/tests/cmsg.rs
@@ -1,11 +1,13 @@
+use std::mem::MaybeUninit;
+
 use aligned_array::{A8, Aligned};
-use compio_buf::IoBuf;
+use compio_buf::{IoBuf, IoBufMut};
 use compio_net::{CMsgBuilder, CMsgIter};
 
 #[test]
 fn test_cmsg() {
     let mut buf: Aligned<A8, [u8; 64]> = Aligned([0u8; 64]);
-    let mut builder = CMsgBuilder::new(buf.as_mut_slice());
+    let mut builder = CMsgBuilder::new(buf.as_uninit());
 
     builder.try_push(0, 0, ()).unwrap(); // 16 / 12
     builder.try_push(1, 1, u32::MAX).unwrap(); // 16 + 4 + 4 / 12 + 4
@@ -36,13 +38,13 @@ fn test_cmsg() {
 #[test]
 #[should_panic]
 fn invalid_buffer_length() {
-    let mut buf = [0u8; 1];
+    let mut buf = [MaybeUninit::new(0u8); 1];
     CMsgBuilder::new(&mut buf);
 }
 
 #[test]
 #[should_panic]
 fn invalid_buffer_alignment() {
-    let mut buf = [0u8; 64];
+    let mut buf = [MaybeUninit::new(0u8); 64];
     CMsgBuilder::new(&mut buf[1..]);
 }

--- a/compio-quic/src/socket.rs
+++ b/compio-quic/src/socket.rs
@@ -68,7 +68,7 @@ impl<const N: usize> Ancillary<N> {
     fn new() -> Self {
         Self {
             inner: [0u8; N],
-            len: N,
+            len: 0,
             _align: [],
         }
     }
@@ -84,16 +84,6 @@ impl<const N: usize> SetLen for Ancillary<N> {
     unsafe fn set_len(&mut self, len: usize) {
         debug_assert!(len <= N);
         self.len = len;
-    }
-
-    // FIXME(George-Miao, AsakuraMizu): this is not the desired behavior, only
-    // served as a workaround for now.
-    // See: https://github.com/compio-rs/compio/issues/580
-    unsafe fn advance_to(&mut self, len: usize)
-    where
-        Self: IoBuf,
-    {
-        unsafe { self.set_len(len) };
     }
 }
 
@@ -423,7 +413,7 @@ impl Socket {
         let ecn = transmit.ecn.map_or(0, |x| x as u8);
 
         let mut control = Ancillary::<CMSG_LEN>::new();
-        let mut builder = CMsgBuilder::new(&mut control);
+        let mut builder = CMsgBuilder::new(control.as_uninit());
 
         // ECN
         if is_ipv4 {


### PR DESCRIPTION
Closes #580 