### PR TITLE
fix(tls): example.com tls misconfigured

### DIFF
--- a/compio-quic/README.md
+++ b/compio-quic/README.md
@@ -44,7 +44,7 @@ Example:
 use compio::quic::{Endpoint, ClientConfig};
 
 let mut endpoint = Endpoint::client("0.0.0.0:0".parse()?)?;
-let connection = endpoint.connect("example.com:443", "example.com").await?;
+let connection = endpoint.connect("compio.rs:443", "compio.rs").await?;
 
 // Use the QUIC connection
 let (mut send, mut recv) = connection.open_bi().await?;

--- a/compio-tls/tests/connect.rs
+++ b/compio-tls/tests/connect.rs
@@ -3,11 +3,11 @@ use compio_net::TcpStream;
 use compio_tls::TlsConnector;
 
 async fn connect(connector: TlsConnector) {
-    let stream = TcpStream::connect("www.example.com:443").await.unwrap();
-    let mut stream = connector.connect("www.example.com", stream).await.unwrap();
+    let stream = TcpStream::connect("compio.rs:443").await.unwrap();
+    let mut stream = connector.connect("compio.rs", stream).await.unwrap();
 
     stream
-        .write_all("GET / HTTP/1.1\r\nHost:www.example.com\r\nConnection: close\r\n\r\n")
+        .write_all("GET / HTTP/1.1\r\nHost:compio.rs\r\nConnection: close\r\n\r\n")
         .await
         .unwrap();
     stream.flush().await.unwrap();

--- a/compio-ws/README.md
+++ b/compio-ws/README.md
@@ -46,7 +46,7 @@ Example:
 ```rust
 use compio::ws::connect_async;
 
-let (mut ws_stream, _) = connect_async("wss://example.com/socket").await?;
+let (mut ws_stream, _) = connect_async("wss://echo.websocket.org").await?;
 
 // Send and receive messages
 ws_stream.send(Message::text("Hello WebSocket!")).await?;


### PR DESCRIPTION
example.com has a TLS misconfiguration causing certificate verification to fail in rustls and OpenSSL:

```bash
> openssl s_client -connect www.example.com:443
# ...
New, TLSv1.3, Cipher is TLS_AES_256_GCM_SHA384
Protocol: TLSv1.3
Server public key is 256 bit
This TLS version forbids renegotiation.
Compression: NONE
Expansion: NONE
No ALPN negotiated
Early data was not sent
Verify return code: 26 (unsuitable certificate purpose)
# ...
``` 