### PR TITLE
feat(driver): add register_files/unregister_files for fixed-file ops

### DIFF
--- a/compio-driver/src/lib.rs
+++ b/compio-driver/src/lib.rs
@@ -290,6 +290,54 @@ impl Proactor {
         unsafe { self.driver.release_buffer_pool(buffer_pool) }
     }
 
+    /// Register file descriptors for fixed-file operations with io_uring.
+    ///
+    /// This only works on `io_uring` driver. It will return an [`Unsupported`]
+    /// error on other drivers.
+    ///
+    /// [`Unsupported`]: std::io::ErrorKind::Unsupported
+    pub fn register_files(&self, fds: &[RawFd]) -> io::Result<()> {
+        fn unsupported(_: &[RawFd]) -> io::Error {
+            io::Error::new(
+                io::ErrorKind::Unsupported,
+                "Fixed-file registration is only supported on io-uring driver",
+            )
+        }
+
+        #[cfg(io_uring)]
+        match self.driver.as_iour() {
+            Some(iour) => iour.register_files(fds),
+            None => Err(unsupported(fds)),
+        }
+
+        #[cfg(not(io_uring))]
+        Err(unsupported(fds))
+    }
+
+    /// Unregister previously registered file descriptors.
+    ///
+    /// This only works on `io_uring` driver. It will return an [`Unsupported`]
+    /// error on other drivers.
+    ///
+    /// [`Unsupported`]: std::io::ErrorKind::Unsupported
+    pub fn unregister_files(&self) -> io::Result<()> {
+        fn unsupported() -> io::Error {
+            io::Error::new(
+                io::ErrorKind::Unsupported,
+                "Fixed-file unregistration is only supported on io-uring driver",
+            )
+        }
+
+        #[cfg(io_uring)]
+        match self.driver.as_iour() {
+            Some(iour) => iour.unregister_files(),
+            None => Err(unsupported()),
+        }
+
+        #[cfg(not(io_uring))]
+        Err(unsupported())
+    }
+
     /// Register a new personality in io-uring driver.
     ///
     /// Returns the personality id, which can be used with

--- a/compio-driver/src/sys/iour/mod.rs
+++ b/compio-driver/src/sys/iour/mod.rs
@@ -216,6 +216,16 @@ impl Driver {
         Some(self)
     }
 
+    pub fn register_files(&self, fds: &[RawFd]) -> io::Result<()> {
+        self.inner.submitter().register_files(fds)?;
+        Ok(())
+    }
+
+    pub fn unregister_files(&self) -> io::Result<()> {
+        self.inner.submitter().unregister_files()?;
+        Ok(())
+    }
+
     pub fn register_personality(&self) -> io::Result<u16> {
         self.inner.submitter().register_personality()
     }

--- a/compio-runtime/src/runtime/mod.rs
+++ b/compio-runtime/src/runtime/mod.rs
@@ -404,6 +404,26 @@ impl Runtime {
         self.id
     }
 
+    /// Register file descriptors for fixed-file operations.
+    ///
+    /// This is only supported on io-uring driver, and will return an
+    /// [`Unsupported`] io error on all other drivers.
+    ///
+    /// [`Unsupported`]: std::io::ErrorKind::Unsupported
+    pub fn register_files(&self, fds: &[RawFd]) -> io::Result<()> {
+        self.driver.borrow_mut().register_files(fds)
+    }
+
+    /// Unregister previously registered file descriptors.
+    ///
+    /// This is only supported on io-uring driver, and will return an
+    /// [`Unsupported`] io error on all other drivers.
+    ///
+    /// [`Unsupported`]: std::io::ErrorKind::Unsupported
+    pub fn unregister_files(&self) -> io::Result<()> {
+        self.driver.borrow_mut().unregister_files()
+    }
+
     /// Register the personality for the runtime.
     ///
     /// This is only supported on io-uring driver, and will return an
@@ -591,6 +611,38 @@ pub fn submit<T: OpCode + 'static>(op: T) -> Submit<T> {
 #[deprecated(since = "0.11.0", note = "use `submit(op).with_extra()` instead")]
 pub fn submit_with_extra<T: OpCode + 'static>(op: T) -> Submit<T, Extra> {
     Runtime::with_current(|r| r.submit(op).with_extra())
+}
+
+/// Register file descriptors for fixed-file operations with the current
+/// runtime's io_uring instance.
+///
+/// This only works on `io_uring` driver. It will return an [`Unsupported`]
+/// error on other drivers.
+///
+/// ## Panics
+///
+/// This method doesn't create runtime. It tries to obtain the current runtime
+/// by [`Runtime::with_current`].
+///
+/// [`Unsupported`]: std::io::ErrorKind::Unsupported
+pub fn register_files(fds: &[RawFd]) -> io::Result<()> {
+    Runtime::with_current(|r| r.register_files(fds))
+}
+
+/// Unregister previously registered file descriptors from the current
+/// runtime's io_uring instance.
+///
+/// This only works on `io_uring` driver. It will return an [`Unsupported`]
+/// error on other drivers.
+///
+/// ## Panics
+///
+/// This method doesn't create runtime. It tries to obtain the current runtime
+/// by [`Runtime::with_current`].
+///
+/// [`Unsupported`]: std::io::ErrorKind::Unsupported
+pub fn unregister_files() -> io::Result<()> {
+    Runtime::with_current(|r| r.unregister_files())
 }
 
 #[cfg(feature = "time")]


### PR DESCRIPTION
## Summary

- Add `register_files` / `unregister_files` support for io_uring fixed-file operations
- Follows the same pattern as the existing `register_personality` / `unregister_personality` API
- Exposed at all three levels: Driver, Proactor, and Runtime (+ free functions)

## Motivation

FUSE over io_uring requires registering file descriptors with the ring before using `Fixed(index)` in submission queue entries. Currently there is no way to do this through compio's public API, requiring users to maintain a fork.

## Changes

- `compio-driver/src/sys/iour/mod.rs`: Direct `submitter().register_files()` / `unregister_files()` calls
- `compio-driver/src/lib.rs` (`Proactor`): Platform-gated public API with `Unsupported` fallback on non-io_uring drivers
- `compio-runtime/src/runtime/mod.rs` (`Runtime`): Runtime-level methods + convenience free functions `register_files()` / `unregister_files()`