### PR TITLE
fix(lint): fix ambiguity linter error in compio-io

### DIFF
--- a/compio-io/tests/framed.rs
+++ b/compio-io/tests/framed.rs
@@ -58,7 +58,7 @@ impl AsyncWrite for InMemoryPipe {
     }
 
     async fn flush(&mut self) -> io::Result<()> {
-        self.0.get_ref().lock().await.flush().await
+        compio_io::AsyncWrite::flush(&mut *self.0.get_ref().lock().await).await
     }
 
     async fn shutdown(&mut self) -> io::Result<()> {


### PR DESCRIPTION
Surfaced during H2 PR test run:

```
error[E0034]: multiple applicable items in scope
  --> compio-io/tests/framed.rs:61:39
   |
61 |         self.0.get_ref().lock().await.flush().await
   |                                       ^^^^^ multiple `flush` found
   |
   = note: candidate #1 is defined in an impl of the trait `futures_util::SinkExt` for the type `T`
   = note: candidate #2 is defined in an impl of the trait `compio_io::AsyncWrite` for the type `std::vec::Vec<u8, A>`
```