### PR TITLE
feat(buf): add `ensure_init` for convenience

### DIFF
--- a/compio-buf/src/io_buf.rs
+++ b/compio-buf/src/io_buf.rs
@@ -833,14 +833,11 @@ impl SetLen for std::io::BorrowedBuf<'static> {
     unsafe fn set_len(&mut self, len: usize) {
         debug_assert!(self.capacity() >= len);
 
-        let old_len = self.len();
-        if len > old_len {
-            // SAFETY: `len` range is initialized guaranteed by invariant of `set_len`
-            #[allow(unused_unsafe)]
-            unsafe {
-                self.clear().unfilled().advance(len - old_len)
-            };
-        }
+        // SAFETY: `len` range is initialized guaranteed by invariant of `set_len`
+        #[allow(unused_unsafe)]
+        unsafe {
+            self.clear().unfilled().advance(len)
+        };
     }
 }
 

--- a/compio-buf/src/io_buf.rs
+++ b/compio-buf/src/io_buf.rs
@@ -372,9 +372,14 @@ pub trait IoBufMut: IoBuf + SetLen {
     fn as_uninit(&mut self) -> &mut [MaybeUninit<u8>];
 
     /// Initialize all bytes in the buffer and return them.
+    ///
+    /// Bytes in the already-initialized prefix (`0..buf_len()`) are preserved.
+    /// Only the uninitialized tail (`buf_len()..buf_capacity()`) is
+    /// zero-initialized.
     fn ensure_init(&mut self) -> &mut [u8] {
+        let len = self.buf_len();
         let slice = self.as_uninit();
-        slice.fill(MaybeUninit::new(0));
+        slice[len..].fill(MaybeUninit::new(0));
         unsafe { slice.assume_init_mut() }
     }
 

--- a/compio-buf/src/io_buf.rs
+++ b/compio-buf/src/io_buf.rs
@@ -377,7 +377,7 @@ pub trait IoBufMut: IoBuf + SetLen {
     /// Only the uninitialized tail (`buf_len()..buf_capacity()`) is
     /// zero-initialized.
     fn ensure_init(&mut self) -> &mut [u8] {
-        let len = self.buf_len();
+        let len = (*self).buf_len();
         let slice = self.as_uninit();
         slice[len..].fill(MaybeUninit::new(0));
         unsafe { slice.assume_init_mut() }

--- a/compio-buf/src/io_buf.rs
+++ b/compio-buf/src/io_buf.rs
@@ -371,6 +371,13 @@ pub trait IoBufMut: IoBuf + SetLen {
     /// and uninitialized bytes.
     fn as_uninit(&mut self) -> &mut [MaybeUninit<u8>];
 
+    /// Initialize all bytes in the buffer and return them.
+    fn ensure_init(&mut self) -> &mut [u8] {
+        let slice = self.as_uninit();
+        slice.fill(MaybeUninit::new(0));
+        unsafe { slice.assume_init_mut() }
+    }
+
     /// Total capacity of the buffer, including both initialized and
     /// uninitialized bytes.
     fn buf_capacity(&mut self) -> usize {

--- a/compio-fs/src/stdio/windows.rs
+++ b/compio-fs/src/stdio/windows.rs
@@ -43,9 +43,9 @@ unsafe impl<R: Read, B: IoBufMut> OpCode for StdRead<R, B> {
         _: &mut Self::Control,
         _optr: *mut OVERLAPPED,
     ) -> Poll<io::Result<usize>> {
-        let slice = self.buffer.as_uninit();
         #[cfg(feature = "read_buf")]
         {
+            let slice = self.buffer.as_uninit();
             let mut buf = io::BorrowedBuf::from(slice);
             let mut cursor = buf.unfilled();
             self.reader.read_buf(cursor.reborrow())?;
@@ -53,17 +53,8 @@ unsafe impl<R: Read, B: IoBufMut> OpCode for StdRead<R, B> {
         }
         #[cfg(not(feature = "read_buf"))]
         {
-            use std::mem::MaybeUninit;
-
-            slice.fill(MaybeUninit::new(0));
-            self.reader
-                .read(unsafe {
-                    std::slice::from_raw_parts_mut(
-                        self.buffer.buf_mut_ptr() as _,
-                        self.buffer.buf_capacity(),
-                    )
-                })
-                .into()
+            let slice = self.buffer.ensure_init();
+            self.reader.read(slice).into()
         }
     }
 }

--- a/compio-io/src/ancillary/mod.rs
+++ b/compio-io/src/ancillary/mod.rs
@@ -176,9 +176,8 @@ impl<'a, B: IoBufMut + ?Sized> AncillaryBuilder<'a, B> {
     pub fn new(buffer: &'a mut B) -> Self {
         // SAFETY: always safe to make it empty.
         unsafe { buffer.set_len(0) };
-        let slice = buffer.as_uninit();
-        slice.fill(MaybeUninit::new(0));
-        let inner = sys::CMsgIter::new(slice.as_mut_ptr().cast(), slice.len());
+        let slice = buffer.ensure_init();
+        let inner = sys::CMsgIter::new(slice.as_ptr(), slice.len());
         Self { inner, buffer }
     }
 

--- a/compio-quic/src/recv_stream.rs
+++ b/compio-quic/src/recv_stream.rs
@@ -373,7 +373,7 @@ impl RecvStream {
             return BufResult(Err(io::Error::new(io::ErrorKind::OutOfMemory, e)), buf);
         }
         let mut buf = buf.slice(..len);
-        let slice = &mut buf.ensure_init();
+        let slice = buf.ensure_init();
         for (offset, bytes) in chunks {
             let offset = (offset - start) as usize;
             let buf_len = bytes.len();

--- a/compio-quic/src/recv_stream.rs
+++ b/compio-quic/src/recv_stream.rs
@@ -4,7 +4,7 @@ use std::{
     task::{Context, Poll},
 };
 
-use compio_buf::{BufResult, IoBufMut, bytes::Bytes};
+use compio_buf::{BufResult, IntoInner, IoBufMut, bytes::Bytes};
 use compio_io::AsyncRead;
 use futures_util::future::poll_fn;
 use quinn_proto::{Chunk, Chunks, ClosedStream, ReadableError, StreamId, VarInt};
@@ -372,15 +372,14 @@ impl RecvStream {
         {
             return BufResult(Err(io::Error::new(io::ErrorKind::OutOfMemory, e)), buf);
         }
-        let slice = &mut buf.as_uninit()[..len];
-        slice.fill(MaybeUninit::new(0));
+        let mut buf = buf.slice(..len);
+        let slice = &mut buf.ensure_init();
         for (offset, bytes) in chunks {
             let offset = (offset - start) as usize;
             let buf_len = bytes.len();
-            slice[offset..offset + buf_len].copy_from_slice(unsafe {
-                std::slice::from_raw_parts(bytes.as_ptr().cast(), buf_len)
-            });
+            slice[offset..offset + buf_len].copy_from_slice(&bytes);
         }
+        let mut buf = buf.into_inner();
         unsafe { buf.advance_to(len) }
         BufResult(Ok(len), buf)
     }

--- a/compio-tls/Cargo.toml
+++ b/compio-tls/Cargo.toml
@@ -58,5 +58,5 @@ py-dynamic-openssl = ["dep:compio-py-dynamic-openssl", "dep:pin-project-lite"]
 
 ring = ["rustls", "rustls/ring", "futures-rustls/ring"]
 
-read_buf = ["compio-buf/read_buf", "compio-io/read_buf", "rustls?/read_buf"]
+read_buf = ["compio-buf/read_buf", "compio-io/read_buf"]
 nightly = ["read_buf"]

--- a/compio-tls/src/stream.rs
+++ b/compio-tls/src/stream.rs
@@ -1,7 +1,6 @@
 use std::{
     borrow::Cow,
     io,
-    mem::MaybeUninit,
     pin::Pin,
     task::{Context, Poll},
 };
@@ -144,11 +143,7 @@ pub(crate) async fn read_futures<S: futures_util::AsyncRead + Unpin, B: IoBufMut
     s: &mut S,
     mut buf: B,
 ) -> BufResult<usize, B> {
-    let slice = buf.as_uninit();
-    slice.fill(MaybeUninit::new(0));
-    // SAFETY: The memory has been initialized
-    let slice =
-        unsafe { std::slice::from_raw_parts_mut::<u8>(slice.as_mut_ptr().cast(), slice.len()) };
+    let slice = buf.ensure_init();
     let res = futures_util::AsyncReadExt::read(s, slice).await;
     let res = match res {
         Ok(len) => {


### PR DESCRIPTION
Inspired by `BorrowedCursor::ensure_init`.