### PR TITLE
docs: fix deprecation note

### DIFF
--- a/compio-runtime/src/runtime/mod.rs
+++ b/compio-runtime/src/runtime/mod.rs
@@ -546,7 +546,7 @@ pub fn submit<T: OpCode + 'static>(op: T) -> Submit<T> {
 ///
 /// This method doesn't create runtime. It tries to obtain the current runtime
 /// by [`Runtime::with_current`].
-#[deprecated(since = "0.8.0", note = "use `submit(op).with_extra()` instead")]
+#[deprecated(since = "0.11.0", note = "use `submit(op).with_extra()` instead")]
 pub fn submit_with_extra<T: OpCode + 'static>(op: T) -> Submit<T, Extra> {
     Runtime::with_current(|r| r.submit(op).with_extra())
 }


### PR DESCRIPTION
I somehow wrote 0.8.0. I guess I was trying to say 0.18.0 but that's not correct neither 🤣