### PR TITLE
feat(driver,unix): add splice

### DIFF
--- a/compio-driver/build.rs
+++ b/compio-driver/build.rs
@@ -15,6 +15,7 @@ fn main() {
         solarish: { any(target_os = "illumos", target_os = "solaris") },
         aio: { any(freebsd, solarish) },
         io_uring: { all(target_os = "linux", feature = "io-uring") },
-        fusion: { all(target_os = "linux", feature = "io-uring", feature = "polling") }
+        fusion: { all(target_os = "linux", feature = "io-uring", feature = "polling") },
+        linux_all: { any(target_os = "linux", target_os = "android") },
     }
 }

--- a/compio-driver/src/op.rs
+++ b/compio-driver/src/op.rs
@@ -10,6 +10,8 @@ use compio_buf::{BufResult, IntoInner, IoBuf, IoBufMut, IoVectoredBuf, SetLen};
 use pin_project_lite::pin_project;
 use socket2::{SockAddr, SockAddrStorage, socklen_t};
 
+#[cfg(linux_all)]
+pub use crate::sys::op::Splice;
 pub use crate::sys::op::{
     Accept, Recv, RecvFrom, RecvFromVectored, RecvMsg, RecvVectored, Send, SendMsg, SendTo,
     SendToVectored, SendVectored,

--- a/compio-driver/src/sys/iour/op.rs
+++ b/compio-driver/src/sys/iour/op.rs
@@ -725,6 +725,22 @@ impl<S: AsFd> OpCode for PollOnce<S> {
     }
 }
 
+#[cfg(linux_all)]
+impl<S1: AsFd, S2: AsFd> OpCode for Splice<S1, S2> {
+    fn create_entry(self: Pin<&mut Self>) -> OpEntry {
+        opcode::Splice::new(
+            Fd(self.fd_in.as_fd().as_raw_fd()),
+            self.offset_in,
+            Fd(self.fd_out.as_fd().as_raw_fd()),
+            self.offset_out,
+            self.len,
+        )
+        .flags(self.flags)
+        .build()
+        .into()
+    }
+}
+
 mod buf_ring {
     use std::{
         io,

--- a/compio-driver/src/sys/poll/op.rs
+++ b/compio-driver/src/sys/poll/op.rs
@@ -1203,3 +1203,33 @@ impl<S: AsFd> OpCode for PollOnce<S> {
         Poll::Ready(Ok(0))
     }
 }
+
+#[cfg(linux_all)]
+impl<S1: AsFd, S2: AsFd> OpCode for Splice<S1, S2> {
+    fn pre_submit(self: Pin<&mut Self>) -> io::Result<Decision> {
+        Ok(Decision::Blocking)
+    }
+
+    fn operate(self: Pin<&mut Self>) -> Poll<io::Result<usize>> {
+        let mut offset_in = self.offset_in;
+        let mut offset_out = self.offset_out;
+        let offset_in_ptr = if offset_in < 0 {
+            std::ptr::null_mut()
+        } else {
+            &mut offset_in
+        };
+        let offset_out_ptr = if offset_out < 0 {
+            std::ptr::null_mut()
+        } else {
+            &mut offset_out
+        };
+        Poll::Ready(Ok(syscall!(libc::splice(
+            self.fd_in.as_fd().as_raw_fd(),
+            offset_in_ptr,
+            self.fd_out.as_fd().as_raw_fd(),
+            offset_out_ptr,
+            self.len as _,
+            self.flags as _,
+        ))? as _))
+    }
+}

--- a/compio-driver/src/sys/unix_op.rs
+++ b/compio-driver/src/sys/unix_op.rs
@@ -641,3 +641,39 @@ impl<S> PollOnce<S> {
         Self { fd, interest }
     }
 }
+
+/// Splice data between two file descriptors.
+#[cfg(linux_all)]
+pub struct Splice<S1, S2> {
+    pub(crate) fd_in: S1,
+    pub(crate) offset_in: i64,
+    pub(crate) fd_out: S2,
+    pub(crate) offset_out: i64,
+    pub(crate) len: u32,
+    pub(crate) flags: u32,
+}
+
+#[cfg(linux_all)]
+impl<S1, S2> Splice<S1, S2> {
+    /// Create [`Splice`].
+    ///
+    /// `offset_in` and `offset_out` specify the offset to read from and write
+    /// to. Use `-1` for pipe ends or to use/update the current file
+    /// position.
+    pub fn new(fd_in: S1, offset_in: i64, fd_out: S2, offset_out: i64, len: u32) -> Self {
+        Self {
+            fd_in,
+            offset_in,
+            fd_out,
+            offset_out,
+            len,
+            flags: 0,
+        }
+    }
+
+    /// Set splice flags.
+    pub fn flags(mut self, flags: u32) -> Self {
+        self.flags = flags;
+        self
+    }
+}

--- a/compio-fs/build.rs
+++ b/compio-fs/build.rs
@@ -9,5 +9,6 @@ fn main() {
         ) },
         solarish: { any(target_os = "illumos", target_os = "solaris") },
         gnulinux: { all(target_os = "linux", target_env = "gnu") },
+        linux_all: { any(target_os = "linux", target_os = "android") },
     }
 }

--- a/compio-fs/src/pipe.rs
+++ b/compio-fs/src/pipe.rs
@@ -6,8 +6,12 @@ use std::{
     os::fd::{FromRawFd, IntoRawFd},
     path::Path,
 };
+#[cfg(linux_all)]
+use std::{future::IntoFuture, os::fd::AsFd, pin::Pin};
 
 use compio_buf::{BufResult, IntoInner, IoBuf, IoBufMut, IoVectoredBuf, IoVectoredBufMut};
+#[cfg(linux_all)]
+use compio_driver::op::Splice;
 use compio_driver::{
     AsRawFd, ToSharedFd, impl_raw_fd,
     op::{
@@ -540,6 +544,88 @@ impl AsyncReadManaged for &Receiver {
 }
 
 impl_raw_fd!(Receiver, std::fs::File, file, file);
+
+/// Splice data between two file descriptors without copying through userspace.
+///
+/// At least one of `fd_in` or `fd_out` must be a pipe. Returns a builder that
+/// can be configured with optional offsets and flags before awaiting.
+///
+/// # Example
+/// ```ignore
+/// let n = splice(&file, &pipe_tx, 1024).await?;
+///
+/// let n = splice(&file, &pipe_tx, 1024)
+///     .offset_in(0)
+///     .flags(libc::SPLICE_F_MOVE)
+///     .await?;
+/// ```
+#[cfg(linux_all)]
+pub fn splice<TIn: AsFd + 'static, TOut: AsFd + 'static>(
+    fd_in: &impl ToSharedFd<TIn>,
+    fd_out: &impl ToSharedFd<TOut>,
+    len: u32,
+) -> SpliceBuilder<TIn, TOut> {
+    SpliceBuilder {
+        fd_in: fd_in.to_shared_fd(),
+        fd_out: fd_out.to_shared_fd(),
+        len,
+        offset_in: -1,
+        offset_out: -1,
+        flags: 0,
+    }
+}
+
+/// Builder for splice operations.
+#[cfg(linux_all)]
+pub struct SpliceBuilder<TIn, TOut> {
+    fd_in: compio_driver::SharedFd<TIn>,
+    fd_out: compio_driver::SharedFd<TOut>,
+    len: u32,
+    offset_in: i64,
+    offset_out: i64,
+    flags: u32,
+}
+
+#[cfg(linux_all)]
+impl<TIn, TOut> SpliceBuilder<TIn, TOut> {
+    /// Set the offset to read from.
+    pub fn offset_in(mut self, offset: i64) -> Self {
+        self.offset_in = offset;
+        self
+    }
+
+    /// Set the offset to write to.
+    pub fn offset_out(mut self, offset: i64) -> Self {
+        self.offset_out = offset;
+        self
+    }
+
+    /// Set splice flags.
+    pub fn flags(mut self, flags: u32) -> Self {
+        self.flags = flags;
+        self
+    }
+}
+
+#[cfg(linux_all)]
+impl<TIn: AsFd + 'static, TOut: AsFd + 'static> IntoFuture for SpliceBuilder<TIn, TOut> {
+    type IntoFuture = Pin<Box<dyn Future<Output = Self::Output>>>;
+    type Output = io::Result<usize>;
+
+    fn into_future(self) -> Self::IntoFuture {
+        Box::pin(async move {
+            let op = Splice::new(
+                self.fd_in,
+                self.offset_in,
+                self.fd_out,
+                self.offset_out,
+                self.len,
+            )
+            .flags(self.flags);
+            compio_runtime::submit(op).await.0
+        })
+    }
+}
 
 /// Checks if file is a FIFO
 async fn is_fifo(file: &File) -> io::Result<bool> {


### PR DESCRIPTION
### Usage (file -> socket example)

```rs
use compio_fs::pipe::{anonymous, splice};
use compio_fs::File;

let file = File::open("data.bin").await?;
let (rx, tx) = anonymous()?;

// Splice file -> pipe (zero-copy)
let n = splice(&file, &tx, 4096).offset_in(0).await?;

// Then splice pipe -> socket (zero-copy)
let n = splice(&rx, &socket, 4096).await?;
```