### PR TITLE
feat(quic,tls,ws): readd aws-lc support

### DIFF
--- a/compio-quic/Cargo.toml
+++ b/compio-quic/Cargo.toml
@@ -30,6 +30,7 @@ h3 = { version = "0.0.8", optional = true }
 h3-datagram = { version = "0.0.2", optional = true }
 
 # Utils
+cfg-if = { workspace = true, optional = true }
 flume = { workspace = true, default-features = false, features = ["async"] }
 futures-util = { workspace = true }
 thiserror = { workspace = true }
@@ -71,7 +72,8 @@ native-certs = ["dep:rustls-native-certs"]
 webpki-roots = ["dep:webpki-roots"]
 qlog = ["quinn-proto/qlog"]
 h3 = ["dep:h3", "dep:h3-datagram"]
-ring = ["quinn-proto/rustls-ring"]
+ring = ["dep:cfg-if", "quinn-proto/rustls-ring"]
+aws-lc-rs = ["dep:cfg-if", "quinn-proto/rustls-aws-lc-rs"]
 windows-gro = []
 sync = []
 

--- a/compio-quic/build.rs
+++ b/compio-quic/build.rs
@@ -11,6 +11,6 @@ fn main() {
         bsd: { any(freebsd, non_freebsd) },
         solarish: { any(target_os = "illumos", target_os = "solaris") },
         apple: { target_vendor = "apple" },
-        rustls: { feature = "ring" }
+        rustls: { any(feature = "aws-lc-rs", feature = "ring") }
     }
 }

--- a/compio-quic/src/builder.rs
+++ b/compio-quic/src/builder.rs
@@ -239,8 +239,13 @@ mod verifier {
                 rustls::crypto::CryptoProvider::get_default()
                     .map(|provider| provider.signature_verification_algorithms)
                     .unwrap_or_else(|| {
-                        #[cfg(feature = "ring")]
-                        use rustls::crypto::ring::default_provider;
+                        cfg_if::cfg_if! {
+                            if #[cfg(feature = "aws-lc-rs")] {
+                                use rustls::crypto::aws_lc_rs::default_provider;
+                            } else if #[cfg(feature = "ring")] {
+                                use rustls::crypto::ring::default_provider;
+                            }
+                        }
                         default_provider().signature_verification_algorithms
                     }),
             )

--- a/compio-tls/Cargo.toml
+++ b/compio-tls/Cargo.toml
@@ -51,6 +51,7 @@ native-tls-vendored = ["native-tls/vendored"]
 py-dynamic-openssl = ["dep:compio-py-dynamic-openssl"]
 
 ring = ["rustls", "rustls/ring", "futures-rustls/ring"]
+aws-lc-rs = ["rustls", "rustls/aws_lc_rs", "futures-rustls/aws_lc_rs"]
 
 read_buf = ["compio-buf/read_buf", "compio-io/read_buf", "rustls?/read_buf"]
 nightly = ["read_buf"]

--- a/compio-ws/Cargo.toml
+++ b/compio-ws/Cargo.toml
@@ -46,6 +46,7 @@ rustls-platform-verifier = ["rustls", "dep:rustls-platform-verifier"]
 rustls-native-certs = ["rustls", "dep:rustls-native-certs"]
 webpki-roots = ["rustls", "dep:webpki-roots"]
 ring = ["compio-tls/ring"]
+aws-lc-rs = ["compio-tls/aws-lc-rs"]
 
 io-compat = ["dep:futures-util", "dep:pin-project-lite"]
 

--- a/compio/Cargo.toml
+++ b/compio/Cargo.toml
@@ -167,6 +167,12 @@ windows-gro = ["compio-quic?/windows-gro"]
 # TLS
 py-dynamic-openssl = ["tls", "compio-tls/py-dynamic-openssl"]
 ring = ["tls", "compio-tls/ring", "compio-quic?/ring", "compio-ws?/ring"]
+aws-lc-rs = [
+    "tls",
+    "compio-tls/aws-lc-rs",
+    "compio-quic?/aws-lc-rs",
+    "compio-ws?/aws-lc-rs",
+]
 native-tls-vendored = [
     "compio-tls/native-tls-vendored",
     "compio-ws?/native-tls-vendored",


### PR DESCRIPTION
Recently, I've heard that `aws-lc-rs` has improved its build system. I would like to restore the support, but without `fips` support.

@George-Miao could you test if your nix config is OK with this PR?