### PR TITLE
test(quic): avoid shutting down early

### DIFF
--- a/compio-quic/tests/control.rs
+++ b/compio-quic/tests/control.rs
@@ -54,12 +54,12 @@ async fn ip_blocking() {
         .await
         .unwrap();
 
-    client2.shutdown().await.unwrap();
-    client1.shutdown().await.unwrap();
-
     shutdown_handle.notify();
 
     srv.await.unwrap();
+
+    client2.shutdown().await.unwrap();
+    client1.shutdown().await.unwrap();
 }
 
 #[compio_macros::test]


### PR DESCRIPTION
CI randomly reports "ApplicationClosed" on the server. We should shutdown the server before shutting down the clients.