### PR TITLE
ci: disable aarch64 musl

### DIFF
--- a/.github/workflows/ci_test_musl.yml
+++ b/.github/workflows/ci_test_musl.yml
@@ -31,8 +31,8 @@ jobs:
         setup:
           - target: 'x86_64-unknown-linux-musl'
             features: 'native-tls-vendored,ring,sync,polling'
-          - target: 'aarch64-unknown-linux-musl'
-            features: 'native-tls-vendored,ring,sync,polling'
+          # - target: 'aarch64-unknown-linux-musl'
+          #   features: 'native-tls-vendored,ring,sync,polling'
     steps:
       - uses: actions/checkout@v4
       - name: Setup cross-rs


### PR DESCRIPTION
The aarch64 target is too slow. It seems running on a qemu.