### PR TITLE
refactor(signal): runtime agnostic

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ criterion = "0.8.0"
 crossbeam-queue = "0.3.8"
 flume = { version = "0.12.0", default-features = false }
 futures-channel = "0.3.29"
+futures-executor = "0.3.30"
 futures-rustls = { version = "0.26.0", default-features = false }
 futures-util = "0.3.29"
 libc = "0.2.175"

--- a/compio-io/Cargo.toml
+++ b/compio-io/Cargo.toml
@@ -20,7 +20,9 @@ cfg-if = { workspace = true, optional = true }
 thiserror = { workspace = true, optional = true }
 serde = { version = "1.0.219", optional = true }
 serde_json = { version = "1.0.140", optional = true }
-bytemuck = { workspace = true, optional = true, features = ["min_const_generics"] }
+bytemuck = { workspace = true, optional = true, features = [
+    "min_const_generics",
+] }
 
 [target.'cfg(unix)'.dependencies]
 libc = { workspace = true, optional = true }
@@ -35,7 +37,7 @@ compio-net = { workspace = true }
 compio-runtime = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt"] }
 serde = { version = "1.0.219", features = ["derive"] }
-futures-executor = "0.3.30"
+futures-executor = { workspace = true }
 
 [features]
 default = ["bytes"]

--- a/compio-signal/Cargo.toml
+++ b/compio-signal/Cargo.toml
@@ -20,7 +20,6 @@ synchrony = { workspace = true, features = ["async_flag"] }
 
 # Windows specific dependencies
 [target.'cfg(windows)'.dependencies]
-compio-driver = { workspace = true }
 windows-sys = { workspace = true, features = [
     "Win32_Foundation",
     "Win32_System_Console",
@@ -32,7 +31,7 @@ libc = { workspace = true }
 os_pipe = { workspace = true }
 
 [dev-dependencies]
-compio-runtime = { workspace = true }
+futures-executor = { workspace = true }
 
 [features]
 # Nightly features

--- a/compio-signal/src/lib.rs
+++ b/compio-signal/src/lib.rs
@@ -7,7 +7,7 @@
 //! ```rust,no_run
 //! use compio_signal::ctrl_c;
 //!
-//! # compio_runtime::Runtime::new().unwrap().block_on(async {
+//! # futures_executor::block_on(async {
 //! ctrl_c().await.unwrap();
 //! println!("ctrl-c received!");
 //! # })

--- a/compio-signal/src/windows.rs
+++ b/compio-signal/src/windows.rs
@@ -6,7 +6,6 @@ use std::sync::LazyLock;
 use std::sync::OnceLock;
 use std::{collections::HashMap, io, sync::Mutex};
 
-use compio_driver::syscall;
 #[cfg(not(feature = "lazy_cell"))]
 use once_cell::sync::Lazy as LazyLock;
 #[cfg(not(feature = "once_cell_try"))]
@@ -41,8 +40,11 @@ unsafe extern "system" fn ctrl_event_handler(ctrltype: u32) -> BOOL {
 static INIT: OnceLock<()> = OnceLock::new();
 
 fn init() -> io::Result<()> {
-    syscall!(BOOL, SetConsoleCtrlHandler(Some(ctrl_event_handler), 1))?;
-    Ok(())
+    if unsafe { SetConsoleCtrlHandler(Some(ctrl_event_handler), 1) } != 0 {
+        Ok(())
+    } else {
+        Err(io::Error::last_os_error())
+    }
 }
 
 fn register(ctrltype: u32, e: &Event) -> usize {


### PR DESCRIPTION
Now it's possible to make `compio-signal` runtime agnostic.