### PR TITLE
refactor(driver)!: require IntoInner for opcodes

### DIFF
--- a/compio-driver/src/lib.rs
+++ b/compio-driver/src/lib.rs
@@ -20,7 +20,7 @@ use std::{
     time::Duration,
 };
 
-use compio_buf::BufResult;
+use compio_buf::{BufResult, IntoInner};
 use compio_log::instrument;
 
 mod macros;
@@ -147,14 +147,17 @@ impl Proactor {
     ///
     /// The cancellation is not reliable. The underlying operation may continue,
     /// but just don't return from [`Proactor::poll`].
-    pub fn cancel<T: OpCode>(&mut self, key: Key<T>) -> Option<BufResult<usize, T>> {
+    pub fn cancel<T: OpCode + IntoInner>(
+        &mut self,
+        key: Key<T>,
+    ) -> Option<BufResult<usize, T::Inner>> {
         instrument!(compio_log::Level::DEBUG, "cancel", ?key);
         if key.set_cancelled() {
             return None;
         }
         self.cancel.remove(&key);
         if key.is_unique() && key.has_result() {
-            Some(key.take_result())
+            Some(key.take_result().into_inner())
         } else {
             self.driver.cancel(key.erase());
             None
@@ -193,26 +196,26 @@ impl Proactor {
 
     /// Push an operation into the driver, and return the unique key [`Key`],
     /// associated with it.
-    pub fn push<T: sys::OpCode + 'static>(
+    pub fn push<T: sys::OpCode + IntoInner + 'static>(
         &mut self,
         op: T,
-    ) -> PushEntry<Key<T>, BufResult<usize, T>> {
+    ) -> PushEntry<Key<T>, BufResult<usize, T::Inner>> {
         self.push_with_extra(op, self.default_extra())
     }
 
     /// Push an operation into the driver with user-defined [`Extra`], and
     /// return the unique key [`Key`], associated with it.
-    pub fn push_with_extra<T: sys::OpCode + 'static>(
+    pub fn push_with_extra<T: sys::OpCode + IntoInner + 'static>(
         &mut self,
         op: T,
         extra: Extra,
-    ) -> PushEntry<Key<T>, BufResult<usize, T>> {
+    ) -> PushEntry<Key<T>, BufResult<usize, T::Inner>> {
         let key = Key::new(op, extra);
         match self.driver.push(key.clone().erase()) {
             Poll::Pending => PushEntry::Pending(key),
             Poll::Ready(res) => {
                 key.set_result(res);
-                PushEntry::Ready(key.take_result())
+                PushEntry::Ready(key.take_result().into_inner())
             }
         }
     }
@@ -229,12 +232,15 @@ impl Proactor {
     /// # Panics
     ///
     /// This function will panic if the [`Key`] is not unique.
-    pub fn pop<T>(&mut self, key: Key<T>) -> PushEntry<Key<T>, BufResult<usize, T>> {
+    pub fn pop<T: IntoInner>(
+        &mut self,
+        key: Key<T>,
+    ) -> PushEntry<Key<T>, BufResult<usize, T::Inner>> {
         instrument!(compio_log::Level::DEBUG, "pop", ?key);
         if key.has_result() {
             self.cancel.remove(&key);
             self.driver.cleanup_multishot(&key);
-            PushEntry::Ready(key.take_result())
+            PushEntry::Ready(key.take_result().into_inner())
         } else {
             PushEntry::Pending(key)
         }
@@ -246,16 +252,17 @@ impl Proactor {
     /// # Panics
     ///
     /// This function will panic if the [`Key`] is not unique.
-    pub fn pop_with_extra<T>(
+    #[allow(clippy::type_complexity)]
+    pub fn pop_with_extra<T: IntoInner>(
         &mut self,
         key: Key<T>,
-    ) -> PushEntry<Key<T>, (BufResult<usize, T>, Extra)> {
+    ) -> PushEntry<Key<T>, (BufResult<usize, T::Inner>, Extra)> {
         instrument!(compio_log::Level::DEBUG, "pop", ?key);
         if key.has_result() {
             self.cancel.remove(&key);
             self.driver.cleanup_multishot(&key);
             let extra = key.swap_extra(self.default_extra());
-            let res = key.take_result();
+            let res = key.take_result().into_inner();
             PushEntry::Ready((res, extra))
         } else {
             PushEntry::Pending(key)

--- a/compio-driver/src/op.rs
+++ b/compio-driver/src/op.rs
@@ -301,6 +301,12 @@ impl CloseFile {
     }
 }
 
+impl IntoInner for CloseFile {
+    type Inner = ();
+
+    fn into_inner(self) -> Self::Inner {}
+}
+
 pin_project! {
     /// Read a file at specified position into specified buffer.
     #[derive(Debug)]
@@ -446,6 +452,12 @@ impl<S> Sync<S> {
     }
 }
 
+impl<S> IntoInner for Sync<S> {
+    type Inner = ();
+
+    fn into_inner(self) -> Self::Inner {}
+}
+
 /// Shutdown a socket.
 pub struct ShutdownSocket<S> {
     pub(crate) fd: S,
@@ -457,6 +469,12 @@ impl<S> ShutdownSocket<S> {
     pub fn new(fd: S, how: Shutdown) -> Self {
         Self { fd, how }
     }
+}
+
+impl<S> IntoInner for ShutdownSocket<S> {
+    type Inner = ();
+
+    fn into_inner(self) -> Self::Inner {}
 }
 
 /// Close socket fd.
@@ -471,6 +489,12 @@ impl CloseSocket {
             fd: ManuallyDrop::new(fd),
         }
     }
+}
+
+impl IntoInner for CloseSocket {
+    type Inner = ();
+
+    fn into_inner(self) -> Self::Inner {}
 }
 
 /// Connect to a remote address.
@@ -492,24 +516,35 @@ pub(crate) mod managed {
 
     use compio_buf::IntoInner;
     use pin_project_lite::pin_project;
-    use socket2::SockAddr;
+    use socket2::{SockAddr, SockAddrStorage, socklen_t};
 
     use super::{Read, ReadAt, Recv, RecvFrom};
     use crate::{AsFd, BorrowedBuffer, BufferPool, OwnedBuffer, TakeBuffer};
 
-    fn take_buffer(
-        slice: OwnedBuffer,
-        buffer_pool: &BufferPool,
-        result: io::Result<usize>,
-    ) -> io::Result<BorrowedBuffer<'_>> {
-        let result = result?;
-        #[cfg(fusion)]
-        let buffer_pool = buffer_pool.as_poll();
-        // SAFETY: result is valid
-        let res = unsafe { buffer_pool.create_proxy(slice, result) };
-        #[cfg(fusion)]
-        let res = BorrowedBuffer::new_poll(res);
-        Ok(res)
+    /// The result of [`ReadManaged`], [`ReadManagedAt`], and [`RecvManaged`].
+    pub struct ReadManagedResult {
+        inner: OwnedBuffer,
+    }
+
+    impl TakeBuffer for ReadManagedResult {
+        type Buffer<'a> = BorrowedBuffer<'a>;
+        type BufferPool = BufferPool;
+
+        fn take_buffer(
+            self,
+            buffer_pool: &BufferPool,
+            result: io::Result<usize>,
+            _: u16,
+        ) -> io::Result<BorrowedBuffer<'_>> {
+            let result = result?;
+            #[cfg(fusion)]
+            let buffer_pool = buffer_pool.as_poll();
+            // SAFETY: result is valid
+            let res = unsafe { buffer_pool.create_proxy(self.inner, result) };
+            #[cfg(fusion)]
+            let res = BorrowedBuffer::new_poll(res);
+            Ok(res)
+        }
     }
 
     pin_project! {
@@ -531,17 +566,13 @@ pub(crate) mod managed {
         }
     }
 
-    impl<S> TakeBuffer for ReadManagedAt<S> {
-        type Buffer<'a> = BorrowedBuffer<'a>;
-        type BufferPool = BufferPool;
+    impl<S> IntoInner for ReadManagedAt<S> {
+        type Inner = ReadManagedResult;
 
-        fn take_buffer(
-            self,
-            buffer_pool: &BufferPool,
-            result: io::Result<usize>,
-            _: u16,
-        ) -> io::Result<BorrowedBuffer<'_>> {
-            take_buffer(self.op.into_inner(), buffer_pool, result)
+        fn into_inner(self) -> Self::Inner {
+            ReadManagedResult {
+                inner: self.op.into_inner(),
+            }
         }
     }
 
@@ -564,17 +595,13 @@ pub(crate) mod managed {
         }
     }
 
-    impl<S> TakeBuffer for ReadManaged<S> {
-        type Buffer<'a> = BorrowedBuffer<'a>;
-        type BufferPool = BufferPool;
+    impl<S> IntoInner for ReadManaged<S> {
+        type Inner = ReadManagedResult;
 
-        fn take_buffer(
-            self,
-            buffer_pool: &Self::BufferPool,
-            result: io::Result<usize>,
-            _: u16,
-        ) -> io::Result<Self::Buffer<'_>> {
-            take_buffer(self.op.into_inner(), buffer_pool, result)
+        fn into_inner(self) -> Self::Inner {
+            ReadManagedResult {
+                inner: self.op.into_inner(),
+            }
         }
     }
 
@@ -600,17 +627,13 @@ pub(crate) mod managed {
         }
     }
 
-    impl<S> TakeBuffer for RecvManaged<S> {
-        type Buffer<'a> = BorrowedBuffer<'a>;
-        type BufferPool = BufferPool;
+    impl<S> IntoInner for RecvManaged<S> {
+        type Inner = ReadManagedResult;
 
-        fn take_buffer(
-            self,
-            buffer_pool: &Self::BufferPool,
-            result: io::Result<usize>,
-            _: u16,
-        ) -> io::Result<Self::Buffer<'_>> {
-            take_buffer(self.op.into_inner(), buffer_pool, result)
+        fn into_inner(self) -> Self::Inner {
+            ReadManagedResult {
+                inner: self.op.into_inner(),
+            }
         }
     }
 
@@ -633,7 +656,27 @@ pub(crate) mod managed {
         }
     }
 
-    impl<S: AsFd> TakeBuffer for RecvFromManaged<S> {
+    impl<S: AsFd> IntoInner for RecvFromManaged<S> {
+        type Inner = RecvFromManagedResult;
+
+        fn into_inner(self) -> Self::Inner {
+            let (inner, addr_buffer, addr_size) = self.op.into_inner();
+            RecvFromManagedResult {
+                inner,
+                addr_buffer,
+                addr_size,
+            }
+        }
+    }
+
+    /// The result of [`RecvFromManaged`].
+    pub struct RecvFromManagedResult {
+        inner: OwnedBuffer,
+        addr_buffer: SockAddrStorage,
+        addr_size: socklen_t,
+    }
+
+    impl TakeBuffer for RecvFromManagedResult {
         type Buffer<'a> = (BorrowedBuffer<'a>, Option<SockAddr>);
         type BufferPool = BufferPool;
 
@@ -646,10 +689,10 @@ pub(crate) mod managed {
             let result = result?;
             #[cfg(fusion)]
             let buffer_pool = buffer_pool.as_poll();
-            let (slice, addr_buffer, addr_size) = self.op.into_inner();
-            let addr = (addr_size > 0).then(|| unsafe { SockAddr::new(addr_buffer, addr_size) });
+            let addr = (self.addr_size > 0)
+                .then(|| unsafe { SockAddr::new(self.addr_buffer, self.addr_size) });
             // SAFETY: result is valid
-            let res = unsafe { buffer_pool.create_proxy(slice, result) };
+            let res = unsafe { buffer_pool.create_proxy(self.inner, result) };
             #[cfg(fusion)]
             let res = BorrowedBuffer::new_poll(res);
             Ok((res, addr))

--- a/compio-driver/src/sys/unix_op.rs
+++ b/compio-driver/src/sys/unix_op.rs
@@ -81,10 +81,10 @@ impl<S: AsFd> OpenFile<S> {
 }
 
 impl<S: AsFd> IntoInner for OpenFile<S> {
-    type Inner = OwnedFd;
+    type Inner = Option<OwnedFd>;
 
     fn into_inner(self) -> Self::Inner {
-        self.opened_fd.expect("file not opened")
+        self.opened_fd
     }
 }
 
@@ -115,6 +115,12 @@ impl<S: AsFd> TruncateFile<S> {
             .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e))?;
         crate::syscall!(ftruncate64(self.fd.as_fd().as_raw_fd(), size)).map(|v| v as _)
     }
+}
+
+impl<S: AsFd> IntoInner for TruncateFile<S> {
+    type Inner = ();
+
+    fn into_inner(self) -> Self::Inner {}
 }
 
 #[cfg(not(gnulinux))]
@@ -367,6 +373,12 @@ impl<S: AsFd> Unlink<S> {
     }
 }
 
+impl<S: AsFd> IntoInner for Unlink<S> {
+    type Inner = ();
+
+    fn into_inner(self) -> Self::Inner {}
+}
+
 /// Create a directory.
 pub struct CreateDir<S: AsFd> {
     pub(crate) dirfd: S,
@@ -387,6 +399,12 @@ impl<S: AsFd> CreateDir<S> {
             self.mode
         ))? as _)
     }
+}
+
+impl<S: AsFd> IntoInner for CreateDir<S> {
+    type Inner = ();
+
+    fn into_inner(self) -> Self::Inner {}
 }
 
 /// Rename a file or directory.
@@ -418,6 +436,12 @@ impl<S1: AsFd, S2: AsFd> Rename<S1, S2> {
     }
 }
 
+impl<S1: AsFd, S2: AsFd> IntoInner for Rename<S1, S2> {
+    type Inner = ();
+
+    fn into_inner(self) -> Self::Inner {}
+}
+
 /// Create a symlink.
 pub struct Symlink<S: AsFd> {
     pub(crate) source: CString,
@@ -442,6 +466,12 @@ impl<S: AsFd> Symlink<S> {
             self.target.as_ptr()
         ))? as _)
     }
+}
+
+impl<S: AsFd> IntoInner for Symlink<S> {
+    type Inner = ();
+
+    fn into_inner(self) -> Self::Inner {}
 }
 
 /// Create a hard link.
@@ -474,6 +504,12 @@ impl<S1: AsFd, S2: AsFd> HardLink<S1, S2> {
     }
 }
 
+impl<S1: AsFd, S2: AsFd> IntoInner for HardLink<S1, S2> {
+    type Inner = ();
+
+    fn into_inner(self) -> Self::Inner {}
+}
+
 pin_project! {
     /// Create a socket.
     pub struct CreateSocket {
@@ -497,10 +533,10 @@ impl CreateSocket {
 }
 
 impl IntoInner for CreateSocket {
-    type Inner = Socket2;
+    type Inner = Option<Socket2>;
 
     fn into_inner(self) -> Self::Inner {
-        self.opened_fd.expect("socket not created")
+        self.opened_fd
     }
 }
 
@@ -550,9 +586,27 @@ impl<S> Accept<S> {
     }
 
     /// Get the remote address from the inner buffer.
-    pub fn into_addr(mut self) -> (Socket2, SockAddr) {
-        let socket = self.accepted_fd.take().expect("socket not accepted");
-        (socket, unsafe { SockAddr::new(self.buffer, self.addr_len) })
+    fn into_addr(mut self) -> Option<(Socket2, SockAddr)> {
+        let socket = self.accepted_fd.take()?;
+        Some((socket, unsafe { SockAddr::new(self.buffer, self.addr_len) }))
+    }
+}
+
+impl<S> IntoInner for Accept<S> {
+    type Inner = Option<(Socket2, SockAddr)>;
+
+    fn into_inner(self) -> Self::Inner {
+        self.into_addr()
+    }
+}
+
+pub struct ConnectResult(());
+
+impl<S> IntoInner for Connect<S> {
+    type Inner = ConnectResult;
+
+    fn into_inner(self) -> Self::Inner {
+        ConnectResult(())
     }
 }
 
@@ -864,6 +918,12 @@ impl<S> PollOnce<S> {
     }
 }
 
+impl<S> IntoInner for PollOnce<S> {
+    type Inner = ();
+
+    fn into_inner(self) -> Self::Inner {}
+}
+
 /// Splice data between two file descriptors.
 #[cfg(linux_all)]
 pub struct Splice<S1, S2> {
@@ -899,4 +959,11 @@ impl<S1, S2> Splice<S1, S2> {
             flags,
         }
     }
+}
+
+#[cfg(linux_all)]
+impl<S1, S2> IntoInner for Splice<S1, S2> {
+    type Inner = ();
+
+    fn into_inner(self) -> Self::Inner {}
 }

--- a/compio-driver/tests/asyncify.rs
+++ b/compio-driver/tests/asyncify.rs
@@ -1,4 +1,4 @@
-use compio_buf::BufResult;
+use compio_buf::{BufResult, IntoInner};
 use compio_driver::{Key, OpCode, Proactor, PushEntry, op::Asyncify};
 
 fn take_key<T: OpCode, R>(res: PushEntry<Key<T>, R>) -> Key<T> {
@@ -10,7 +10,10 @@ fn take_key<T: OpCode, R>(res: PushEntry<Key<T>, R>) -> Key<T> {
     }
 }
 
-fn wait_for<T: OpCode>(driver: &mut Proactor, mut key: Key<T>) -> BufResult<usize, T> {
+fn wait_for<T: OpCode + IntoInner>(
+    driver: &mut Proactor,
+    mut key: Key<T>,
+) -> BufResult<usize, T::Inner> {
     loop {
         driver.poll(None).unwrap();
         match driver.pop(key) {

--- a/compio-driver/tests/file.rs
+++ b/compio-driver/tests/file.rs
@@ -5,7 +5,7 @@ use std::{
     time::Duration,
 };
 
-use compio_buf::BufResult;
+use compio_buf::{BufResult, IntoInner};
 use compio_driver::{
     AsRawFd, BufferPool, Extra, OpCode, OwnedFd, Proactor, PushEntry, SharedFd, TakeBuffer,
     op::{
@@ -62,7 +62,6 @@ fn open_file(driver: &mut Proactor) -> OwnedFd {
 fn open_file(driver: &mut Proactor) -> OwnedFd {
     use std::ffi::CString;
 
-    use compio_buf::IntoInner;
     use compio_driver::op::{CurrentDir, OpenFile};
 
     let op = OpenFile::new(
@@ -72,13 +71,13 @@ fn open_file(driver: &mut Proactor) -> OwnedFd {
         0o666,
     );
     let (_, op) = push_and_wait(driver, op).unwrap();
-    op.into_inner()
+    op.expect("file not opened")
 }
 
-fn push_and_wait_extra<O: OpCode + 'static>(
+fn push_and_wait_extra<O: OpCode + IntoInner + 'static>(
     driver: &mut Proactor,
     op: O,
-) -> (BufResult<usize, O>, Option<Extra>) {
+) -> (BufResult<usize, O::Inner>, Option<Extra>) {
     match driver.push(op) {
         PushEntry::Ready(res) => (res, None),
         PushEntry::Pending(mut user_data) => loop {
@@ -91,7 +90,10 @@ fn push_and_wait_extra<O: OpCode + 'static>(
     }
 }
 
-fn push_and_wait<O: OpCode + 'static>(driver: &mut Proactor, op: O) -> BufResult<usize, O> {
+fn push_and_wait<O: OpCode + IntoInner + 'static>(
+    driver: &mut Proactor,
+    op: O,
+) -> BufResult<usize, O::Inner> {
     match driver.push(op) {
         PushEntry::Ready(res) => res,
         PushEntry::Pending(mut user_data) => loop {
@@ -104,13 +106,14 @@ fn push_and_wait<O: OpCode + 'static>(driver: &mut Proactor, op: O) -> BufResult
     }
 }
 
-fn push_and_wait_multi<O: OpCode + TakeBuffer<BufferPool = BufferPool> + 'static>(
+fn push_and_wait_multi<O: OpCode + IntoInner + 'static>(
     driver: &mut Proactor,
     op: O,
     pool: &BufferPool,
 ) -> Vec<u8>
 where
-    for<'a> O::Buffer<'a>: Deref<Target = [u8]>,
+    O::Inner: TakeBuffer<BufferPool = BufferPool>,
+    for<'a> <O::Inner as TakeBuffer>::Buffer<'a>: Deref<Target = [u8]>,
 {
     match driver.push(op) {
         PushEntry::Ready(res) => match (res, driver.default_extra()).take_buffer(pool) {

--- a/compio-driver/tests/splice.rs
+++ b/compio-driver/tests/splice.rs
@@ -22,6 +22,7 @@ mod splice_impl {
         task::{Poll, ready},
     };
 
+    use compio_buf::IntoInner;
     use compio_driver::{Decision, OpCode, OpType, WaitArg, syscall};
 
     pub const SPLICE_F_NONBLOCK: u32 = 0;
@@ -80,12 +81,21 @@ mod splice_impl {
             )
         }
     }
+
+    impl<S1, S2> IntoInner for Splice<S1, S2> {
+        type Inner = ();
+
+        fn into_inner(self) -> Self::Inner {}
+    }
 }
 
 #[cfg(not(linux_all))]
 use splice_impl::{SPLICE_F_NONBLOCK, Splice};
 
-fn push_and_wait<O: OpCode + 'static>(driver: &mut Proactor, op: O) -> BufResult<usize, O> {
+fn push_and_wait<O: OpCode + IntoInner + 'static>(
+    driver: &mut Proactor,
+    op: O,
+) -> BufResult<usize, O::Inner> {
     match driver.push(op) {
         PushEntry::Ready(res) => res,
         PushEntry::Pending(mut user_data) => loop {
@@ -130,8 +140,7 @@ fn splice() {
 
     push_and_wait(&mut driver, write_op).unwrap();
     push_and_wait(&mut driver, splice_op).unwrap();
-    let (res, op) = push_and_wait(&mut driver, read_op).unwrap();
-    let mut buf = op.into_inner();
+    let (res, mut buf) = push_and_wait(&mut driver, read_op).unwrap();
     assert_eq!(res, 11);
     unsafe { buf.set_len(res) }
     assert_eq!(&buf[..], b"hello world");

--- a/compio-fs/src/file.rs
+++ b/compio-fs/src/file.rs
@@ -136,7 +136,7 @@ impl File {
     pub async fn metadata(&self) -> io::Result<Metadata> {
         let op = FileStat::new(self.to_shared_fd());
         let BufResult(res, op) = compio_runtime::submit(op).await;
-        res.map(|_| Metadata::from_stat(op.into_inner()))
+        res.map(|_| Metadata::from_stat(op))
     }
 
     /// Changes the permissions on the underlying file.
@@ -194,7 +194,7 @@ impl AsyncReadAt for File {
     async fn read_at<T: IoBufMut>(&self, buffer: T, pos: u64) -> BufResult<usize, T> {
         let fd = self.inner.to_shared_fd();
         let op = ReadAt::new(fd, pos, buffer);
-        let res = compio_runtime::submit(op).await.into_inner();
+        let res = compio_runtime::submit(op).await;
         unsafe { res.map_advanced() }
     }
 
@@ -208,7 +208,7 @@ impl AsyncReadAt for File {
 
         let fd = self.inner.to_shared_fd();
         let op = ReadVectoredAt::new(fd, pos, buffer);
-        let res = compio_runtime::submit(op).await.into_inner();
+        let res = compio_runtime::submit(op).await;
         unsafe { res.map_vec_advanced() }
     }
 }
@@ -254,7 +254,7 @@ impl AsyncWriteAt for &File {
     async fn write_at<T: IoBuf>(&mut self, buffer: T, pos: u64) -> BufResult<usize, T> {
         let fd = self.inner.to_shared_fd();
         let op = WriteAt::new(fd, pos, buffer);
-        compio_runtime::submit(op).await.into_inner()
+        compio_runtime::submit(op).await
     }
 
     #[cfg(all(unix, not(solarish)))]
@@ -265,7 +265,7 @@ impl AsyncWriteAt for &File {
     ) -> BufResult<usize, T> {
         let fd = self.inner.to_shared_fd();
         let op = WriteVectoredAt::new(fd, pos, buffer);
-        compio_runtime::submit(op).await.into_inner()
+        compio_runtime::submit(op).await
     }
 }
 

--- a/compio-fs/src/lib.rs
+++ b/compio-fs/src/lib.rs
@@ -60,7 +60,7 @@ pub(crate) fn path_string(path: impl AsRef<std::path::Path>) -> io::Result<std::
     })
 }
 
-use compio_buf::{BufResult, IntoInner};
+use compio_buf::BufResult;
 use compio_driver::{SharedFd, op::AsyncifyFd};
 
 pub(crate) async fn spawn_blocking_with<T: 'static, R: Send + 'static>(
@@ -73,7 +73,7 @@ pub(crate) async fn spawn_blocking_with<T: 'static, R: Send + 'static>(
     });
     let BufResult(res, meta) = compio_runtime::submit(op).await;
     res?;
-    Ok(meta.into_inner().expect("result should be present"))
+    Ok(meta.expect("result should be present"))
 }
 
 #[cfg(all(windows, dirfd))]
@@ -90,5 +90,5 @@ pub(crate) async fn spawn_blocking_with2<T1: 'static, T2: 'static, R: Send + 'st
     });
     let BufResult(res, meta) = compio_runtime::submit(op).await;
     res?;
-    Ok(meta.into_inner().expect("result should be present"))
+    Ok(meta.expect("result should be present"))
 }

--- a/compio-fs/src/metadata/unix.rs
+++ b/compio-fs/src/metadata/unix.rs
@@ -10,7 +10,7 @@ use std::{
     time::{Duration, SystemTime},
 };
 
-use compio_buf::{BufResult, IntoInner};
+use compio_buf::BufResult;
 use compio_driver::{
     ToSharedFd,
     op::{CurrentDir, PathStat, Stat},
@@ -25,8 +25,8 @@ async fn metadata_impl(
 ) -> io::Result<Metadata> {
     let path = path_string(path)?;
     let op = PathStat::new(dir, path, follow_symlink);
-    let BufResult(res, op) = compio_runtime::submit(op).await;
-    res.map(|_| Metadata::from_stat(op.into_inner()))
+    let BufResult(res, stat) = compio_runtime::submit(op).await;
+    res.map(|_| Metadata::from_stat(stat))
 }
 
 pub async fn metadata(path: impl AsRef<Path>) -> io::Result<Metadata> {

--- a/compio-fs/src/open_options/unix.rs
+++ b/compio-fs/src/open_options/unix.rs
@@ -1,6 +1,6 @@
 use std::{io, os::fd::AsFd, path::Path};
 
-use compio_buf::{IntoInner, buf_try};
+use compio_buf::buf_try;
 use compio_driver::{
     ToSharedFd,
     op::{CurrentDir, OpenFile},
@@ -90,8 +90,8 @@ impl OpenOptions {
             | (self.custom_flags & !libc::O_ACCMODE);
         let p = path_string(p)?;
         let op = OpenFile::new(dir, p, flags, self.mode);
-        let (_, op) = buf_try!(@try compio_runtime::submit(op).await);
-        File::from_std(op.into_inner().into())
+        let (_, fd) = buf_try!(@try compio_runtime::submit(op).await);
+        File::from_std(fd.expect("file not opened").into())
     }
 
     pub async fn open(&self, p: impl AsRef<Path>) -> io::Result<File> {

--- a/compio-fs/src/pipe/mod.rs
+++ b/compio-fs/src/pipe/mod.rs
@@ -7,7 +7,7 @@ use std::{
     path::Path,
 };
 
-use compio_buf::{BufResult, IntoInner, IoBuf, IoBufMut, IoVectoredBuf, IoVectoredBufMut};
+use compio_buf::{BufResult, IoBuf, IoBufMut, IoVectoredBuf, IoVectoredBufMut};
 use compio_driver::{
     AsRawFd, ToSharedFd, impl_raw_fd,
     op::{
@@ -379,13 +379,13 @@ impl AsyncWrite for &Sender {
     async fn write<T: IoBuf>(&mut self, buffer: T) -> BufResult<usize, T> {
         let fd = self.to_shared_fd();
         let op = Write::new(fd, buffer);
-        compio_runtime::submit(op).await.into_inner()
+        compio_runtime::submit(op).await
     }
 
     async fn write_vectored<T: IoVectoredBuf>(&mut self, buffer: T) -> BufResult<usize, T> {
         let fd = self.to_shared_fd();
         let op = WriteVectored::new(fd, buffer);
-        compio_runtime::submit(op).await.into_inner()
+        compio_runtime::submit(op).await
     }
 
     #[inline]
@@ -502,14 +502,14 @@ impl AsyncRead for &Receiver {
     async fn read<B: IoBufMut>(&mut self, buffer: B) -> BufResult<usize, B> {
         let fd = self.to_shared_fd();
         let op = Read::new(fd, buffer);
-        let res = compio_runtime::submit(op).await.into_inner();
+        let res = compio_runtime::submit(op).await;
         unsafe { res.map_advanced() }
     }
 
     async fn read_vectored<V: IoVectoredBufMut>(&mut self, buffer: V) -> BufResult<usize, V> {
         let fd = self.to_shared_fd();
         let op = ReadVectored::new(fd, buffer);
-        let res = compio_runtime::submit(op).await.into_inner();
+        let res = compio_runtime::submit(op).await;
         unsafe { res.map_vec_advanced() }
     }
 }

--- a/compio-net/src/socket.rs
+++ b/compio-net/src/socket.rs
@@ -64,9 +64,8 @@ impl Socket {
             ty.into(),
             protocol.map(|p| p.into()).unwrap_or_default(),
         );
-        let (_, op) = buf_try!(@try compio_runtime::submit(op).await);
-
-        Self::from_socket2(op.into_inner())
+        let (_, socket) = buf_try!(@try compio_runtime::submit(op).await);
+        Self::from_socket2(socket.expect("socket not created"))
     }
 
     pub async fn bind(addr: &SockAddr, ty: Type, protocol: Option<Protocol>) -> io::Result<Self> {
@@ -85,17 +84,17 @@ impl Socket {
 
     pub async fn connect_async(&self, addr: &SockAddr) -> io::Result<()> {
         let op = Connect::new(self.to_shared_fd(), addr.clone());
-        let (_, _op) = buf_try!(@try compio_runtime::submit(op).await);
+        let (_, _res) = buf_try!(@try compio_runtime::submit(op).await);
         #[cfg(windows)]
-        _op.update_context()?;
+        _res.update_context()?;
         Ok(())
     }
 
     #[cfg(unix)]
     pub async fn accept(&self) -> io::Result<(Self, SockAddr)> {
         let op = Accept::new(self.to_shared_fd());
-        let (_, op) = buf_try!(@try compio_runtime::submit(op).await);
-        let (accept_sock, addr) = op.into_addr();
+        let (_, res) = buf_try!(@try compio_runtime::submit(op).await);
+        let (accept_sock, addr) = res.expect("socket not accepted");
         let accept_sock = Self::from_socket2(accept_sock)?;
         Ok((accept_sock, addr))
     }
@@ -147,7 +146,7 @@ impl Socket {
     pub async fn recv<B: IoBufMut>(&self, buffer: B, flags: i32) -> BufResult<usize, B> {
         let fd = self.to_shared_fd();
         let op = Recv::new(fd, buffer, flags);
-        let res = compio_runtime::submit(op).await.into_inner();
+        let res = compio_runtime::submit(op).await;
         unsafe { res.map_advanced() }
     }
 
@@ -158,7 +157,7 @@ impl Socket {
     ) -> BufResult<usize, V> {
         let fd = self.to_shared_fd();
         let op = RecvVectored::new(fd, buffer, flags);
-        let res = compio_runtime::submit(op).await.into_inner();
+        let res = compio_runtime::submit(op).await;
         unsafe { res.map_vec_advanced() }
     }
 
@@ -195,7 +194,7 @@ impl Socket {
     pub async fn send<T: IoBuf>(&self, buffer: T, flags: i32) -> BufResult<usize, T> {
         let fd = self.to_shared_fd();
         let op = Send::new(fd, buffer, flags);
-        compio_runtime::submit(op).await.into_inner()
+        compio_runtime::submit(op).await
     }
 
     pub async fn send_vectored<T: IoVectoredBuf>(
@@ -205,7 +204,7 @@ impl Socket {
     ) -> BufResult<usize, T> {
         let fd = self.to_shared_fd();
         let op = SendVectored::new(fd, buffer, flags);
-        compio_runtime::submit(op).await.into_inner()
+        compio_runtime::submit(op).await
     }
 
     pub async fn recv_from<T: IoBufMut>(
@@ -215,7 +214,7 @@ impl Socket {
     ) -> BufResult<(usize, Option<SockAddr>), T> {
         let fd = self.to_shared_fd();
         let op = RecvFrom::new(fd, buffer, flags);
-        let res = compio_runtime::submit(op).await.into_inner().map_addr();
+        let res = compio_runtime::submit(op).await.map_addr();
         unsafe { res.map_advanced() }
     }
 
@@ -226,7 +225,7 @@ impl Socket {
     ) -> BufResult<(usize, Option<SockAddr>), T> {
         let fd = self.to_shared_fd();
         let op = RecvFromVectored::new(fd, buffer, flags);
-        let res = compio_runtime::submit(op).await.into_inner().map_addr();
+        let res = compio_runtime::submit(op).await.map_addr();
         unsafe { res.map_vec_advanced() }
     }
 
@@ -249,7 +248,7 @@ impl Socket {
     ) -> BufResult<(usize, usize, Option<SockAddr>), (T, C)> {
         let fd = self.to_shared_fd();
         let op = RecvMsg::new(fd, buffer, control, flags);
-        let res = compio_runtime::submit(op).await.into_inner().map_addr();
+        let res = compio_runtime::submit(op).await.map_addr();
         unsafe { res.map_vec_advanced() }
     }
 
@@ -261,7 +260,7 @@ impl Socket {
     ) -> BufResult<usize, T> {
         let fd = self.to_shared_fd();
         let op = SendTo::new(fd, buffer, addr.clone(), flags);
-        compio_runtime::submit(op).await.into_inner()
+        compio_runtime::submit(op).await
     }
 
     pub async fn send_to_vectored<T: IoVectoredBuf>(
@@ -272,7 +271,7 @@ impl Socket {
     ) -> BufResult<usize, T> {
         let fd = self.to_shared_fd();
         let op = SendToVectored::new(fd, buffer, addr.clone(), flags);
-        compio_runtime::submit(op).await.into_inner()
+        compio_runtime::submit(op).await
     }
 
     pub async fn send_msg<T: IoBuf, C: IoBuf>(
@@ -296,7 +295,7 @@ impl Socket {
     ) -> BufResult<usize, (T, C)> {
         let fd = self.to_shared_fd();
         let op = SendMsg::new(fd, buffer, control, addr.cloned(), flags);
-        compio_runtime::submit(op).await.into_inner()
+        compio_runtime::submit(op).await
     }
 
     #[cfg(unix)]

--- a/compio-process/src/unix.rs
+++ b/compio-process/src/unix.rs
@@ -1,6 +1,6 @@
 use std::{io, panic::resume_unwind, process};
 
-use compio_buf::{BufResult, IntoInner, IoBuf, IoBufMut};
+use compio_buf::{BufResult, IoBuf, IoBufMut};
 use compio_driver::{
     ToSharedFd,
     op::{BufResultExt, Read, ReadManaged, ResultTakeBuffer, Write},
@@ -20,7 +20,7 @@ impl AsyncRead for ChildStdout {
     async fn read<B: IoBufMut>(&mut self, buffer: B) -> BufResult<usize, B> {
         let fd = self.to_shared_fd();
         let op = Read::new(fd, buffer);
-        let res = compio_runtime::submit(op).await.into_inner();
+        let res = compio_runtime::submit(op).await;
         unsafe { res.map_advanced() }
     }
 }
@@ -48,7 +48,7 @@ impl AsyncRead for ChildStderr {
     async fn read<B: IoBufMut>(&mut self, buffer: B) -> BufResult<usize, B> {
         let fd = self.to_shared_fd();
         let op = Read::new(fd, buffer);
-        let res = compio_runtime::submit(op).await.into_inner();
+        let res = compio_runtime::submit(op).await;
         unsafe { res.map_advanced() }
     }
 }
@@ -76,7 +76,7 @@ impl AsyncWrite for ChildStdin {
     async fn write<T: IoBuf>(&mut self, buffer: T) -> BufResult<usize, T> {
         let fd = self.to_shared_fd();
         let op = Write::new(fd, buffer);
-        compio_runtime::submit(op).await.into_inner()
+        compio_runtime::submit(op).await
     }
 
     async fn flush(&mut self) -> io::Result<()> {

--- a/compio-runtime/src/cancel.rs
+++ b/compio-runtime/src/cancel.rs
@@ -9,6 +9,7 @@ use std::{
     task::{Context, Poll},
 };
 
+use compio_buf::IntoInner;
 use compio_driver::{Cancel, Key, OpCode};
 use futures_util::{FutureExt, ready};
 use synchrony::unsync::event::{Event, EventListener};
@@ -95,7 +96,7 @@ impl CancelToken {
     ///
     /// Multiple registrations of the same key does nothing, and the key will
     /// only be cancelled once.
-    pub fn register<T: OpCode>(&self, key: &Key<T>) {
+    pub fn register<T: OpCode + IntoInner>(&self, key: &Key<T>) {
         if self.0.is_cancelled.get() {
             self.0.runtime.cancel(key.clone());
         } else {

--- a/compio-runtime/src/fd/async_fd/mod.rs
+++ b/compio-runtime/src/fd/async_fd/mod.rs
@@ -96,7 +96,7 @@ impl<T: AsFd + 'static> AsyncRead for &AsyncFd<T> {
     async fn read<B: IoBufMut>(&mut self, buf: B) -> BufResult<usize, B> {
         let fd = self.inner.to_shared_fd();
         let op = Read::new(fd, buf);
-        let res = crate::submit(op).await.into_inner();
+        let res = crate::submit(op).await;
         unsafe { res.map_advanced() }
     }
 
@@ -106,7 +106,7 @@ impl<T: AsFd + 'static> AsyncRead for &AsyncFd<T> {
 
         let fd = self.inner.to_shared_fd();
         let op = ReadVectored::new(fd, buf);
-        let res = crate::submit(op).await.into_inner();
+        let res = crate::submit(op).await;
         unsafe { res.map_vec_advanced() }
     }
 }
@@ -138,14 +138,14 @@ impl<T: AsFd + 'static> AsyncWrite for &AsyncFd<T> {
     async fn write<B: IoBuf>(&mut self, buf: B) -> BufResult<usize, B> {
         let fd = self.inner.to_shared_fd();
         let op = Write::new(fd, buf);
-        crate::submit(op).await.into_inner()
+        crate::submit(op).await
     }
 
     #[cfg(unix)]
     async fn write_vectored<V: IoVectoredBuf>(&mut self, buf: V) -> BufResult<usize, V> {
         let fd = self.inner.to_shared_fd();
         let op = WriteVectored::new(fd, buf);
-        crate::submit(op).await.into_inner()
+        crate::submit(op).await
     }
 
     async fn flush(&mut self) -> io::Result<()> {

--- a/compio-runtime/src/runtime/future.rs
+++ b/compio-runtime/src/runtime/future.rs
@@ -7,7 +7,7 @@ use std::{
     task::{Context, Poll},
 };
 
-use compio_buf::BufResult;
+use compio_buf::{BufResult, IntoInner};
 use compio_driver::{Extra, Key, OpCode, PushEntry};
 use futures_util::future::FusedFuture;
 
@@ -50,7 +50,7 @@ impl ContextExt for Context<'_> {
 /// which implements `Future<Output = (BufResult<usize, T>, Extra)>`.
 ///
 /// [`.with_extra()`]: Submit::with_extra
-pub struct Submit<T: OpCode, E = ()> {
+pub struct Submit<T: OpCode + IntoInner, E = ()> {
     runtime: Runtime,
     state: Option<State<T, E>>,
 }
@@ -69,7 +69,7 @@ impl<T: OpCode, E> State<T, E> {
     }
 }
 
-impl<T: OpCode> Submit<T, ()> {
+impl<T: OpCode + IntoInner> Submit<T, ()> {
     pub(crate) fn new(runtime: Runtime, op: T) -> Self {
         Submit {
             runtime,
@@ -103,8 +103,8 @@ impl<T: OpCode> Submit<T, ()> {
     }
 }
 
-impl<T: OpCode + 'static> Future for Submit<T, ()> {
-    type Output = BufResult<usize, T>;
+impl<T: OpCode + IntoInner + 'static> Future for Submit<T, ()> {
+    type Output = BufResult<usize, T::Inner>;
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let this = unsafe { self.get_unchecked_mut() };
@@ -139,8 +139,8 @@ impl<T: OpCode + 'static> Future for Submit<T, ()> {
     }
 }
 
-impl<T: OpCode + 'static> Future for Submit<T, Extra> {
-    type Output = (BufResult<usize, T>, Extra);
+impl<T: OpCode + IntoInner + 'static> Future for Submit<T, Extra> {
+    type Output = (BufResult<usize, T::Inner>, Extra);
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let this = unsafe { self.get_unchecked_mut() };
@@ -175,7 +175,7 @@ impl<T: OpCode + 'static> Future for Submit<T, Extra> {
     }
 }
 
-impl<T: OpCode, E> FusedFuture for Submit<T, E>
+impl<T: OpCode + IntoInner, E> FusedFuture for Submit<T, E>
 where
     Submit<T, E>: Future,
 {
@@ -184,7 +184,7 @@ where
     }
 }
 
-impl<T: OpCode, E> Drop for Submit<T, E> {
+impl<T: OpCode + IntoInner, E> Drop for Submit<T, E> {
     fn drop(&mut self) {
         if let Some(State::Submitted { key, .. }) = self.state.take() {
             self.runtime.cancel(key);

--- a/compio-runtime/src/runtime/mod.rs
+++ b/compio-runtime/src/runtime/mod.rs
@@ -250,7 +250,7 @@ impl Runtime {
         });
         // It is safe and sound to use `submit` here because the task is spawned
         // immediately.
-        self.spawn_impl(self.submit(op).map(|res| res.1.into_inner()))
+        self.spawn_impl(self.submit(op).map(|res| res.1))
     }
 
     /// Attach a raw file descriptor/handle/socket to the runtime.
@@ -261,11 +261,11 @@ impl Runtime {
         self.driver.borrow_mut().attach(fd)
     }
 
-    fn submit_raw<T: OpCode + 'static>(
+    fn submit_raw<T: OpCode + IntoInner + 'static>(
         &self,
         op: T,
         extra: Option<Extra>,
-    ) -> PushEntry<Key<T>, BufResult<usize, T>> {
+    ) -> PushEntry<Key<T>, BufResult<usize, T::Inner>> {
         let mut this = self.driver.borrow_mut();
         match extra {
             Some(e) => this.push_with_extra(op, e),
@@ -280,11 +280,11 @@ impl Runtime {
     /// Submit an operation to the runtime.
     ///
     /// You only need this when authoring your own [`OpCode`].
-    pub fn submit<T: OpCode + 'static>(&self, op: T) -> Submit<T> {
+    pub fn submit<T: OpCode + IntoInner + 'static>(&self, op: T) -> Submit<T> {
         Submit::new(self.clone(), op)
     }
 
-    pub(crate) fn cancel<T: OpCode>(&self, key: Key<T>) {
+    pub(crate) fn cancel<T: OpCode + IntoInner>(&self, key: Key<T>) {
         self.driver.borrow_mut().cancel(key);
     }
 
@@ -301,11 +301,11 @@ impl Runtime {
         self.timer_runtime.borrow_mut().cancel(key);
     }
 
-    pub(crate) fn poll_task<T: OpCode>(
+    pub(crate) fn poll_task<T: OpCode + IntoInner>(
         &self,
         waker: &Waker,
         key: Key<T>,
-    ) -> PushEntry<Key<T>, BufResult<usize, T>> {
+    ) -> PushEntry<Key<T>, BufResult<usize, T::Inner>> {
         instrument!(compio_log::Level::DEBUG, "poll_task", ?key);
         let mut driver = self.driver.borrow_mut();
         driver.pop(key).map_pending(|k| {
@@ -314,11 +314,12 @@ impl Runtime {
         })
     }
 
-    pub(crate) fn poll_task_with_extra<T: OpCode>(
+    #[allow(clippy::type_complexity)]
+    pub(crate) fn poll_task_with_extra<T: OpCode + IntoInner>(
         &self,
         waker: &Waker,
         key: Key<T>,
-    ) -> PushEntry<Key<T>, (BufResult<usize, T>, Extra)> {
+    ) -> PushEntry<Key<T>, (BufResult<usize, T::Inner>, Extra)> {
         instrument!(compio_log::Level::DEBUG, "poll_task_with_extra", ?key);
         let mut driver = self.driver.borrow_mut();
         driver.pop_with_extra(key).map_pending(|k| {
@@ -597,7 +598,7 @@ pub fn spawn_blocking<T: Send + 'static>(
 /// This method doesn't create runtime and will panic if it's not within a
 /// runtime. It tries to obtain the current runtime by
 /// [`Runtime::with_current`].
-pub fn submit<T: OpCode + 'static>(op: T) -> Submit<T> {
+pub fn submit<T: OpCode + IntoInner + 'static>(op: T) -> Submit<T> {
     Runtime::with_current(|r| r.submit(op))
 }
 

--- a/compio/examples/driver.rs
+++ b/compio/examples/driver.rs
@@ -43,10 +43,13 @@ fn open_file(driver: &mut Proactor) -> OwnedFd {
         0o666,
     );
     let (_, op) = push_and_wait(driver, op);
-    op.into_inner()
+    op.expect("file not opened")
 }
 
-fn push_and_wait<O: OpCode + 'static>(driver: &mut Proactor, op: O) -> (usize, O) {
+fn push_and_wait<O: OpCode + IntoInner + 'static>(
+    driver: &mut Proactor,
+    op: O,
+) -> (usize, O::Inner) {
     match driver.push(op) {
         PushEntry::Ready(res) => res.unwrap(),
         PushEntry::Pending(mut user_data) => loop {
@@ -67,9 +70,8 @@ fn main() {
     driver.attach(fd.as_raw_fd()).unwrap();
 
     let op = ReadAt::new(fd.clone(), 0, Vec::with_capacity(4096));
-    let (n, op) = push_and_wait(&mut driver, op);
+    let (n, mut buffer) = push_and_wait(&mut driver, op);
 
-    let mut buffer = op.into_inner();
     unsafe {
         buffer.set_len(n);
     }


### PR DESCRIPTION
Closes #741 

This PR requires `IntoInner` for submitted opcodes. The `OpCode` itself will be dropped after completed, and only the `Inner` will be returned. Users will not be able to access the invalid self-referential fields.