### PR TITLE
refactor(driver)!: make update_waker take `&Key`

### DIFF
--- a/compio-driver/src/lib.rs
+++ b/compio-driver/src/lib.rs
@@ -271,7 +271,7 @@ impl Proactor {
     }
 
     /// Update the waker of the specified op.
-    pub fn update_waker<T>(&mut self, op: &mut Key<T>, waker: &Waker) {
+    pub fn update_waker<T>(&mut self, op: &Key<T>, waker: &Waker) {
         op.set_waker(waker);
     }
 

--- a/compio-runtime/src/runtime/mod.rs
+++ b/compio-runtime/src/runtime/mod.rs
@@ -308,8 +308,8 @@ impl Runtime {
     ) -> PushEntry<Key<T>, BufResult<usize, T>> {
         instrument!(compio_log::Level::DEBUG, "poll_task", ?key);
         let mut driver = self.driver.borrow_mut();
-        driver.pop(key).map_pending(|mut k| {
-            driver.update_waker(&mut k, waker);
+        driver.pop(key).map_pending(|k| {
+            driver.update_waker(&k, waker);
             k
         })
     }
@@ -321,8 +321,8 @@ impl Runtime {
     ) -> PushEntry<Key<T>, (BufResult<usize, T>, Extra)> {
         instrument!(compio_log::Level::DEBUG, "poll_task_with_extra", ?key);
         let mut driver = self.driver.borrow_mut();
-        driver.pop_with_extra(key).map_pending(|mut k| {
-            driver.update_waker(&mut k, waker);
+        driver.pop_with_extra(key).map_pending(|k| {
+            driver.update_waker(&k, waker);
             k
         })
     }
@@ -336,7 +336,7 @@ impl Runtime {
             Poll::Ready(())
         } else {
             debug!("pending");
-            timer_runtime.update_waker(key, cx.waker().clone());
+            timer_runtime.update_waker(key, cx.waker());
             Poll::Pending
         }
     }

--- a/compio-runtime/src/runtime/time.rs
+++ b/compio-runtime/src/runtime/time.rs
@@ -53,9 +53,11 @@ impl TimerRuntime {
     }
 
     /// Update the waker for a timer.
-    pub fn update_waker(&mut self, key: &TimerKey, waker: Waker) {
-        if let Some(w) = self.wheel.get_mut(key) {
-            *w = waker;
+    pub fn update_waker(&mut self, key: &TimerKey, waker: &Waker) {
+        if let Some(w) = self.wheel.get_mut(key)
+            && !waker.will_wake(w)
+        {
+            *w = waker.clone();
         }
     }
 


### PR DESCRIPTION
`update_waker` doesn't need `&mut Key`. In fact, `&mut Key` is useless no matter where.