### PR TITLE
fix(driver,iocp): fairness

### DIFF
--- a/compio-driver/src/sys/iocp/cp/mod.rs
+++ b/compio-driver/src/sys/iocp/cp/mod.rs
@@ -35,7 +35,7 @@ use windows_sys::Win32::{
         },
         SystemServices::ERROR_SEVERITY_ERROR,
         Threading::INFINITE,
-        WindowsProgramming::{FILE_SKIP_COMPLETION_PORT_ON_SUCCESS, FILE_SKIP_SET_EVENT_ON_HANDLE},
+        WindowsProgramming::FILE_SKIP_SET_EVENT_ON_HANDLE,
     },
 };
 
@@ -75,10 +75,7 @@ impl CompletionPort {
         )?;
         syscall!(
             BOOL,
-            SetFileCompletionNotificationModes(
-                fd,
-                (FILE_SKIP_COMPLETION_PORT_ON_SUCCESS | FILE_SKIP_SET_EVENT_ON_HANDLE) as _
-            )
+            SetFileCompletionNotificationModes(fd, FILE_SKIP_SET_EVENT_ON_HANDLE as _)
         )?;
         Ok(())
     }

--- a/compio-driver/src/sys/iocp/op.rs
+++ b/compio-driver/src/sys/iocp/op.rs
@@ -67,7 +67,7 @@ fn win32_result(res: i32, transferred: u32) -> Poll<io::Result<usize>> {
     if res == 0 {
         winapi_result(transferred)
     } else {
-        Poll::Ready(Ok(transferred as _))
+        Poll::Pending
     }
 }
 
@@ -76,7 +76,7 @@ fn winsock_result(res: i32, transferred: u32) -> Poll<io::Result<usize>> {
     if res != 0 {
         winapi_result(transferred)
     } else {
-        Poll::Ready(Ok(transferred as _))
+        Poll::Pending
     }
 }
 


### PR DESCRIPTION
Previously we believe `FILE_SKIP_COMPLETION_PORT_ON_SUCCESS` will decrease the letancy, but now we have found that it makes an always-ready loop occupy the CPU time unfairly. As it is a handle-wide setting, we can only enable or disable it totally, instead of controlling it op by op.