### PR TITLE
fix(driver,iour): len field for RecvMulti

### DIFF
--- a/compio-driver/Cargo.toml
+++ b/compio-driver/Cargo.toml
@@ -51,7 +51,7 @@ windows-sys = { workspace = true, features = [
 # Linux specific dependencies
 [target.'cfg(target_os = "linux")'.dependencies]
 compile_warning = { version = "0.1.0", optional = true }
-io-uring = { version = "0.7.0", optional = true }
+io-uring = { version = "0.7.12", optional = true }
 once_cell = { workspace = true, optional = true }
 polling = { version = "3.3.0", optional = true }
 rustix = { workspace = true, features = ["linux_5_11"] }

--- a/compio-driver/src/sys/op/managed/iour.rs
+++ b/compio-driver/src/sys/op/managed/iour.rs
@@ -550,6 +550,7 @@ unsafe impl<S: AsFd> OpCode for RecvMulti<S> {
         let fd = self.inner.fd.as_fd().as_raw_fd();
         opcode::RecvMulti::new(Fd(fd), self.inner.buffer_group)
             .flags(self.inner.flags.bits() as _)
+            .len(self.inner.len)
             .build()
             .into()
     }


### PR DESCRIPTION
I added the missing field of `RecvMulti` of the io-uring bindings: https://github.com/tokio-rs/io-uring/pull/392

UPDATE: not testing it because it requires very new kernel.