### PR TITLE
feat(driver): use nix instead of rustix

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,7 +70,6 @@ widestring = "1.0.2"
 windows-sys = "0.61.0"
 thiserror = "2.0.3"
 smallvec = "1.13.2"
-rustix = "1.0.0"
 
 [profile.bench]
 debug = true

--- a/compio-driver/Cargo.toml
+++ b/compio-driver/Cargo.toml
@@ -55,7 +55,7 @@ paste = { workspace = true }
 slab = { workspace = true, optional = true }
 
 [target.'cfg(any(target_os = "linux", target_os = "android"))'.dev-dependencies]
-rustix = { workspace = true, features = ["pipe"] }
+nix = { workspace = true, features = ["fs"] }
 
 # Other platform dependencies
 [target.'cfg(all(not(target_os = "linux"), unix))'.dependencies]

--- a/compio-driver/tests/splice.rs
+++ b/compio-driver/tests/splice.rs
@@ -5,7 +5,7 @@ use compio_driver::{
     AsRawFd, OpCode, Proactor, PushEntry, SharedFd,
     op::{Read, Splice, Write},
 };
-use rustix::pipe::{PipeFlags, pipe_with};
+use nix::{fcntl::OFlag, unistd::pipe2};
 
 fn push_and_wait<O: OpCode + 'static>(driver: &mut Proactor, op: O) -> BufResult<usize, O> {
     match driver.push(op) {
@@ -24,13 +24,13 @@ fn push_and_wait<O: OpCode + 'static>(driver: &mut Proactor, op: O) -> BufResult
 fn splice() {
     let mut driver = Proactor::new().unwrap();
 
-    let mut flags = PipeFlags::CLOEXEC;
+    let mut flags = OFlag::O_CLOEXEC;
     if driver.driver_type().is_polling() {
-        flags |= PipeFlags::NONBLOCK;
+        flags |= OFlag::O_NONBLOCK;
     }
 
-    let (rx, tx) = pipe_with(flags).unwrap();
-    let (rx1, tx1) = pipe_with(flags).unwrap();
+    let (rx, tx) = pipe2(flags).unwrap();
+    let (rx1, tx1) = pipe2(flags).unwrap();
     println!(
         "rx={}, tx={}, rx1={}, tx1={}",
         rx.as_raw_fd(),


### PR DESCRIPTION
It seems that nix provides broader APIs than rustix.