### PR TITLE
fix(executor): uaf

### DIFF
--- a/.github/workflows/ci_test_executor.yml
+++ b/.github/workflows/ci_test_executor.yml
@@ -53,17 +53,19 @@ jobs:
       - uses: taiki-e/install-action@nextest
       - name: Test loom on ${{ matrix.setup.os }} nightly ${{ matrix.setup.target }}
         shell: bash
-        env:
-          LOOM_MAX_PREEMPTIONS: 4
         run: |
           set -ex
 
           cargo miri test \
-            --test executor \
-            -p compio-executor
+            -p compio-executor \
+            --test executor
 
-          RUSTFLAGS="--cfg loom" cargo nextest run \
-            --no-fail-fast \
-            --failure-output final \
+          RUSTFLAGS="--cfg loom" \
+          LOOM_LOCATION=1 \
+          LOOM_LOG=info,compio_executor=trace \
+          cargo nextest run \
+            -p compio-executor \
+            --features enable_log \
             --test loom \
-            -p compio-executor
+            --no-fail-fast \
+            --failure-output final

--- a/compio-executor/Cargo.toml
+++ b/compio-executor/Cargo.toml
@@ -25,7 +25,6 @@ slotmap = { workspace = true }
 loom = { version = "0.7", features = ["checkpoint"] }
 
 [dev-dependencies]
-compio-log = { workspace = true, features = ["enable_log"] }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
 
 [target.'cfg(unix)'.dev-dependencies]
@@ -33,6 +32,7 @@ nix = { workspace = true, features = ["resource", "signal"] }
 
 [features]
 notify-always = []
+enable_log = ["compio-log/enable_log"]
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(loom)'] }

--- a/compio-executor/src/join_handle.rs
+++ b/compio-executor/src/join_handle.rs
@@ -1,4 +1,6 @@
 use std::{
+    error::Error,
+    fmt::Display,
     marker::PhantomData,
     mem::ManuallyDrop,
     panic::resume_unwind,
@@ -7,7 +9,7 @@ use std::{
     task::{Context, Poll},
 };
 
-use compio_log::instrument;
+use compio_log::{instrument, trace};
 
 use crate::{Panic, task::Task};
 
@@ -19,7 +21,7 @@ use crate::{Panic, task::Task};
 #[derive(Debug)]
 #[repr(transparent)]
 pub struct JoinHandle<T> {
-    task: Task,
+    task: Option<Task>,
     _marker: PhantomData<T>,
 }
 
@@ -35,14 +37,14 @@ impl<T> Unpin for JoinHandle<T> {}
 impl<T> JoinHandle<T> {
     pub(crate) fn new(task: Task) -> Self {
         Self {
-            task,
+            task: Some(task),
             _marker: PhantomData,
         }
     }
 
     /// Cancel the task and wait for the result, if any.
     pub async fn cancel(self) -> Option<T> {
-        self.task.cancel(false);
+        self.task.as_ref()?.cancel(false);
         self.await.ok()
     }
 
@@ -91,14 +93,35 @@ impl JoinError {
     }
 }
 
+impl Display for JoinError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            JoinError::Cancelled => write!(f, "Task was cancelled"),
+            JoinError::Panicked(_) => write!(f, "Task has panicked"),
+        }
+    }
+}
+
+impl Error for JoinError {}
+
 impl<T> Future for JoinHandle<T> {
     type Output = Result<T, JoinError>;
 
-    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        unsafe { self.task.poll(cx) }.map(|res| match res {
-            Some(Ok(res)) => Ok(res),
-            Some(Err(e)) => Err(JoinError::Panicked(e)),
-            None => Err(JoinError::Cancelled),
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        instrument!(compio_log::Level::TRACE, "JoinHandle::poll");
+
+        let task = self.task.as_ref().expect("Cannot poll after completion");
+
+        unsafe { task.poll(cx) }.map(|res| {
+            trace!("Poll ready");
+
+            self.task = None;
+
+            match res {
+                Some(Ok(res)) => Ok(res),
+                Some(Err(e)) => Err(JoinError::Panicked(e)),
+                None => Err(JoinError::Cancelled),
+            }
         })
     }
 }
@@ -107,6 +130,8 @@ impl<T> Drop for JoinHandle<T> {
     fn drop(&mut self) {
         instrument!(compio_log::Level::TRACE, "JoinHandle::drop");
 
-        self.task.cancel(true);
+        if let Some(task) = self.task.as_ref() {
+            task.cancel(true);
+        }
     }
 }

--- a/compio-executor/src/queue.rs
+++ b/compio-executor/src/queue.rs
@@ -7,7 +7,7 @@ use crate::{Shared, task::Task, util::assert_not_impl};
 
 new_key_type! { pub struct TaskId; }
 
-use compio_log::instrument;
+use compio_log::{instrument, trace};
 use slotmap::SlotMap;
 
 use crate::UnsafeCell;
@@ -78,11 +78,14 @@ impl TaskQueue {
     ///
     /// Must only be called by `Executor`.
     pub unsafe fn clear(&self) {
-        instrument!(compio_log::Level::DEBUG, "clear");
+        instrument!(compio_log::Level::DEBUG, "TaskQueue::clear");
+
+        trace!("Clearing");
 
         unsafe {
             self.with_inner(|inner| {
                 if inner.map.is_empty() {
+                    trace!("Map empty, return");
                     return;
                 }
 
@@ -92,8 +95,10 @@ impl TaskQueue {
                 inner.cold.tail = None;
 
                 for task in inner.map.drain().filter_map(|(_, i)| i.task) {
-                    task.unset_shared();
+                    trace!(?task, "Dropping task");
+
                     task.drop();
+                    task.wait_for_scheduling();
                 }
 
                 debug_assert!(inner.map.is_empty());

--- a/compio-executor/src/task/local.rs
+++ b/compio-executor/src/task/local.rs
@@ -68,8 +68,6 @@ impl<'a> Local<'a> {
     }
 
     pub unsafe fn poll<T>(&self, cx: &mut Context<'_>) -> Poll<Option<PanicResult<T>>> {
-        instrument!(compio_log::Level::TRACE, "Local::poll", id = ?self.header().id);
-
         let state = self.state();
         trace!(?state);
 

--- a/compio-executor/src/task/mod.rs
+++ b/compio-executor/src/task/mod.rs
@@ -13,7 +13,7 @@ use compio_log::{debug, instrument, trace};
 use compio_send_wrapper::SendWrapper;
 
 use crate::{
-    AtomicPtr, PanicResult, Shared, UnsafeCell, hint,
+    AtomicPtr, PanicResult, Shared, UnsafeCell,
     queue::TaskId,
     task::{
         local::Local,
@@ -237,25 +237,24 @@ impl Task {
             trace!("Run future");
             let res = unsafe { (header.vtable.run_future)(self.0, ctx) };
             if res.is_ready() {
-                debug!("Ready");
-                let mut state = header.state.finish_running();
+                debug!("Task finished");
+                let state = header.state.finish_running();
 
-                // JoinHandle is polling the state when we're running and has not finished
-                // cloning yet. It will stop as soon as they found out that we have
-                // finished running or when finished cloning, so it's fine to busy spin here for
-                // a short burst.
-                while state.is_setting_waker() {
-                    hint::spin_loop();
-                    state = header.state.load::<Strong>();
-                }
+                trace!(?state, "Try to wake up JoinHandle");
 
-                if state.has_waker() {
+                // JoinHandle will not set another waker after this check since we have set the
+                // state to completed before with Release order: they will either observe it and
+                // get the result, or not observe it and enter SETTING_WAKER critical section.
+                if state.has_waker() && !state.is_setting_waker() {
+                    trace!("Waking up JoinHandle");
                     header
                         .waker
                         .with_mut(|ptr| unsafe { (*ptr).assume_init_ref() }.wake_by_ref());
                 }
+            } else {
+                trace!("Pending");
             }
-            trace!("Pending");
+
             res
         })
     }
@@ -265,8 +264,14 @@ impl Task {
     /// This function can only be called by `JoinHandle`.
     pub unsafe fn poll<T>(&self, cx: &mut Context<'_>) -> Poll<Option<PanicResult<T>>> {
         match self.view() {
-            Ok(local) => unsafe { local.poll(cx) },
-            Err(remote) => unsafe { remote.poll(cx) },
+            Ok(local) => unsafe {
+                instrument!(compio_log::Level::TRACE, "Task::poll", id = ?self.header().id, remote = false);
+                local.poll(cx)
+            },
+            Err(remote) => unsafe {
+                instrument!(compio_log::Level::TRACE, "Task::poll", id = ?self.header().id, remote = true);
+                remote.poll(cx)
+            },
         }
     }
 
@@ -275,8 +280,8 @@ impl Task {
     // future, result and/or waker, but the memory will be deallocated when the
     // reference count reaches 0.
     //
-    // The shared pointer is kept valid until the Executor itself is dropped, to
-    // avoid use-after-free issues with concurrent wakers.
+    // The shared pointer is also set to null to prevent any further scheduling or
+    // waker setting.
     //
     // # Safety
     //
@@ -287,11 +292,14 @@ impl Task {
         let header = self.header();
         debug_assert!(
             header.tracker.valid(),
-            "drop_future should only be called by Executor"
+            "drop should only be called by Executor"
         );
         let state = header.state.set_dropped();
 
+        header.shared.store(ptr::null_mut(), Release);
+
         if !state.is_completed() {
+            trace!("Dropping future");
             // The task has not completed yet, drop future
             unsafe { (header.vtable.drop_future)(self.0, false) };
         }
@@ -300,23 +308,21 @@ impl Task {
         // afterwards and drop the waker. Otherwise, we drop the waker here if
         // it exists.
         if state.has_waker() && !state.is_setting_waker() {
+            trace!("Dropping waker");
             crate::panic_guard!();
 
             header
                 .waker
                 .with_mut(|ptr| unsafe { drop_in_place(ptr.cast::<Waker>()) });
         }
+
+        trace!("Completed");
     }
 
-    /// Unset the shared pointer to prevent wakers from accessing it after
-    /// Executor drop. This must only be called by the Executor during its
-    /// drop.
-    pub(crate) fn unset_shared(&self) {
+    /// Wait for wakers to finish scheduling, if any. This is necessary for
+    /// `Executor` to drop `Shared` since scheduling requires it.
+    pub(crate) fn wait_for_scheduling(&self) {
         let header = self.header();
-
-        // Set shared pointer to null with Release ordering so concurrent schedulers see
-        // it
-        header.shared.store(ptr::null_mut(), Release);
 
         // Wait for any ongoing scheduling to complete.
         // We MUST do this to prevent use-after-free when we drop Shared.
@@ -337,12 +343,10 @@ impl Task {
     #[inline(always)]
     fn view(&self) -> Result<Local<'_>, Remote<'_>> {
         if self.header().tracker.valid() {
-            trace!("Local view");
             // SAFETY: We have checked that the tracker is valid, so this must be the same
             // thread as the task allocation is created on.
             Ok(unsafe { Local::new(self.0) })
         } else {
-            trace!("Remote view");
             Err(Remote::new(self.0))
         }
     }
@@ -352,19 +356,31 @@ impl Drop for Task {
     fn drop(&mut self) {
         let header = self.header();
         let state = header.state.dec();
-        trace!(old = ?state, "Task dropped");
+        trace!(?state, "Task dropped");
         if state.count() > 1 {
             return;
         };
 
+        crate::panic_guard!();
+
         debug_assert!(state.is_completed() | state.is_cancelled());
         debug_assert!(!state.is_setting_waker());
-        debug_assert!(!state.has_waker());
 
         // If the result is still present, drop it now
         // This happens when JoinHandle was dropped/detached without taking the result
         if state.has_result() {
             unsafe { (header.vtable.drop_future)(self.0, true) };
+        }
+
+        // If the waker is still present, drop it now
+        // This happens when the Task is dropped when JoinHandle was setting waker
+        // remotely.
+        if state.has_waker() {
+            trace!("Dropping waker");
+
+            header
+                .waker
+                .with_mut(|ptr| unsafe { drop_in_place(ptr.cast::<Waker>()) });
         }
 
         trace!("Task deallocated");

--- a/compio-executor/src/task/remote.rs
+++ b/compio-executor/src/task/remote.rs
@@ -1,7 +1,6 @@
 use std::{
     marker::PhantomData,
     mem::MaybeUninit,
-    ops::ControlFlow,
     ptr::NonNull,
     sync::atomic::Ordering,
     task::{Context, Poll},
@@ -79,16 +78,16 @@ impl<'a> Remote<'a> {
     }
 
     pub unsafe fn poll<T>(&self, cx: &mut Context<'_>) -> Poll<Option<PanicResult<T>>> {
-        instrument!(compio_log::Level::TRACE, "Remote::poll", id = ?self.header().id);
         let mut state = self.state();
 
         loop {
             trace!(?state);
 
-            debug_assert!(state.has_result() || !state.is_completed() || state.is_cancelled());
+            debug_assert!(state.has_result() || state.is_cancelled() || !state.is_completed());
 
             // The task is completed, take the result
             if state.has_result() {
+                trace!("Has result");
                 self.header().state.set_has_result::<Strong, false>();
 
                 let mut res = MaybeUninit::<PanicResult<T>>::uninit();
@@ -96,78 +95,54 @@ impl<'a> Remote<'a> {
                 unsafe { (self.header().vtable.take_result)(self.ptr, target) };
 
                 break Poll::Ready(Some(unsafe { res.assume_init() }));
-            }
-
-            // The task is cancelled without result, return None
-            if state.is_cancelled() {
+            } else if state.is_cancelled() {
+                trace!("Task cancelled");
+                // The task is cancelled without result, return None
                 break Poll::Ready(None);
             }
 
-            // Task is not completed yet, set up waker
-            if !state.is_completed() {
-                if state.has_waker()
-                    && let Some(poll) = self.header().waker.with(|waker| {
-                        cx.waker()
-                            .will_wake(unsafe { (&*waker).assume_init_ref() })
-                            .then_some(Poll::Pending)
-                    })
-                {
-                    break poll;
-                };
+            state = self.header().state.start_setting_waker();
 
-                let res = self.header().waker.with_mut(|ptr| {
-                    crate::panic_guard!();
+            if state.has_result() {
+                // It's waiting for us to stop. Finish setting waker here.
+                debug_assert!(state.is_completed());
+                state = self.header().state.finish_setting_waker::<false>();
 
-                    state = self.header().state.start_setting_waker();
+                continue;
+            } else if state.is_cancelled() {
+                // The task was cancelled after last check
+                self.header().state.finish_setting_waker::<false>();
 
-                    // The task was cancelled after last check
-                    if state.is_cancelled() {
-                        self.header().state.finish_setting_waker::<false>();
-
-                        return ControlFlow::Break(Poll::Ready(None));
-                    }
-
-                    // SAFETY: We're in SETTING_WAKER state, Executor will not access the waker
-                    // until we're finished.
-                    let waker = unsafe { &mut *ptr };
-
-                    if state.has_waker() {
-                        unsafe { waker.assume_init_drop() };
-                    }
-
-                    // Executor finished running after last check
-                    if state.is_completed() && state.has_result() {
-                        // It's waiting for us to stop. Finish setting waker here.
-                        self.header().state.finish_setting_waker::<false>();
-
-                        return ControlFlow::Continue(state);
-                    }
-
-                    // We're in the critical section, executor will wait for us to finish
-                    waker.write(cx.waker().clone());
-
-                    let state = self.header().state.finish_setting_waker::<true>();
-
-                    // Executor dropped the task during setting waker
-                    if state.is_cancelled() {
-                        // Executor has cancelled the task - there will be no more access to the
-                        // waker, so it's fine to just drop it here.
-                        unsafe { waker.assume_init_drop() };
-
-                        self.header().state.set_has_waker::<Strong, false>();
-
-                        ControlFlow::Break(Poll::Ready(None))
-                    } else {
-                        ControlFlow::Break(Poll::Pending)
-                    }
-                });
-                match res {
-                    // The task was completed during setting waker, loop again so that we can
-                    // retrieve the result
-                    ControlFlow::Continue(s) => state = s,
-                    ControlFlow::Break(poll) => break poll,
-                }
+                break Poll::Ready(None);
+            } else if state.has_waker()
+                && self
+                    .header()
+                    .waker
+                    .with(|waker| cx.waker().will_wake(unsafe { (&*waker).assume_init_ref() }))
+            {
+                // Waker is already up-to-date, leave it in place.
+                self.header().state.finish_setting_waker::<true>();
+                break Poll::Pending;
             }
+
+            self.header().waker.with_mut(|ptr| {
+                crate::panic_guard!();
+
+                // SAFETY: We're in SETTING_WAKER state, Executor will not access the waker
+                // until we're finished.
+                let waker = unsafe { &mut *ptr };
+
+                if state.has_waker() {
+                    unsafe { waker.assume_init_drop() };
+                }
+
+                // We're in the critical section, executor will wait for us to finish
+                waker.write(cx.waker().clone());
+            });
+
+            self.header().state.finish_setting_waker::<true>();
+
+            break Poll::Pending;
         }
     }
 
@@ -176,6 +151,7 @@ impl<'a> Remote<'a> {
     }
 
     fn state(&self) -> Snapshot {
+        trace!("Load state");
         self.header().state.load::<Strong>()
     }
 }

--- a/compio-executor/src/task/state.rs
+++ b/compio-executor/src/task/state.rs
@@ -47,7 +47,7 @@ impl Debug for State {
 
 impl Debug for Snapshot {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("State")
+        f.debug_struct("Snapshot")
             .field("count", &self.count())
             .field("scheduling", &self.is_scheduling())
             .field("scheduled", &self.is_scheduled())
@@ -146,7 +146,7 @@ impl State {
     }
 
     pub(crate) fn finish_setting_waker<const SUCCESS: bool>(&self) -> Snapshot {
-        trace!("finish_setting_waker");
+        trace!(SUCCESS, "finish_setting_waker");
 
         let flag = if SUCCESS {
             NOT_SETTING_WAKER | HAS_WAKER
@@ -172,20 +172,20 @@ impl State {
     }
 
     pub(crate) fn inc(&self) -> Snapshot {
-        let old = Snapshot(self.0.fetch_add(RC_UNIT, Strong::RELEASE));
-        trace!(?old, "inc");
-        if old.count() == RC_MAX {
+        let state = Snapshot(self.0.fetch_add(RC_UNIT, Strong::RELEASE));
+        trace!(?state, "inc");
+        if state.count() == RC_MAX {
             abort()
         }
-        old
+        state
     }
 
     /// Decrease the reference count by one and return the old state.
     pub(crate) fn dec(&self) -> Snapshot {
-        let old = Snapshot(self.0.fetch_sub(RC_UNIT, Strong::ACQ_REL));
-        trace!(?old, "dec");
-        debug_assert!(old.count() >= 1, "Reference count underflow");
-        old
+        let state = Snapshot(self.0.fetch_sub(RC_UNIT, Strong::ACQ_REL));
+        trace!(?state, "dec");
+        debug_assert!(state.count() >= 1, "Reference count underflow");
+        state
     }
 }
 

--- a/compio-executor/tests/executor.rs
+++ b/compio-executor/tests/executor.rs
@@ -6,15 +6,15 @@ use std::{
 };
 
 use compio_executor::{Executor, JoinError, JoinHandle};
-use tracing_subscriber::EnvFilter;
 
 std::thread_local! {
     static EXE: Executor = Executor::new();
 }
 
 fn setup_log() {
+    #[cfg(feature = "enable_log")]
     tracing_subscriber::fmt()
-        .with_env_filter(EnvFilter::from_default_env())
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
         .try_init()
         .ok();
 }

--- a/compio-executor/tests/loom.rs
+++ b/compio-executor/tests/loom.rs
@@ -1,12 +1,13 @@
 #![cfg(loom)]
 
 use std::{
-    future::Future,
+    future::{Future, ready},
     pin::Pin,
     task::{Context, Poll, Waker},
 };
 
 use compio_executor::Executor;
+use compio_log::info;
 use loom::thread;
 
 fn block_on<F: Future + 'static>(exe: &Executor, f: F) -> F::Output {
@@ -102,5 +103,32 @@ fn test_cross_thread_wake() {
 
         let handle = exe.spawn(CrossThreadWake(false));
         block_on(&exe, handle).unwrap();
+    });
+}
+
+#[test]
+fn test_join_while_complete() {
+    loom::model(|| {
+        let exe = Executor::new();
+
+        let handle = exe.spawn(ready(0));
+
+        let thread1 = thread::spawn(move || {
+            let cx = &mut Context::from_waker(Waker::noop());
+            let mut f = std::pin::pin!(handle);
+            loop {
+                info!("Poll from thread 1");
+                if let Poll::Ready(res) = f.as_mut().poll(cx) {
+                    return res;
+                }
+                thread::yield_now();
+            }
+        });
+
+        while exe.tick() {
+            thread::yield_now();
+        }
+
+        let _ = thread1.join().unwrap();
     });
 }

--- a/flake.nix
+++ b/flake.nix
@@ -34,9 +34,10 @@
             gdb
             lldb
             openssl
+            python315
             pkg-config
             cargo-nextest
-            python315
+            cargo-flamegraph
             (rust-bin.selectLatestNightlyWith (
               toolchain:
               toolchain.default.override {


### PR DESCRIPTION
This PR solves an UAF bug found by @fantix, and optimizes waking-up logic when a task has finished running and the JoinHandle is remotely polling at the same time.
