### PR TITLE
fix(io): fix bytes feature and warnings

### DIFF
--- a/compio-io/src/buffer.rs
+++ b/compio-io/src/buffer.rs
@@ -98,6 +98,7 @@ impl<B> Buffer<B> {
         self.inner_mut().as_inner_mut()
     }
 
+    #[cfg(feature = "compat")]
     pub(crate) fn has_inner(&self) -> bool {
         self.0.is_some()
     }

--- a/compio-io/src/framed/mod.rs
+++ b/compio-io/src/framed/mod.rs
@@ -8,11 +8,7 @@ use std::marker::PhantomData;
 use compio_buf::IoBufMut;
 use futures_util::FutureExt;
 
-use crate::{
-    AsyncRead,
-    framed::{codec::Decoder, frame::NoopFramer},
-    util::Splittable,
-};
+use crate::{AsyncRead, util::Splittable};
 
 pub mod codec;
 pub mod frame;
@@ -164,7 +160,7 @@ pub type BytesFramed<R, W> = Framed<
     R,
     W,
     codec::bytes::BytesCodec,
-    NoopFramer,
+    frame::NoopFramer,
     compio_buf::bytes::Bytes,
     compio_buf::bytes::Bytes,
 >;
@@ -185,7 +181,7 @@ impl BytesFramed<(), ()> {
             read_state: read::State::empty(),
             write_state: write::State::empty(),
             codec: codec::bytes::BytesCodec::new(),
-            framer: NoopFramer::new(),
+            framer: frame::NoopFramer::new(),
             types: PhantomData,
         }
     }

--- a/compio-io/src/framed/read.rs
+++ b/compio-io/src/framed/read.rs
@@ -56,7 +56,7 @@ enum StateInner<Io, B> {
 impl<R, W, C, F, In, Out, B> Stream for Framed<R, W, C, F, In, Out, B>
 where
     R: AsyncRead + 'static,
-    C: Decoder<Out, B>,
+    C: codec::Decoder<Out, B>,
     F: Framer<B>,
     B: IoBufMut,
     Self: Unpin,

--- a/compio-io/src/read/ext.rs
+++ b/compio-io/src/read/ext.rs
@@ -5,8 +5,7 @@ use std::{io, io::ErrorKind};
 use compio_buf::{BufResult, IntoInner, IoBuf, IoBufMut, IoVectoredBufMut, Uninit, t_alloc};
 
 use crate::{
-    AsyncRead, AsyncReadAt, IoResult,
-    framed::{BytesFramed, Framed},
+    AsyncRead, AsyncReadAt, IoResult, framed,
     util::{Splittable, Take},
 };
 
@@ -189,26 +188,27 @@ pub trait AsyncReadExt: AsyncRead {
         loop_read_exact!(buf, len, read, loop self.read_vectored(buf.slice_mut(read)));
     }
 
-    /// Create a [`Framed`] reader/writer with the given codec and framer.
+    /// Create a [`framed::Framed`] reader/writer with the given codec and
+    /// framer.
     fn framed<T, C, F>(
         self,
         codec: C,
         framer: F,
-    ) -> Framed<Self::ReadHalf, Self::WriteHalf, C, F, T, T>
+    ) -> framed::Framed<Self::ReadHalf, Self::WriteHalf, C, F, T, T>
     where
         Self: Splittable + Sized,
     {
-        Framed::new(codec, framer).with_duplex(self)
+        framed::Framed::new(codec, framer).with_duplex(self)
     }
 
-    /// Convenience method to create a [`BytesFramed`] reader/writter
+    /// Convenience method to create a [`framed::BytesFramed`] reader/writter
     /// out of a splittable.
     #[cfg(feature = "bytes")]
-    fn bytes(self) -> BytesFramed<Self::ReadHalf, Self::WriteHalf>
+    fn bytes(self) -> framed::BytesFramed<Self::ReadHalf, Self::WriteHalf>
     where
         Self: Splittable + Sized,
     {
-        BytesFramed::new_bytes().with_duplex(self)
+        framed::BytesFramed::new_bytes().with_duplex(self)
     }
 
     /// Create a [`Splittable`] that uses `Self` as [`ReadHalf`] and `()` as

--- a/compio-io/src/write/ext.rs
+++ b/compio-io/src/write/ext.rs
@@ -1,10 +1,6 @@
 use compio_buf::{BufResult, IntoInner, IoBuf, IoVectoredBuf};
 
-use crate::{
-    AsyncWrite, AsyncWriteAt, IoResult,
-    framed::{BytesFramed, Framed},
-    util::Splittable,
-};
+use crate::{AsyncWrite, AsyncWriteAt, IoResult, framed, util::Splittable};
 
 /// Shared code for write a scalar value into the underlying writer.
 macro_rules! write_scalar {
@@ -120,26 +116,27 @@ pub trait AsyncWriteExt: AsyncWrite {
         loop_write_all!(buf, len, needle, loop self.write_vectored(buf.slice(needle)));
     }
 
-    /// Create a [`Framed`] reader/writer with the given codec and framer.
+    /// Create a [`framed::Framed`] reader/writer with the given codec and
+    /// framer.
     fn framed<T, C, F>(
         self,
         codec: C,
         framer: F,
-    ) -> Framed<Self::ReadHalf, Self::WriteHalf, C, F, T, T>
+    ) -> framed::Framed<Self::ReadHalf, Self::WriteHalf, C, F, T, T>
     where
         Self: Splittable + Sized,
     {
-        Framed::new(codec, framer).with_duplex(self)
+        framed::Framed::new(codec, framer).with_duplex(self)
     }
 
-    /// Convenience method to create a [`BytesFramed`] reader/writer
+    /// Convenience method to create a [`framed::BytesFramed`] reader/writer
     /// out of a splittable.
     #[cfg(feature = "bytes")]
-    fn bytes(self) -> BytesFramed<Self::ReadHalf, Self::WriteHalf>
+    fn bytes(self) -> framed::BytesFramed<Self::ReadHalf, Self::WriteHalf>
     where
         Self: Splittable + Sized,
     {
-        BytesFramed::new_bytes().with_duplex(self)
+        framed::BytesFramed::new_bytes().with_duplex(self)
     }
 
     /// Create a [`Splittable`] that uses `Self` as [`WriteHalf`] and `()` as


### PR DESCRIPTION
Broken in #752: `BytesFramed` requires `bytes` feature