### PR TITLE
feat(driver,iocp): impl AsFd for borrowed handle

### DIFF
--- a/compio-driver/src/sys/iocp/mod.rs
+++ b/compio-driver/src/sys/iocp/mod.rs
@@ -228,6 +228,12 @@ impl AsFd for OwnedHandle {
     }
 }
 
+impl AsFd for BorrowedHandle<'_> {
+    fn as_fd(&self) -> BorrowedFd<'_> {
+        (*self).into()
+    }
+}
+
 impl AsFd for socket2::Socket {
     fn as_fd(&self) -> BorrowedFd<'_> {
         self.as_socket().into()
@@ -237,6 +243,12 @@ impl AsFd for socket2::Socket {
 impl AsFd for OwnedSocket {
     fn as_fd(&self) -> BorrowedFd<'_> {
         self.as_socket().into()
+    }
+}
+
+impl AsFd for BorrowedSocket<'_> {
+    fn as_fd(&self) -> BorrowedFd<'_> {
+        (*self).into()
     }
 }
 


### PR DESCRIPTION
Used in https://github.com/compio-rs/compio-py/pull/9/changes#diff-f5a20b394a5ba72e0e625bac291ac8e2fa04a59b2801dae39b277499d14729fdR337-R350 where the socket/fd is not owned.