### PR TITLE
fix(driver): rust-analyzer is confused by Extra

### DIFF
--- a/compio-driver/src/lib.rs
+++ b/compio-driver/src/lib.rs
@@ -43,7 +43,7 @@ mod buffer_pool;
 pub use buffer_pool::*;
 
 mod sys;
-pub use sys::*;
+pub use sys::{Extra, *};
 
 mod cancel;
 pub use cancel::*;
@@ -122,7 +122,7 @@ impl Proactor {
 
     /// Get a default [`Extra`] for underlying driver.
     pub fn default_extra(&self) -> Extra {
-        self.driver.default_extra().into()
+        sys::default_extra(&self.driver)
     }
 
     /// The current driver type.

--- a/compio-driver/src/sys/extra.rs
+++ b/compio-driver/src/sys/extra.rs
@@ -21,7 +21,7 @@ impl<I: Into<imp::Extra>> From<I> for Extra {
 }
 
 impl Extra {
-    pub(super) fn new(inner: imp::Extra) -> Self {
+    pub(in crate::sys) fn new(inner: imp::Extra) -> Self {
         Self(inner)
     }
 

--- a/compio-driver/src/sys/fusion/extra.rs
+++ b/compio-driver/src/sys/fusion/extra.rs
@@ -1,0 +1,57 @@
+use super::*;
+
+pub(in crate::sys) enum Extra {
+    Poll(poll::Extra),
+    IoUring(iour::Extra),
+}
+
+impl From<poll::Extra> for Extra {
+    fn from(inner: poll::Extra) -> Self {
+        Self::Poll(inner)
+    }
+}
+
+impl From<iour::Extra> for Extra {
+    fn from(inner: iour::Extra) -> Self {
+        Self::IoUring(inner)
+    }
+}
+
+#[allow(dead_code)]
+impl crate::sys::Extra {
+    pub(crate) fn is_iour(&self) -> bool {
+        matches!(self.0, Extra::IoUring(_))
+    }
+
+    pub(in crate::sys) fn try_as_iour(&self) -> Option<&iour::Extra> {
+        if let Extra::IoUring(extra) = &self.0 {
+            Some(extra)
+        } else {
+            None
+        }
+    }
+
+    pub(in crate::sys) fn try_as_iour_mut(&mut self) -> Option<&mut iour::Extra> {
+        if let Extra::IoUring(extra) = &mut self.0 {
+            Some(extra)
+        } else {
+            None
+        }
+    }
+
+    pub(in crate::sys) fn try_as_poll(&self) -> Option<&poll::Extra> {
+        if let Extra::Poll(extra) = &self.0 {
+            Some(extra)
+        } else {
+            None
+        }
+    }
+
+    pub(in crate::sys) fn try_as_poll_mut(&mut self) -> Option<&mut poll::Extra> {
+        if let Extra::Poll(extra) = &mut self.0 {
+            Some(extra)
+        } else {
+            None
+        }
+    }
+}

--- a/compio-driver/src/sys/fusion/mod.rs
+++ b/compio-driver/src/sys/fusion/mod.rs
@@ -18,61 +18,8 @@ use super::{iour, poll};
 pub use crate::driver_type::DriverType; // Re-export so current user won't be broken
 use crate::{BufferPool, ProactorBuilder, key::ErasedKey};
 
-pub enum Extra {
-    Poll(poll::Extra),
-    IoUring(iour::Extra),
-}
-
-impl From<poll::Extra> for Extra {
-    fn from(inner: poll::Extra) -> Self {
-        Self::Poll(inner)
-    }
-}
-
-impl From<iour::Extra> for Extra {
-    fn from(inner: iour::Extra) -> Self {
-        Self::IoUring(inner)
-    }
-}
-
-#[allow(dead_code)]
-impl super::Extra {
-    pub(crate) fn is_iour(&self) -> bool {
-        matches!(self.0, Extra::IoUring(_))
-    }
-
-    pub(in crate::sys) fn try_as_iour(&self) -> Option<&iour::Extra> {
-        if let Extra::IoUring(extra) = &self.0 {
-            Some(extra)
-        } else {
-            None
-        }
-    }
-
-    pub(in crate::sys) fn try_as_iour_mut(&mut self) -> Option<&mut iour::Extra> {
-        if let Extra::IoUring(extra) = &mut self.0 {
-            Some(extra)
-        } else {
-            None
-        }
-    }
-
-    pub(in crate::sys) fn try_as_poll(&self) -> Option<&poll::Extra> {
-        if let Extra::Poll(extra) = &self.0 {
-            Some(extra)
-        } else {
-            None
-        }
-    }
-
-    pub(in crate::sys) fn try_as_poll_mut(&mut self) -> Option<&mut poll::Extra> {
-        if let Extra::Poll(extra) = &mut self.0 {
-            Some(extra)
-        } else {
-            None
-        }
-    }
-}
+mod extra;
+pub(in crate::sys) use extra::Extra;
 
 /// Fused [`OpCode`]
 ///
@@ -136,7 +83,7 @@ impl Driver {
         }
     }
 
-    pub fn default_extra(&self) -> Extra {
+    pub(in crate::sys) fn default_extra(&self) -> Extra {
         match &self.fuse {
             FuseDriver::Poll(driver) => Extra::Poll(driver.default_extra()),
             FuseDriver::IoUring(driver) => Extra::IoUring(driver.default_extra()),

--- a/compio-driver/src/sys/iocp/mod.rs
+++ b/compio-driver/src/sys/iocp/mod.rs
@@ -28,7 +28,7 @@ mod wait;
 
 /// Extra data attached for IOCP.
 #[repr(C)]
-pub struct Extra {
+pub(in crate::sys) struct Extra {
     overlapped: Overlapped,
 }
 
@@ -358,7 +358,7 @@ impl Driver {
         &self.notify.port
     }
 
-    pub fn default_extra(&self) -> Extra {
+    pub(in crate::sys) fn default_extra(&self) -> Extra {
         Extra::new(self.port().as_raw_handle() as _)
     }
 

--- a/compio-driver/src/sys/iour/extra.rs
+++ b/compio-driver/src/sys/iour/extra.rs
@@ -1,26 +1,26 @@
 /// Extra data for RawOp.
-pub struct Extra {
+pub(in crate::sys) struct Extra {
     flags: u32,
     personality: Option<u16>,
 }
 
 impl Extra {
-    pub(crate) fn new() -> Self {
+    pub fn new() -> Self {
         Self {
             flags: 0,
             personality: None,
         }
     }
 
-    pub(crate) fn set_personality(&mut self, personality: u16) {
+    pub fn set_personality(&mut self, personality: u16) {
         self.personality = Some(personality);
     }
 
-    pub(crate) fn get_personality(&self) -> Option<u16> {
+    pub fn get_personality(&self) -> Option<u16> {
         self.personality
     }
 
-    pub(crate) fn buffer_id(&self) -> Option<u16> {
+    pub fn buffer_id(&self) -> Option<u16> {
         io_uring::cqueue::buffer_select(self.flags)
     }
 }

--- a/compio-driver/src/sys/iour/mod.rs
+++ b/compio-driver/src/sys/iour/mod.rs
@@ -43,7 +43,7 @@ use crate::{
 };
 
 mod extra;
-pub use extra::Extra;
+pub(in crate::sys) use extra::Extra;
 pub(crate) mod op;
 pub(crate) use op::take_buffer;
 
@@ -318,7 +318,7 @@ impl Driver {
         has_entry
     }
 
-    pub fn default_extra(&self) -> Extra {
+    pub(in crate::sys) fn default_extra(&self) -> Extra {
         Extra::new()
     }
 

--- a/compio-driver/src/sys/mod.rs
+++ b/compio-driver/src/sys/mod.rs
@@ -28,6 +28,10 @@ mod extra;
 pub use extra::Extra;
 pub use imp::*;
 
+pub(crate) fn default_extra(driver: &Driver) -> Extra {
+    driver.default_extra().into()
+}
+
 #[cfg(aio)]
 pub(crate) mod aio {
     pub use libc::aiocb;

--- a/compio-driver/src/sys/poll/extra.rs
+++ b/compio-driver/src/sys/poll/extra.rs
@@ -1,7 +1,7 @@
 use super::*;
 
 /// Extra data for RawOp.
-pub struct Extra {
+pub(in crate::sys) struct Extra {
     pub(super) track: Multi<Track>,
 }
 
@@ -12,19 +12,19 @@ impl Extra {
         }
     }
 
-    pub(crate) fn next_fd(&self) -> Option<RawFd> {
+    pub fn next_fd(&self) -> Option<RawFd> {
         self.track.iter().find(|t| !t.ready).map(|t| t.arg.fd)
     }
 
-    pub(super) fn reset(&mut self) {
+    pub fn reset(&mut self) {
         self.track.iter_mut().for_each(|t| t.ready = false);
     }
 
-    pub(super) fn set_args(&mut self, args: Multi<WaitArg>) {
+    pub fn set_args(&mut self, args: Multi<WaitArg>) {
         self.track = args.into_iter().map(Into::into).collect();
     }
 
-    pub(super) fn handle_event(&mut self, fd: RawFd) -> bool {
+    pub fn handle_event(&mut self, fd: RawFd) -> bool {
         self.track.iter_mut().fold(true, |curr, t| {
             if t.arg.fd == fd {
                 t.ready = true;
@@ -37,7 +37,7 @@ impl Extra {
 #[allow(dead_code)]
 #[cfg(not(fusion))]
 impl crate::sys::Extra {
-    pub(crate) fn is_iour(&self) -> bool {
+    pub(in crate::sys) fn is_iour(&self) -> bool {
         false
     }
 

--- a/compio-driver/src/sys/poll/mod.rs
+++ b/compio-driver/src/sys/poll/mod.rs
@@ -27,7 +27,7 @@ use crate::{
 };
 
 mod extra;
-pub use extra::Extra;
+pub(in crate::sys) use extra::Extra;
 pub(crate) mod op;
 
 struct Track {
@@ -319,7 +319,7 @@ impl Driver {
         DriverType::Poll
     }
 
-    pub fn default_extra(&self) -> Extra {
+    pub(in crate::sys) fn default_extra(&self) -> Extra {
         Extra::new()
     }
 

--- a/compio-driver/src/sys/stub/mod.rs
+++ b/compio-driver/src/sys/stub/mod.rs
@@ -24,7 +24,7 @@ use compio_buf::BufResult;
 
 use crate::{BufferPool, DriverType, ErasedKey, ProactorBuilder};
 
-pub struct Extra {}
+pub(in crate::sys) struct Extra {}
 
 impl Extra {
     pub fn new() -> Self {
@@ -63,7 +63,7 @@ impl Driver {
 
     pub fn cancel(&mut self, _: ErasedKey) {}
 
-    pub fn default_extra(&self) -> Extra {
+    pub(in crate::sys) fn default_extra(&self) -> Extra {
         Extra::new()
     }
 


### PR DESCRIPTION
Rust analyzer is confused by `sys::extra::Extra` and each driver's own `Extra` though rustc is fine with it. This PR hides driver's own extra within `sys` and only expose wrapped one.