### PR TITLE
feat(driver): ensure that all supported statx fields are filled

### DIFF
--- a/compio-driver/src/sys/iour/op.rs
+++ b/compio-driver/src/sys/iour/op.rs
@@ -123,6 +123,7 @@ impl<S: AsFd> OpCode for FileStat<S> {
             this.stat as *mut _ as _,
         )
         .flags(libc::AT_EMPTY_PATH)
+        .mask(statx_mask())
         .build()
         .into()
     }
@@ -166,6 +167,7 @@ impl OpCode for PathStat {
             std::ptr::addr_of_mut!(self.stat).cast(),
         )
         .flags(flags)
+        .mask(statx_mask())
         .build()
         .into()
     }

--- a/compio-driver/src/sys/poll/op.rs
+++ b/compio-driver/src/sys/poll/op.rs
@@ -135,7 +135,7 @@ impl<S: AsFd> OpCode for FileStat<S> {
                 this.fd.as_fd().as_raw_fd(),
                 EMPTY_NAME.as_ptr().cast(),
                 libc::AT_EMPTY_PATH,
-                0,
+                statx_mask(),
                 &mut s
             ))?;
             *this.stat = statx_to_stat(s);
@@ -193,7 +193,7 @@ impl OpCode for PathStat {
                 libc::AT_FDCWD,
                 self.path.as_ptr(),
                 flags,
-                0,
+                statx_mask(),
                 &mut s
             ))?;
             self.stat = statx_to_stat(s);

--- a/compio-driver/src/sys/unix_op.rs
+++ b/compio-driver/src/sys/unix_op.rs
@@ -108,6 +108,25 @@ pub(crate) struct Statx {
 }
 
 #[cfg(target_os = "linux")]
+pub(crate) const fn statx_mask() -> u32 {
+    // Set mask to ensure all known fields are filled
+    libc::STATX_TYPE
+        | libc::STATX_MODE
+        | libc::STATX_NLINK
+        | libc::STATX_UID
+        | libc::STATX_GID
+        | libc::STATX_ATIME
+        | libc::STATX_MTIME
+        | libc::STATX_CTIME
+        | libc::STATX_INO
+        | libc::STATX_SIZE
+        | libc::STATX_BLOCKS
+        | libc::STATX_BTIME
+        | libc::STATX_MNT_ID
+        | libc::STATX_DIOALIGN
+}
+
+#[cfg(target_os = "linux")]
 pub(crate) const fn statx_to_stat(statx: Statx) -> Stat {
     let mut stat: Stat = unsafe { std::mem::zeroed() };
     stat.st_dev = libc::makedev(statx.stx_dev_major, statx.stx_dev_minor) as _;


### PR DESCRIPTION
Before this change, mtime is 0 in statx because the statx mask does not get set. This sets the mask so all fields are filled in that are currently part of the `statx` struct.