### PR TITLE
ci(illumos): update action version

### DIFF
--- a/.github/workflows/ci_test_illumos.yml
+++ b/.github/workflows/ci_test_illumos.yml
@@ -30,8 +30,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Test in Illumos
         id: test
-        # FIXME: v1.1.6 is buggy
-        uses: vmactions/omnios-vm@v1.1.5
+        uses: vmactions/omnios-vm@v1
         with:
           usesh: true
           sync: rsync


### PR DESCRIPTION
Update vmactions/omnios-vm to v1.2.0.

They say the issue has been fixed; let's see.

This is basically a revert of #591.