### PR TITLE
test(driver): read multi on pipe

### DIFF
--- a/compio-driver/tests/op.rs
+++ b/compio-driver/tests/op.rs
@@ -282,7 +282,7 @@ fn read_multi() {
     let (r, w) = pipe2::pipe2(flags).unwrap();
 
     let op = Write::new(w, b"hello world");
-    let (_, _op) = push_and_wait(&mut driver, op).unwrap();
+    push_and_wait(&mut driver, op).unwrap();
 
     let pool = driver.create_buffer_pool(4, 1024).unwrap();
 


### PR DESCRIPTION
`READ_MULTISHOT` doesn't support regular files, so we have to test on a pipe.

However, I don't want to remove `ReadMultiAt` because io-uring allows to do so. Maybe they will support regular files in the future.