### PR TITLE
build: add python to flake

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -34,6 +34,7 @@
             openssl
             pkg-config
             cargo-nextest
+            python315
             (rust-bin.selectLatestNightlyWith (
               toolchain:
               toolchain.default.override {


### PR DESCRIPTION
pyo3 requires python interpreter to build
