### PR TITLE
feat(driver): buffer pool allocator

### DIFF
--- a/compio-driver/Cargo.toml
+++ b/compio-driver/Cargo.toml
@@ -64,6 +64,9 @@ crossbeam-queue = { workspace = true }
 libc = { workspace = true }
 nix = { workspace = true, features = ["fs"] }
 
+[dev-dependencies]
+nix = { workspace = true, features = ["mman"] }
+
 [build-dependencies]
 cfg_aliases = { workspace = true }
 
@@ -88,3 +91,6 @@ iocp-wait-packet = []
 once_cell_try = []
 proc_macro_diagnostic = ["dep:compile_warning"]
 nightly = ["once_cell_try", "proc_macro_diagnostic"]
+
+[[test]]
+name = "buffer_pool"

--- a/compio-driver/src/buffer_pool.rs
+++ b/compio-driver/src/buffer_pool.rs
@@ -1,0 +1,435 @@
+use std::{
+    cell::UnsafeCell,
+    fmt::Debug,
+    io,
+    mem::{self, MaybeUninit},
+    ops::{Deref, DerefMut},
+    ptr::{self, NonNull},
+    rc::{Rc, Weak},
+    slice,
+};
+
+use compio_buf::{IoBuf, IoBufMut, SetLen};
+
+use crate::sys::BufControl;
+
+/// Trait used to allocate buffers for compio-driver's buffer pool.
+///
+/// Default implementation is [`BoxAllocator`], which uses [`Box`] to allocate
+/// and deallocate each buffer.
+pub trait BufferAllocator {
+    /// Allocate a chunk of memory with `len`.
+    fn allocate(len: u32) -> NonNull<MaybeUninit<u8>>;
+
+    /// Deallocate a chunk of memory.
+    ///
+    /// # Safety
+    ///
+    /// The pointer passed in must be previously allocated by this allocator.
+    unsafe fn deallocate(ptr: NonNull<MaybeUninit<u8>>, len: u32);
+}
+
+/// Default implementation of [`BufferAllocator`].
+pub struct BoxAllocator;
+
+// Default implementation of [`BufferAllocator`]
+impl BufferAllocator for BoxAllocator {
+    fn allocate(len: u32) -> NonNull<MaybeUninit<u8>> {
+        let ptr = Box::into_raw(Box::<[u8]>::new_uninit_slice(len as usize)).cast();
+        // SAFETY: Creating `NonNull` from `Box`
+        unsafe { NonNull::new_unchecked(ptr) }
+    }
+
+    unsafe fn deallocate(ptr: NonNull<MaybeUninit<u8>>, len: u32) {
+        let ptr = ptr::slice_from_raw_parts_mut(ptr.as_ptr(), len as usize);
+        // SAFETY: Caller guarantees the pointer was allocated by us with `len`
+        _ = unsafe { Box::from_raw(ptr) };
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct BufferAlloc {
+    allocate: fn(len: u32) -> NonNull<MaybeUninit<u8>>,
+    deallocate: unsafe fn(ptr: NonNull<MaybeUninit<u8>>, len: u32),
+}
+
+impl BufferAlloc {
+    pub fn new<A: BufferAllocator>() -> Self {
+        Self {
+            allocate: A::allocate,
+            deallocate: A::deallocate,
+        }
+    }
+}
+
+/// A buffer pointer without length part.
+pub(crate) type BufPtr = NonNull<MaybeUninit<u8>>;
+/// A buffer slot. It's always 1-pointer sized thanks to niche optimization.
+pub(crate) type Slot = Option<BufPtr>;
+
+const _: () = assert!(size_of::<Slot>() == size_of::<usize>());
+
+/// A buffer pool.
+///
+/// This type by itself does nothing, and should only be used by `*Managed` ops.
+#[derive(Clone)]
+pub struct BufferPool {
+    shared: Weak<Shared>,
+}
+
+#[repr(transparent)]
+#[derive(Debug)]
+pub(crate) struct BufferPoolRoot {
+    shared: Rc<Shared>,
+}
+
+/// A unique reference to a buffer within the buffer pool.
+///
+/// Dropping this type will reset the buffer back to the pool instead of
+/// releasing buffer's memory.
+#[derive(Debug)]
+pub struct BufferRef {
+    /// Allocator to deallocate the buffer in case the driver is dropped.
+    alloc: BufferAlloc,
+    /// Initialized length of the buffer, set with [`SetLen`]
+    len: u32,
+    /// User-set capacity, default to `full_cap`
+    cap: u32,
+    /// Full capacity of the buffer, used to release memory if driver (buffer
+    /// pool) is dropped
+    full_cap: u32,
+    /// Weak handle of the buffer pool
+    shared: Weak<Shared>,
+    /// Pointer of the buffer
+    ptr: BufPtr,
+    /// Buffer id (index within the Vec)
+    buffer_id: u16,
+}
+
+#[repr(transparent)]
+struct Shared {
+    inner: UnsafeCell<Inner>,
+}
+
+struct Inner {
+    /// Allocator of the buffers
+    alloc: BufferAlloc,
+
+    /// Control block corresponds to each driver
+    ctrl: BufControl,
+
+    /// Size of each buffer
+    size: u32,
+
+    /// Buffer pointers
+    bufs: Vec<Slot>,
+}
+
+impl BufferPoolRoot {
+    pub(crate) fn new(
+        driver: &mut crate::Driver,
+        alloc: BufferAlloc,
+        num_of_bufs: u16,
+        buffer_size: usize,
+        flags: u16,
+    ) -> io::Result<Self> {
+        let size: u32 = buffer_size.try_into().map_err(|_| {
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "Buffer size too large. Should be able to fit into u32.",
+            )
+        })?;
+        let bufs = (0..num_of_bufs.next_power_of_two())
+            .map(|_| Some((alloc.allocate)(size)))
+            .collect::<Vec<_>>();
+        let ctrl = unsafe { BufControl::new(driver, &bufs, size, flags) }?;
+
+        Ok(Self {
+            shared: Shared {
+                inner: Inner {
+                    alloc,
+                    ctrl,
+                    size,
+                    bufs,
+                }
+                .into(),
+            }
+            .into(),
+        })
+    }
+
+    /// Release the buffer pool and deallocate all buffers.
+    ///
+    /// If the buffer pool root is dropped without calling this function,
+    /// everything will be leaked and there will be no chance to recover them
+    /// back, except those have been taken by [`BufferRef`], which will be
+    /// released when they're dropped.
+    ///
+    /// If the control block failed to release, this function will return an io
+    /// Error without deallocating buffers, and it's possible to retry.
+    ///
+    /// # Safety
+    ///
+    /// [`BufferPoolRoot`] must not be used after `release` is called and
+    /// returned successfully. Only thing that's safe to do afterwards is to
+    /// drop it.
+    pub(crate) unsafe fn release(&mut self, driver: &mut crate::Driver) -> io::Result<()> {
+        unsafe {
+            self.shared.with(|inner| {
+                inner.ctrl.release(driver)?;
+                for buf in mem::take(&mut inner.bufs).into_iter().flatten() {
+                    // Control is successfully released, now deallocate buffers
+                    (inner.alloc.deallocate)(buf, inner.size)
+                }
+                io::Result::Ok(())
+            })
+        }?;
+
+        Ok(())
+    }
+
+    pub(crate) fn get_pool(&self) -> BufferPool {
+        BufferPool {
+            shared: Rc::downgrade(&self.shared),
+        }
+    }
+
+    pub(crate) fn is_unique(&self) -> bool {
+        Rc::strong_count(&self.shared) == 1
+    }
+}
+
+impl Debug for BufferPool {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if let Some(shared) = self.shared.upgrade() {
+            f.debug_struct("BufferPool")
+                .field("shared", &shared)
+                .finish()
+        } else {
+            f.debug_struct("BufferPool")
+                .field("shared", &"<dropped>")
+                .finish()
+        }
+    }
+}
+
+impl Debug for Shared {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        struct Buf {
+            ptr: BufPtr,
+        }
+
+        impl Debug for Buf {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                write!(f, "Buf<{:p}>", self.ptr)
+            }
+        }
+
+        struct BuffersDebug<'a> {
+            buffers: &'a [Slot],
+        }
+
+        impl Debug for BuffersDebug<'_> {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                f.debug_list()
+                    .entries(self.buffers.iter().map(|buf| buf.map(|ptr| Buf { ptr })))
+                    .finish()
+            }
+        }
+
+        unsafe {
+            self.with(|inner| {
+                let buffers = BuffersDebug {
+                    buffers: &inner.bufs,
+                };
+                f.debug_struct("Shared")
+                    .field("control", &inner.ctrl)
+                    .field("size", &inner.size)
+                    .field("buffers", &buffers)
+                    .finish()
+            })
+        }
+    }
+}
+
+impl BufferPool {
+    /// Pop an available buffer from the pool with given capacity.
+    ///
+    /// This operation is not supported on io-uring driver and will always
+    /// return [`Unsupported`].
+    ///
+    /// [`Unsupported`]: io::ErrorKind::Unsupported
+    pub fn pop(&self) -> io::Result<BufferRef> {
+        let buffer_id = unsafe { self.with(|inner| inner.ctrl.pop()) }??;
+
+        Ok(self.take(buffer_id)?.expect("Buffer should be available"))
+    }
+
+    /// Take the indicated buffer from the pool.
+    ///
+    /// Returns `None` if the buffer is not reset back yet or does not exist.
+    pub fn take(&self, buffer_id: u16) -> io::Result<Option<BufferRef>> {
+        let shared = self.shared()?;
+        let Some(ptr) = shared.take(buffer_id) else {
+            return Ok(None);
+        };
+        let cap = shared.len();
+
+        Ok(Some(BufferRef {
+            alloc: shared.alloc(),
+            len: 0,
+            cap,
+            full_cap: cap,
+            shared: Rc::downgrade(&shared),
+            ptr,
+            buffer_id,
+        }))
+    }
+
+    /// Reset the `buffer_id` so that it's available for kernel to use, return
+    /// whether a buffer has been reset.
+    ///
+    /// This is the same as `take(buffer_id)` and immediately drop it.
+    pub fn reset(&self, buffer_id: u16) -> io::Result<bool> {
+        let shared = self.shared()?;
+        let Some(buf) = shared.take(buffer_id) else {
+            return Ok(false);
+        };
+        shared.reset(buffer_id, buf);
+        Ok(true)
+    }
+
+    fn shared(&self) -> io::Result<Rc<Shared>> {
+        self.shared
+            .upgrade()
+            .ok_or_else(|| io::Error::other("The driver has been dropped"))
+    }
+
+    /// # Safety
+    ///
+    /// `f` must not access `self` reentrantly
+    unsafe fn with<F, R>(&self, f: F) -> io::Result<R>
+    where
+        F: FnOnce(&mut Inner) -> R,
+    {
+        Ok(unsafe { self.shared()?.with(f) })
+    }
+
+    /// Get the group id of this buffer pool.
+    #[cfg(io_uring)]
+    pub(crate) fn buffer_group(&self) -> io::Result<u16> {
+        unsafe { self.with(|i| i.ctrl.buffer_group()) }
+    }
+
+    /// Test if the buffer pool is an io_uring one.
+    #[cfg(fusion)]
+    pub fn is_io_uring(&self) -> io::Result<bool> {
+        unsafe { self.with(|inner| inner.ctrl.is_io_uring()) }
+    }
+}
+
+impl Shared {
+    /// # Safety
+    ///
+    /// `f` must not access [`Self::inner`] reentrantly
+    #[inline(always)]
+    unsafe fn with<F, R>(&self, f: F) -> R
+    where
+        F: FnOnce(&mut Inner) -> R,
+    {
+        f(unsafe { &mut *self.inner.get() })
+    }
+
+    fn alloc(&self) -> BufferAlloc {
+        unsafe { self.with(|inner| inner.alloc) }
+    }
+
+    fn take(&self, buffer_id: u16) -> Option<BufPtr> {
+        unsafe { self.with(|inner| inner.bufs.get_mut(buffer_id as usize)?.take()) }
+    }
+
+    fn reset(&self, buffer_id: u16, ptr: BufPtr) {
+        unsafe {
+            self.with(|inner| {
+                inner.bufs[buffer_id as usize] = Some(ptr);
+                inner.ctrl.reset(buffer_id, ptr, inner.size);
+            })
+        }
+    }
+
+    fn len(&self) -> u32 {
+        unsafe { self.with(|inner| inner.size) }
+    }
+}
+
+impl BufferRef {
+    /// Set the capacity of this buffer.
+    ///
+    /// This does nothing if `cap` is greater than underlying buffer's
+    /// length.
+    pub fn with_capacity(mut self, cap: usize) -> Self {
+        self.set_capacity(cap);
+        self
+    }
+
+    /// Set the capacity of this buffer.
+    ///
+    /// This does nothing if `cap` is greater than underlying buffer's
+    /// length or equals 0.
+    pub fn set_capacity(&mut self, cap: usize) {
+        if cap == 0 {
+            return;
+        }
+        self.cap = (cap as u32).min(self.full_cap);
+        self.len = self.len.min(self.cap);
+    }
+}
+
+impl Deref for BufferRef {
+    type Target = [u8];
+
+    fn deref(&self) -> &Self::Target {
+        // SAFETY: `SetLen` guarantees the range is initialized
+        unsafe { slice::from_raw_parts(self.ptr.as_ptr().cast(), self.len as usize) }
+    }
+}
+
+impl DerefMut for BufferRef {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        // SAFETY: `SetLen` guarantees the range is initialized
+        unsafe { slice::from_raw_parts_mut(self.ptr.as_ptr() as _, self.len as usize) }
+    }
+}
+
+impl IoBuf for BufferRef {
+    fn as_init(&self) -> &[u8] {
+        self
+    }
+}
+
+impl SetLen for BufferRef {
+    unsafe fn set_len(&mut self, len: usize) {
+        debug_assert!(len <= u32::MAX as usize);
+        self.len = (len as u32).min(self.cap);
+    }
+}
+
+impl IoBufMut for BufferRef {
+    fn as_uninit(&mut self) -> &mut [MaybeUninit<u8>] {
+        // SAFETY: Cap is initialized as the buffer length, and setting it is
+        // is capped at full_cap, so it will never exceed buffer length. Pointer is
+        // not deallocated.
+        unsafe { slice::from_raw_parts_mut(self.ptr.as_ptr(), self.cap as usize) }
+    }
+}
+
+impl Drop for BufferRef {
+    fn drop(&mut self) {
+        if let Some(shared) = self.shared.upgrade() {
+            // If the buffer pool is alive, set the pointer back
+            shared.reset(self.buffer_id, self.ptr);
+        } else {
+            unsafe { (self.alloc.deallocate)(self.ptr, self.full_cap) }
+        }
+    }
+}

--- a/compio-driver/src/lib.rs
+++ b/compio-driver/src/lib.rs
@@ -24,6 +24,7 @@ use std::{
 use compio_buf::BufResult;
 use compio_log::instrument;
 
+mod control;
 mod macros;
 
 mod key;
@@ -47,9 +48,14 @@ pub use sys::{Extra, *};
 mod cancel;
 pub use cancel::*;
 
-mod control;
+mod buffer_pool;
+pub use buffer_pool::{BoxAllocator, BufferAllocator, BufferPool, BufferRef};
 
-use crate::{key::ErasedKey, op::OpCodeFlag};
+use crate::{
+    buffer_pool::{BufferAlloc, BufferPoolRoot},
+    key::ErasedKey,
+    op::OpCodeFlag,
+};
 
 mod sys_slice;
 
@@ -103,6 +109,7 @@ pub struct Proactor {
 
 enum BufferPoolState {
     Uninit {
+        allocator: BufferAlloc,
         num_of_bufs: u16,
         buffer_len: usize,
         flags: u16,
@@ -115,12 +122,14 @@ impl BufferPoolState {
         loop {
             match self {
                 BufferPoolState::Uninit {
+                    allocator,
                     num_of_bufs,
                     buffer_len,
                     flags,
                 } => {
                     *self = BufferPoolState::Init(BufferPoolRoot::new(
                         driver,
+                        *allocator,
                         *num_of_bufs,
                         *buffer_len,
                         *flags,
@@ -161,6 +170,7 @@ impl Proactor {
             driver: Driver::new(builder)?,
             cancel: CancelRegistry::new(),
             buffer_pool: BufferPoolState::Uninit {
+                allocator: builder.buffer_pool_allocator,
                 num_of_bufs: builder.buffer_pool_size,
                 buffer_len: builder.buffer_pool_buffer_len,
                 flags: builder.buffer_pool_flag,
@@ -546,6 +556,7 @@ pub struct ProactorBuilder {
     buffer_pool_size: u16,
     buffer_pool_flag: u16,
     buffer_pool_buffer_len: usize,
+    buffer_pool_allocator: BufferAlloc,
 }
 
 // SAFETY: `RawFd` is thread safe.
@@ -574,6 +585,7 @@ impl ProactorBuilder {
             buffer_pool_size: 8,
             buffer_pool_flag: 0,
             buffer_pool_buffer_len: 8192,
+            buffer_pool_allocator: BufferAlloc::new::<BoxAllocator>(),
         }
     }
 
@@ -693,7 +705,8 @@ impl ProactorBuilder {
     /// Support for io-uring opcodes varies by kernel version. Setting this
     /// will force the driver to check for support of the specified opcodes, and
     /// when any of them are not supported:
-    /// - Fallback to `polling` driver if `fusion` driver is enabled,
+    ///
+    /// - Fallback to `polling` driver if it is enabled, or
     /// - Return an [`Unsupported`] error when building the proactor otherwise.
     ///
     /// # Notes
@@ -720,6 +733,8 @@ impl ProactorBuilder {
     /// Number of buffers in the buffer pool.
     ///
     /// `size` will be rounded up if it's not power of 2.
+    ///
+    /// Default to be `8`.
     pub fn buffer_pool_size(&mut self, size: NonZero<u16>) -> &mut Self {
         self.buffer_pool_size = size.get();
         self
@@ -728,14 +743,39 @@ impl ProactorBuilder {
     /// Flag to be used to initialize buffer pool.
     ///
     /// This is only supported on io-uring driver.
+    ///
+    /// Default to be `0`.
     pub fn buffer_pool_flag(&mut self, flag: u16) -> &mut Self {
         self.buffer_pool_flag = flag;
         self
     }
 
     /// Length of each buffer pool's buffer.
+    ///
+    /// Default to be `8192`.
     pub fn buffer_pool_buffer_len(&mut self, size: usize) -> &mut Self {
         self.buffer_pool_buffer_len = size;
+        self
+    }
+
+    /// Set the allocator for buffer pool.
+    ///
+    /// This is different from the std's unstable `Allocator` trait: it's purely
+    /// static and doesn't take an instance at all. This means implementation
+    /// should be global (e.g., `Global`, `malloc` or `mmap`).
+    ///
+    /// Default to [`BoxAllocator`].
+    ///
+    /// # Note
+    ///
+    /// Default allocator performs [very poor] when using managed i/o on Zen 3,
+    /// possibly due to [a bug related to FSRM]. If you observe such a problem,
+    /// try swap the allocator to a mmap-based one may solve it.
+    ///
+    /// [very poor]: https://github.com/compio-rs/compio/issues/472
+    /// [a bug related to FSRM]: https://bugs.launchpad.net/ubuntu/+source/glibc/+bug/2030515
+    pub fn buffer_pool_allocator<A: BufferAllocator>(&mut self) -> &mut Self {
+        self.buffer_pool_allocator = BufferAlloc::new::<A>();
         self
     }
 

--- a/compio-driver/src/sys/buffer_pool.rs
+++ b/compio-driver/src/sys/buffer_pool.rs
@@ -1,417 +1,75 @@
-use std::{
-    cell::UnsafeCell,
-    fmt::Debug,
-    io,
-    mem::{self, MaybeUninit},
-    ops::{Deref, DerefMut},
-    ptr::{self, NonNull},
-    rc::{Rc, Weak},
-    slice,
-};
+use std::{fmt::Debug, io};
 
-use compio_buf::{IoBuf, IoBufMut, SetLen};
-
-/// A buffer pointer without length part.
-pub(crate) type BufPtr = NonNull<MaybeUninit<u8>>;
-/// A buffer slot. It's always 1-pointer sized thanks to niche optimization.
-pub(crate) type Slot = Option<BufPtr>;
-
-const _: () = assert!(size_of::<Slot>() == size_of::<usize>());
+use crate::buffer_pool::*;
 
 cfg_if::cfg_if! {
     if #[cfg(io_uring)] {
-        use super::imp::BufControl;
-
-        unsafe fn create_buf_control(
-            driver: &mut super::Driver,
-            bufs: &[Slot],
-            buf_len: u32,
-            flags: u16
-        ) -> io::Result<BufControl> {
-            unsafe { BufControl::new(driver, bufs, buf_len, flags) }
-        }
+        use super::imp;
     } else {
-        use fallback::BufControl;
-
-        unsafe fn create_buf_control(
-            _: &mut super::Driver,
-            bufs: &[Slot],
-            _: u32,
-            _: u16
-        ) -> io::Result<BufControl> {
-            Ok(BufControl::new(bufs))
-        }
+        use fallback as imp;
     }
 }
 
-/// A buffer pool.
-///
-/// This type by itself does nothing, and should only be used by `*Managed` ops.
-#[derive(Clone)]
-pub struct BufferPool {
-    shared: Weak<Shared>,
+pub(crate) struct BufControl(imp::BufControl);
+
+impl Debug for BufControl {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
+    }
 }
 
-#[repr(transparent)]
-#[derive(Debug)]
-pub(crate) struct BufferPoolRoot {
-    shared: Rc<Shared>,
-}
-
-/// A unique reference to a buffer within the buffer pool.
-///
-/// Dropping this type will reset the buffer back to the pool instead of
-/// releasing buffer's memory.
-#[derive(Debug)]
-pub struct BufferRef {
-    /// Initialized length of the buffer, set with [`SetLen`]
-    len: u32,
-    /// User-set capacity, default to `full_cap`
-    cap: u32,
-    /// Full capacity of the buffer, used to release memory if driver (buffer
-    /// pool) is dropped
-    full_cap: u32,
-    /// Weak handle of the buffer pool
-    shared: Weak<Shared>,
-    /// Pointer of the buffer
-    ptr: BufPtr,
-    /// Buffer id (index within the Vec)
-    buffer_id: u16,
-}
-
-#[repr(transparent)]
-struct Shared {
-    inner: UnsafeCell<Inner>,
-}
-
-struct Inner {
-    /// Control block corresponds to each driver
-    ctrl: BufControl,
-
-    /// Size of each buffer
-    size: u32,
-
-    /// Buffer pointers
-    bufs: Vec<Slot>,
-}
-
-impl BufferPoolRoot {
-    pub(crate) fn new(
-        driver: &mut crate::Driver,
-        num_of_bufs: u16,
-        buffer_size: usize,
+impl BufControl {
+    pub(crate) unsafe fn new(
+        driver: &mut super::Driver,
+        bufs: &[Slot],
+        buf_len: u32,
         flags: u16,
-    ) -> io::Result<Self> {
-        let size: u32 = buffer_size.try_into().map_err(|_| {
-            io::Error::new(
-                io::ErrorKind::InvalidInput,
-                "Buffer size too large. Should be able to fit into u32.",
-            )
-        })?;
-        let buffers = (0..num_of_bufs.next_power_of_two())
-            .map(|_| {
-                let ptr = Box::into_raw(Box::<[u8]>::new_uninit_slice(buffer_size)).cast();
-                // SAFETY: Creating NonNull from Box
-                Some(unsafe { NonNull::new_unchecked(ptr) })
-            })
-            .collect::<Vec<_>>();
-        let control = unsafe { create_buf_control(driver, &buffers, size, flags) }?;
+    ) -> io::Result<BufControl> {
+        #[cfg(io_uring)]
+        let inner = unsafe { imp::BufControl::new(driver, bufs, buf_len, flags)? };
 
-        Ok(Self {
-            shared: Shared {
-                inner: Inner {
-                    ctrl: control,
-                    size,
-                    bufs: buffers,
-                }
-                .into(),
-            }
-            .into(),
-        })
+        #[cfg(not(io_uring))]
+        let inner = fallback::BufControl::new(bufs);
+
+        _ = (driver, buf_len, flags);
+
+        Ok(Self(inner))
     }
 
-    /// Release the buffer pool and deallocate all buffers.
-    ///
-    /// If the buffer pool root is dropped without calling this function,
-    /// everything will be leaked and there will be no chance to recover them
-    /// back, except those have been taken by [`BufferRef`], which will be
-    /// released when they're dropped.
-    ///
-    /// If the control block failed to release, this function will return an io
-    /// Error without deallocating buffers, and it's possible to retry.
-    ///
-    /// # Safety
-    ///
-    /// [`BufferPoolRoot`] must not be used after `release` is called and
-    /// returned successfully. Only thing that's safe to do afterwards is to
-    /// drop it.
-    pub(crate) unsafe fn release(&mut self, driver: &mut crate::Driver) -> io::Result<()> {
-        let (bufs, size) = unsafe {
-            self.shared.with(|inner| {
-                inner.ctrl.release(driver)?;
-                io::Result::Ok((mem::take(&mut inner.bufs), inner.size))
-            })
-        }?;
-
-        // Control is successfully released, now deallocate buffers
-        for ptr in bufs.into_iter().flatten() {
-            let ptr = ptr::slice_from_raw_parts_mut(ptr.as_ptr(), size as usize);
-            _ = unsafe { Box::from_raw(ptr) };
-        }
-
-        Ok(())
+    pub unsafe fn release(&mut self, driver: &mut crate::Driver) -> io::Result<()> {
+        unsafe { self.0.release(driver) }
     }
 
-    pub(crate) fn get_pool(&self) -> BufferPool {
-        BufferPool {
-            shared: Rc::downgrade(&self.shared),
-        }
+    pub fn pop(&mut self) -> io::Result<u16> {
+        self.0.pop()
     }
 
-    pub(crate) fn is_unique(&self) -> bool {
-        Rc::strong_count(&self.shared) == 1
-    }
-}
-
-impl Debug for BufferPool {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        if let Some(shared) = self.shared.upgrade() {
-            f.debug_struct("BufferPool")
-                .field("shared", &shared)
-                .finish()
-        } else {
-            f.debug_struct("BufferPool")
-                .field("shared", &"<dropped>")
-                .finish()
-        }
-    }
-}
-
-impl Debug for Shared {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        struct Buf {
-            ptr: BufPtr,
-        }
-
-        impl Debug for Buf {
-            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-                write!(f, "Buf<{:p}>", self.ptr)
-            }
-        }
-
-        struct BuffersDebug<'a> {
-            buffers: &'a [Slot],
-        }
-
-        impl Debug for BuffersDebug<'_> {
-            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-                f.debug_list()
-                    .entries(self.buffers.iter().map(|buf| buf.map(|ptr| Buf { ptr })))
-                    .finish()
-            }
-        }
-
-        unsafe {
-            self.with(|inner| {
-                let buffers = BuffersDebug {
-                    buffers: &inner.bufs,
-                };
-                f.debug_struct("Shared")
-                    .field("control", &inner.ctrl)
-                    .field("size", &inner.size)
-                    .field("buffers", &buffers)
-                    .finish()
-            })
-        }
-    }
-}
-
-impl BufferPool {
-    /// Pop an available buffer from the pool with given capacity.
-    ///
-    /// This operation is not supported on io-uring driver and will always
-    /// return [`Unsupported`].
-    ///
-    /// [`Unsupported`]: io::ErrorKind::Unsupported
-    pub fn pop(&self) -> io::Result<BufferRef> {
-        let buffer_id = unsafe { self.with(|inner| inner.ctrl.pop()) }??;
-
-        Ok(self.take(buffer_id)?.expect("Buffer should be available"))
+    pub unsafe fn reset(&mut self, buffer_id: u16, ptr: BufPtr, len: u32) {
+        unsafe { self.0.reset(buffer_id, ptr, len) }
     }
 
-    /// Take the indicated buffer from the pool.
-    ///
-    /// Returns `None` if the buffer is not reset back yet or does not exist.
-    pub fn take(&self, buffer_id: u16) -> io::Result<Option<BufferRef>> {
-        let shared = self.shared()?;
-        let Some(ptr) = shared.take(buffer_id) else {
-            return Ok(None);
-        };
-        let cap = shared.len();
-
-        Ok(Some(BufferRef {
-            len: 0,
-            cap,
-            full_cap: cap,
-            shared: Rc::downgrade(&shared),
-            ptr,
-            buffer_id,
-        }))
-    }
-
-    /// Reset the `buffer_id` so that it's available for kernel to use, return
-    /// whether a buffer has been reset.
-    ///
-    /// This is the same as `take(buffer_id)` and immediately drop it.
-    pub fn reset(&self, buffer_id: u16) -> io::Result<bool> {
-        let shared = self.shared()?;
-        let Some(buf) = shared.take(buffer_id) else {
-            return Ok(false);
-        };
-        shared.reset(buffer_id, buf);
-        Ok(true)
-    }
-
-    fn shared(&self) -> io::Result<Rc<Shared>> {
-        self.shared
-            .upgrade()
-            .ok_or_else(|| io::Error::other("The driver has been dropped"))
-    }
-
-    /// # Safety
-    ///
-    /// `f` must not access `self` reentrantly
-    unsafe fn with<F, R>(&self, f: F) -> io::Result<R>
-    where
-        F: FnOnce(&mut Inner) -> R,
-    {
-        Ok(unsafe { self.shared()?.with(f) })
-    }
-
-    /// Get the group id of this buffer pool.
+    /// Get the buffer group id
     #[cfg(io_uring)]
-    pub(crate) fn buffer_group(&self) -> io::Result<u16> {
-        unsafe { self.with(|i| i.ctrl.buffer_group()) }
+    pub fn buffer_group(&self) -> u16 {
+        self.0.buffer_group()
     }
 
     /// Test if the buffer pool is an io_uring one.
     #[cfg(fusion)]
-    pub fn is_io_uring(&self) -> io::Result<bool> {
-        unsafe { self.with(|inner| inner.ctrl.is_io_uring()) }
+    pub fn is_io_uring(&self) -> bool {
+        self.0.is_io_uring()
     }
 }
 
-impl Shared {
-    /// # Safety
-    ///
-    /// `f` must not access [`Self::inner`] reentrantly
-    #[inline(always)]
-    unsafe fn with<F, R>(&self, f: F) -> R
-    where
-        F: FnOnce(&mut Inner) -> R,
-    {
-        f(unsafe { &mut *self.inner.get() })
-    }
-
-    fn take(&self, buffer_id: u16) -> Option<BufPtr> {
-        unsafe { self.with(|inner| inner.bufs[buffer_id as usize].take()) }
-    }
-
-    fn reset(&self, buffer_id: u16, ptr: BufPtr) {
-        unsafe {
-            self.with(|inner| {
-                inner.ctrl.reset(buffer_id, ptr, inner.size);
-                inner.bufs[buffer_id as usize] = Some(ptr);
-            })
-        }
-    }
-
-    fn len(&self) -> u32 {
-        unsafe { self.with(|inner| inner.size) }
-    }
-}
-
-impl BufferRef {
-    /// Set the capacity of this buffer.
-    ///
-    /// This does nothing if `cap` is greater than underlying buffer's
-    /// length.
-    pub fn with_capacity(mut self, cap: usize) -> Self {
-        self.set_capacity(cap);
-        self
-    }
-
-    /// Set the capacity of this buffer.
-    ///
-    /// This does nothing if `cap` is greater than underlying buffer's
-    /// length or equals 0.
-    pub fn set_capacity(&mut self, cap: usize) {
-        if cap == 0 {
-            return;
-        }
-        self.cap = (cap as u32).min(self.full_cap);
-        self.len = self.len.min(self.cap);
-    }
-}
-
-impl Deref for BufferRef {
-    type Target = [u8];
-
-    fn deref(&self) -> &Self::Target {
-        // SAFETY: `SetLen` guarantees the range is initialized
-        unsafe { slice::from_raw_parts(self.ptr.as_ptr().cast(), self.len as usize) }
-    }
-}
-
-impl DerefMut for BufferRef {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        // SAFETY: `SetLen` guarantees the range is initialized
-        unsafe { slice::from_raw_parts_mut(self.ptr.as_ptr() as _, self.len as usize) }
-    }
-}
-
-impl IoBuf for BufferRef {
-    fn as_init(&self) -> &[u8] {
-        self
-    }
-}
-
-impl SetLen for BufferRef {
-    unsafe fn set_len(&mut self, len: usize) {
-        debug_assert!(len <= u32::MAX as usize);
-        self.len = (len as u32).min(self.cap);
-    }
-}
-
-impl IoBufMut for BufferRef {
-    fn as_uninit(&mut self) -> &mut [MaybeUninit<u8>] {
-        // SAFETY: Cap is initialized as the buffer length, and setting it is
-        // is capped at full_cap, so it will never exceed buffer length. Pointer is
-        // not deallocated.
-        unsafe { slice::from_raw_parts_mut(self.ptr.as_ptr(), self.cap as usize) }
-    }
-}
-
-impl Drop for BufferRef {
-    fn drop(&mut self) {
-        if let Some(shared) = self.shared.upgrade() {
-            // If the buffer pool is alive, set the pointer back
-            shared.reset(self.buffer_id, self.ptr);
-        } else {
-            // Otherwise, drop the buffer
-            let ptr = ptr::slice_from_raw_parts_mut(self.ptr.as_ptr(), self.full_cap as usize);
-            _ = unsafe { Box::from_raw(ptr) };
-        }
-    }
-}
 #[cfg(any(fusion, not(io_uring)))]
-pub(crate) mod fallback {
+pub(in crate::sys) mod fallback {
     use std::{collections::VecDeque, io};
 
     use super::*;
+    use crate::buffer_pool::BufPtr;
 
     #[derive(Debug)]
-    pub struct BufControl {
+    pub(in crate::sys) struct BufControl {
         queue: VecDeque<u16>,
     }
 

--- a/compio-driver/src/sys/fusion/buffer_pool.rs
+++ b/compio-driver/src/sys/fusion/buffer_pool.rs
@@ -1,14 +1,14 @@
 use std::io;
 
 use super::iour;
-use crate::sys::{
-    buffer_pool::{BufPtr, Slot, fallback},
-    fusion::FuseDriver,
+use crate::{
+    buffer_pool::{BufPtr, Slot},
+    sys::{buffer_pool::fallback, fusion::FuseDriver},
 };
 
 #[repr(transparent)]
 #[derive(Debug)]
-pub struct BufControl {
+pub(in crate::sys) struct BufControl {
     inner: Inner,
 }
 

--- a/compio-driver/src/sys/fusion/mod.rs
+++ b/compio-driver/src/sys/fusion/mod.rs
@@ -20,7 +20,7 @@ use crate::{BufferPool, ProactorBuilder, key::ErasedKey};
 
 mod buffer_pool;
 mod extra;
-pub(crate) use buffer_pool::BufControl;
+pub(in crate::sys) use buffer_pool::BufControl;
 pub(in crate::sys) use extra::Extra;
 
 /// Fused [`OpCode`]

--- a/compio-driver/src/sys/iour/buffer_pool.rs
+++ b/compio-driver/src/sys/iour/buffer_pool.rs
@@ -12,11 +12,11 @@ use synchrony::unsync::atomic::AtomicU16;
 
 use crate::{
     assert_not_impl,
-    sys::buffer_pool::{BufPtr, Slot},
+    buffer_pool::{BufPtr, Slot},
 };
 
 #[derive(Debug)]
-pub struct BufControl {
+pub(in crate::sys) struct BufControl {
     /// Pointer to the mmap-ed entry memory
     ptr: NonNull<BufRingEntry>,
     /// Number of entries

--- a/compio-driver/src/sys/mod.rs
+++ b/compio-driver/src/sys/mod.rs
@@ -20,14 +20,12 @@ cfg_if::cfg_if! {
     }
 }
 
+mod buffer_pool;
+mod extra;
 #[cfg(unix)]
 mod unix_op;
 
-mod buffer_pool;
-mod extra;
-
-pub(crate) use buffer_pool::BufferPoolRoot;
-pub use buffer_pool::{BufferPool, BufferRef};
+pub(crate) use buffer_pool::BufControl;
 pub use extra::Extra;
 pub use imp::*;
 

--- a/compio-driver/tests/buffer_pool.rs
+++ b/compio-driver/tests/buffer_pool.rs
@@ -1,0 +1,170 @@
+use std::num::NonZeroU16;
+
+use compio_buf::BufResult;
+use compio_driver::{
+    AsRawFd, OpCode, Proactor, ProactorBuilder, PushEntry, ResultTakeBuffer, SharedFd,
+    op::ReadManagedAt,
+};
+
+#[cfg(not(unix))]
+fn build_proactor(num_bufs: u16, buf_len: usize) -> Proactor {
+    ProactorBuilder::new()
+        .buffer_pool_size(NonZeroU16::new(num_bufs).unwrap())
+        .buffer_pool_buffer_len(buf_len)
+        .build()
+        .unwrap()
+}
+
+#[cfg(unix)]
+fn build_proactor(num_bufs: u16, buf_len: usize) -> Proactor {
+    use std::{mem::MaybeUninit, num::NonZeroUsize, ptr::NonNull};
+
+    use compio_driver::{BufferAllocator, DriverType};
+    use nix::sys::mman::{self, MapFlags, ProtFlags};
+
+    struct MmapAllocator;
+
+    impl BufferAllocator for MmapAllocator {
+        fn allocate(len: u32) -> NonNull<MaybeUninit<u8>> {
+            let size = NonZeroUsize::new(len as usize).expect("Cannot allocate zero-sized buffer");
+            let prot = ProtFlags::PROT_READ | ProtFlags::PROT_WRITE;
+            let flags = MapFlags::MAP_PRIVATE | MapFlags::MAP_ANONYMOUS;
+            unsafe { mman::mmap_anonymous(None, size, prot, flags) }
+                .expect("mmap failed")
+                .cast::<MaybeUninit<u8>>()
+        }
+
+        unsafe fn deallocate(ptr: NonNull<MaybeUninit<u8>>, len: u32) {
+            unsafe { mman::munmap(ptr.cast(), len as usize) }.expect("munmap failed");
+        }
+    }
+
+    ProactorBuilder::new()
+        .driver_type(DriverType::Poll)
+        .buffer_pool_allocator::<MmapAllocator>()
+        .buffer_pool_size(NonZeroU16::new(num_bufs).unwrap())
+        .buffer_pool_buffer_len(buf_len)
+        .build()
+        .unwrap()
+}
+
+fn push_and_wait<O: OpCode + 'static>(driver: &mut Proactor, op: O) -> BufResult<usize, O> {
+    match driver.push(op) {
+        PushEntry::Ready(res) => res,
+        PushEntry::Pending(mut key) => loop {
+            driver.poll(None).unwrap();
+            match driver.pop(key) {
+                PushEntry::Pending(k) => key = k,
+                PushEntry::Ready(res) => break res,
+            }
+        },
+    }
+}
+
+#[cfg(any(not(target_os = "linux"), feature = "polling"))]
+#[test]
+fn buffer_pool_pop_and_use() {
+    use compio_buf::{IoBuf, IoBufMut, SetLen};
+
+    let mut driver = build_proactor(4, 4096);
+
+    let pool = driver.buffer_pool().unwrap();
+    let mut buf = pool.pop().unwrap();
+
+    let data = b"hello compio";
+    let uninit = buf.as_uninit();
+    uninit[..data.len()]
+        .copy_from_slice(unsafe { std::slice::from_raw_parts(data.as_ptr().cast(), data.len()) });
+    unsafe { buf.set_len(data.len()) };
+
+    assert_eq!(buf.as_init(), data);
+}
+
+#[test]
+fn buffer_pool_multiple_buffers() {
+    use compio_buf::IoBufMut;
+
+    let mut driver = build_proactor(4, 4096);
+
+    if driver.driver_type().is_iouring() {
+        return;
+    }
+
+    let pool = driver.buffer_pool().unwrap();
+
+    let mut buf1 = pool.pop().unwrap();
+    let mut buf2 = pool.pop().unwrap();
+
+    let p1 = buf1.as_uninit().as_ptr();
+    let p2 = buf2.as_uninit().as_ptr();
+    assert_ne!(p1, p2);
+
+    drop(buf1);
+    drop(buf2);
+
+    let _buf3 = pool.pop().unwrap();
+}
+
+#[test]
+fn buffer_pool_managed_read() {
+    #[cfg(windows)]
+    use std::os::windows::fs::OpenOptionsExt;
+
+    let mut driver = build_proactor(4, 8192);
+
+    #[cfg(not(windows))]
+    let file = std::fs::File::open("Cargo.toml").unwrap();
+    #[cfg(windows)]
+    let file = std::fs::OpenOptions::new()
+        .read(true)
+        .custom_flags(windows_sys::Win32::Storage::FileSystem::FILE_FLAG_OVERLAPPED)
+        .open("Cargo.toml")
+        .unwrap();
+
+    let fd = SharedFd::new(file);
+    driver.attach(fd.as_raw_fd()).unwrap();
+
+    let pool = driver.buffer_pool().unwrap();
+
+    let op = ReadManagedAt::new(fd.clone(), 0, &pool, 1024).unwrap();
+    let res = push_and_wait(&mut driver, op);
+
+    let buffer = unsafe { res.take_buffer() }.unwrap().unwrap();
+    let content = std::str::from_utf8(&buffer).unwrap();
+    assert!(
+        content.starts_with("[package]"),
+        "unexpected content: {content:?}"
+    );
+
+    drop(buffer);
+}
+
+#[cfg(any(not(target_os = "linux"), feature = "polling"))]
+#[test]
+fn buffer_pool_buffer_capacity() {
+    use compio_buf::IoBufMut;
+
+    let mut driver = build_proactor(2, 8192);
+
+    let pool = driver.buffer_pool().unwrap();
+
+    let mut buf = pool.pop().unwrap().with_capacity(128);
+    assert_eq!(buf.as_uninit().len(), 128);
+}
+
+#[cfg(any(not(target_os = "linux"), feature = "polling"))]
+#[test]
+fn buffer_pool_recycle() {
+    let mut driver = build_proactor(1, 4096);
+
+    let pool = driver.buffer_pool().unwrap();
+
+    let buf = pool.pop().unwrap();
+    assert!(pool.pop().is_err());
+    drop(buf);
+
+    let buf = pool.pop().unwrap();
+    drop(driver);
+    drop(pool);
+    drop(buf);
+}


### PR DESCRIPTION
Closes #472

cc @inklesspen1rus

Added buffer pool trait and default implementation, moved platform-agnostic part of the buffer pool into root level of driver, and added some tests.

Maybe in future we can also add an mmap implementation based on the test, and use `VirtualAlloc` on windows, what do you think @BerrySoft?
