### PR TITLE
fix(signal): remove "lazy_cell" as a nightly feature

### DIFF
--- a/compio-signal/Cargo.toml
+++ b/compio-signal/Cargo.toml
@@ -14,12 +14,12 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-once_cell = { workspace = true }
 slab = { workspace = true }
 synchrony = { workspace = true, features = ["async_flag"] }
 
 # Windows specific dependencies
 [target.'cfg(windows)'.dependencies]
+once_cell = { workspace = true }
 windows-sys = { workspace = true, features = [
     "Win32_Foundation",
     "Win32_System_Console",
@@ -35,6 +35,5 @@ futures-executor = { workspace = true }
 
 [features]
 # Nightly features
-lazy_cell = []
 once_cell_try = []
-nightly = ["lazy_cell", "once_cell_try"]
+nightly = ["once_cell_try"]

--- a/compio-signal/src/lib.rs
+++ b/compio-signal/src/lib.rs
@@ -15,11 +15,9 @@
 
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![cfg_attr(feature = "once_cell_try", feature(once_cell_try))]
-#![cfg_attr(feature = "lazy_cell", feature(lazy_cell))]
 #![allow(unused_features)]
 #![warn(missing_docs)]
 #![deny(rustdoc::broken_intra_doc_links)]
-#![allow(stable_features)]
 #![doc(
     html_logo_url = "https://github.com/compio-rs/compio-logo/raw/refs/heads/master/generated/colored-bold.svg"
 )]

--- a/compio-signal/src/unix.rs
+++ b/compio-signal/src/unix.rs
@@ -1,16 +1,12 @@
 //! Unix-specific types for signal handling.
 
-#[cfg(feature = "lazy_cell")]
-use std::sync::LazyLock;
 use std::{
     collections::HashMap,
     io::{self, Read, Write},
     ops::Deref,
-    sync::Mutex,
+    sync::{LazyLock, Mutex},
 };
 
-#[cfg(not(feature = "lazy_cell"))]
-use once_cell::sync::Lazy as LazyLock;
 use os_pipe::{PipeReader, PipeWriter};
 use slab::Slab;
 use synchrony::sync::async_flag::{AsyncFlag as Event, AsyncFlagHandle as EventHandle};

--- a/compio-signal/src/windows.rs
+++ b/compio-signal/src/windows.rs
@@ -1,13 +1,13 @@
 //! Windows-specific types for signal handling.
 
-#[cfg(feature = "lazy_cell")]
-use std::sync::LazyLock;
 #[cfg(feature = "once_cell_try")]
 use std::sync::OnceLock;
-use std::{collections::HashMap, io, sync::Mutex};
+use std::{
+    collections::HashMap,
+    io,
+    sync::{LazyLock, Mutex},
+};
 
-#[cfg(not(feature = "lazy_cell"))]
-use once_cell::sync::Lazy as LazyLock;
 #[cfg(not(feature = "once_cell_try"))]
 use once_cell::sync::OnceCell as OnceLock;
 use slab::Slab;

--- a/compio/Cargo.toml
+++ b/compio/Cargo.toml
@@ -126,7 +126,6 @@ enable_log = ["compio-log/enable_log"]
 # Nightly features
 allocator_api = ["compio-buf/allocator_api", "compio-io?/allocator_api"]
 current_thread_id = ["compio-runtime?/current_thread_id"]
-lazy_cell = ["compio-signal?/lazy_cell"]
 linux_pidfd = ["compio-process?/linux_pidfd"]
 once_cell_try = [
     "compio-driver/once_cell_try",
@@ -146,7 +145,6 @@ future-combinator = ["compio-runtime?/future-combinator"]
 nightly = [
     "allocator_api",
     "current_thread_id",
-    "lazy_cell",
     "linux_pidfd",
     "once_cell_try",
     "proc_macro_diagnostic",


### PR DESCRIPTION
"lazy_cell" has been stablized since July 2024. It's OK to drop the older ones, I think.