### PR TITLE
docs: `compio::runtime` instead of `compio_runtime`

### DIFF
--- a/compio-fs/src/lib.rs
+++ b/compio-fs/src/lib.rs
@@ -37,7 +37,7 @@ pub mod named_pipe;
 pub mod pipe;
 
 /// Providing functionalities to wait for readiness.
-#[deprecated(since = "0.12.0", note = "Use `compio_runtime::fd::AsyncFd` instead")]
+#[deprecated(since = "0.12.0", note = "Use `compio::runtime::fd::AsyncFd` instead")]
 pub type AsyncFd<T> = compio_runtime::fd::AsyncFd<T>;
 
 #[cfg(unix)]

--- a/compio-net/src/lib.rs
+++ b/compio-net/src/lib.rs
@@ -24,7 +24,7 @@ mod unix;
 
 pub use cmsg::*;
 /// Providing functionalities to wait for readiness.
-#[deprecated(since = "0.12.0", note = "Use `compio_runtime::fd::PollFd` instead")]
+#[deprecated(since = "0.12.0", note = "Use `compio::runtime::fd::PollFd` instead")]
 pub type PollFd<T> = compio_runtime::fd::PollFd<T>;
 pub use opts::SocketOpts;
 pub use resolve::ToSocketAddrsAsync;


### PR DESCRIPTION
Small fix
