### PR TITLE
feat(driver): make Proactor Send again

### DIFF
--- a/compio-driver/Cargo.toml
+++ b/compio-driver/Cargo.toml
@@ -89,6 +89,7 @@ iocp-global = []
 iocp-wait-packet = []
 
 # Nightly features
+current_thread_id = []
 once_cell_try = []
 proc_macro_diagnostic = ["dep:compile_warning"]
-nightly = ["once_cell_try", "proc_macro_diagnostic"]
+nightly = ["current_thread_id", "once_cell_try", "proc_macro_diagnostic"]

--- a/compio-driver/src/cancel.rs
+++ b/compio-driver/src/cancel.rs
@@ -1,10 +1,6 @@
-use std::collections::HashSet;
+use std::{collections::HashSet, mem::ManuallyDrop};
 
-use crate::{Key, OpCode, key::ErasedKey};
-
-pub(crate) struct CancelRegistry {
-    cancellers: HashSet<ErasedKey>,
-}
+use crate::{Key, OpCode, key::ErasedKey, thread_map::ThreadMap};
 
 /// A type-erased cancel token.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -18,10 +14,14 @@ impl Cancel {
     }
 }
 
-impl CancelRegistry {
+struct CancelRegistryInner {
+    cancellers: ManuallyDrop<HashSet<ErasedKey>>,
+}
+
+impl CancelRegistryInner {
     pub fn new() -> Self {
         Self {
-            cancellers: HashSet::new(),
+            cancellers: ManuallyDrop::new(HashSet::new()),
         }
     }
 
@@ -40,5 +40,56 @@ impl CancelRegistry {
 
     pub fn remove(&mut self, key: &ErasedKey) -> bool {
         self.cancellers.remove(key)
+    }
+
+    pub fn clear(&mut self) {
+        self.cancellers.clear();
+    }
+}
+
+impl Drop for CancelRegistryInner {
+    fn drop(&mut self) {
+        if self.cancellers.is_empty() {
+            // SAFETY: No keys remain.
+            unsafe { ManuallyDrop::drop(&mut self.cancellers) }
+        }
+    }
+}
+
+pub(crate) struct CancelRegistry {
+    inner: ThreadMap<CancelRegistryInner>,
+}
+
+// SAFETY: `CancelRegistryInner` is only accessed and dropped on the thread it
+// was created on.
+unsafe impl Send for CancelRegistry {}
+
+impl CancelRegistry {
+    pub fn new() -> Self {
+        Self {
+            inner: ThreadMap::new(CancelRegistryInner::new),
+        }
+    }
+
+    pub fn register<T>(&mut self, key: &Key<T>) -> Cancel {
+        self.inner.get_mut().register(key)
+    }
+
+    pub fn take(&mut self, token: Cancel) -> Option<ErasedKey> {
+        self.inner.get_mut().take(token)
+    }
+
+    pub fn remove(&mut self, key: &ErasedKey) -> bool {
+        self.inner.get_mut().remove(key)
+    }
+
+    pub fn clear(&mut self) {
+        self.inner.get_mut().clear();
+    }
+}
+
+impl Drop for CancelRegistry {
+    fn drop(&mut self) {
+        self.clear();
     }
 }

--- a/compio-driver/src/lib.rs
+++ b/compio-driver/src/lib.rs
@@ -3,6 +3,7 @@
 //! Some types differ by compilation target.
 
 #![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(feature = "current_thread_id", feature(current_thread_id))]
 #![cfg_attr(feature = "once_cell_try", feature(once_cell_try))]
 #![warn(missing_docs)]
 #![deny(rustdoc::broken_intra_doc_links)]
@@ -46,6 +47,8 @@ pub use sys::*;
 
 mod cancel;
 pub use cancel::*;
+
+mod thread_map;
 
 use crate::{key::ErasedKey, op::OpCodeFlag};
 
@@ -185,6 +188,15 @@ impl Proactor {
     /// where you're not sure if the operation will be cancelled.
     pub fn register_cancel<T: OpCode>(&mut self, key: &Key<T>) -> Cancel {
         self.cancel.register(key)
+    }
+
+    /// Register all cancel tokens in the current thread.
+    ///
+    /// [`Proactor`] is [`Send`], while the cancel tokens are thread-local, so
+    /// this is useful when you move the proactor to another thread but want to
+    /// avoid memory leaks.
+    pub fn unregister_cancel(&mut self) {
+        self.cancel.clear();
     }
 
     /// Push an operation into the driver, and return the unique key [`Key`],
@@ -663,4 +675,13 @@ impl ProactorBuilder {
     pub fn build(&self) -> io::Result<Proactor> {
         Proactor::with_builder(self)
     }
+}
+
+#[cfg(test)]
+mod test {
+    const fn assert_send_sync<T: Send>() {}
+
+    const _: () = {
+        assert_send_sync::<super::Proactor>();
+    };
 }

--- a/compio-driver/src/lib.rs
+++ b/compio-driver/src/lib.rs
@@ -679,9 +679,9 @@ impl ProactorBuilder {
 
 #[cfg(test)]
 mod test {
-    const fn assert_send_sync<T: Send>() {}
+    const fn assert_send<T: Send>() {}
 
     const _: () = {
-        assert_send_sync::<super::Proactor>();
+        assert_send::<super::Proactor>();
     };
 }

--- a/compio-driver/src/sys/iocp/wait/thread_pool.rs
+++ b/compio-driver/src/sys/iocp/wait/thread_pool.rs
@@ -89,3 +89,7 @@ struct WinThreadpoolWaitContext {
     notify: Arc<Notify>,
     optr: *mut Overlapped,
 }
+
+// SAFETY: `optr` is used as a thread-safe key.
+unsafe impl Send for WinThreadpoolWaitContext {}
+unsafe impl Sync for WinThreadpoolWaitContext {}

--- a/compio-driver/src/thread_map.rs
+++ b/compio-driver/src/thread_map.rs
@@ -1,0 +1,70 @@
+// Copyright (c) 2024-2025 Paulo Villela
+// Copyright (c) 2026 compio-rs
+//
+// MIT License
+
+#[cfg(feature = "current_thread_id")]
+use std::thread::current_id;
+use std::{cell::UnsafeCell, collections::HashMap, fmt::Debug, thread::ThreadId};
+
+// FIXME: the code is the same as the one in `compio-runtime`.
+#[cfg(not(feature = "current_thread_id"))]
+mod imp {
+    use std::{
+        cell::Cell,
+        thread::{self, ThreadId},
+    };
+    thread_local! {
+        static THREAD_ID: Cell<ThreadId> = Cell::new(thread::current().id());
+    }
+
+    pub fn current_id() -> ThreadId {
+        THREAD_ID.get()
+    }
+}
+
+#[cfg(not(feature = "current_thread_id"))]
+use imp::current_id;
+
+/// Wrapper to enable cell to be used as value in `HashMap`.
+struct UnsafeSyncCell<V>(UnsafeCell<V>);
+
+/// SAFETY:
+/// An instance is only accessed by [`ThreadMap`] through mutable references.
+unsafe impl<V> Sync for UnsafeSyncCell<V> {}
+
+impl<V: Debug> Debug for UnsafeSyncCell<V> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_fmt(format_args!("{:?}", unsafe { &*self.0.get() }))
+    }
+}
+
+#[derive(Debug)]
+pub struct ThreadMap<V> {
+    state: HashMap<ThreadId, UnsafeSyncCell<V>>,
+    value_init: fn() -> V,
+}
+
+impl<V> ThreadMap<V> {
+    pub fn new(value_init: fn() -> V) -> Self {
+        Self {
+            state: HashMap::new(),
+            value_init,
+        }
+    }
+
+    pub fn get_mut(&mut self) -> &mut V {
+        let tid = current_id();
+        self.state
+            .entry(tid)
+            .or_insert_with(|| UnsafeSyncCell(UnsafeCell::new((self.value_init)())))
+            .0
+            .get_mut()
+    }
+}
+
+impl<V: Default> Default for ThreadMap<V> {
+    fn default() -> Self {
+        Self::new(V::default)
+    }
+}

--- a/compio-runtime/Cargo.toml
+++ b/compio-runtime/Cargo.toml
@@ -59,7 +59,7 @@ async-fd = ["dep:compio-io"]
 notify-always = []
 
 future-combinator = []
-current_thread_id = []
+current_thread_id = ["compio-driver/current_thread_id"]
 nightly = ["current_thread_id", "future-combinator"]
 
 [[test]]

--- a/compio/Cargo.toml
+++ b/compio/Cargo.toml
@@ -118,7 +118,10 @@ enable_log = ["compio-log/enable_log"]
 
 # Nightly features
 allocator_api = ["compio-buf/allocator_api", "compio-io?/allocator_api"]
-current_thread_id = ["compio-runtime?/current_thread_id"]
+current_thread_id = [
+    "compio-driver/current_thread_id",
+    "compio-runtime?/current_thread_id",
+]
 lazy_cell = ["compio-signal?/lazy_cell"]
 linux_pidfd = ["compio-process?/linux_pidfd"]
 once_cell_try = [


### PR DESCRIPTION
Closes #723 

This is a thread-local solution. The registry only drops the `HashMap` created on current thread.

The code of `ThreadMap` is copied from the crate `thread_map`, but the `RwLock` has been removed.