### PR TITLE
feat(driver, net): support recv_send_poll_first

### DIFF
--- a/compio-driver/Cargo.toml
+++ b/compio-driver/Cargo.toml
@@ -60,6 +60,7 @@ io-uring = { version = "0.7.12", optional = true }
 once_cell = { workspace = true, optional = true }
 polling = { version = "3.3.0", optional = true }
 rustix = { workspace = true, features = ["linux_5_11"] }
+linux-raw-sys = { version = "0.12.1", optional = true }
 
 # Other platform dependencies
 [target.'cfg(all(unix, not(target_os = "linux")))'.dependencies]
@@ -83,6 +84,7 @@ io-uring = [
     "rustix/mm",
     "rustix/event",
     "rustix/system",
+    "linux-raw-sys/io_uring",
     "dep:io-uring",
     "dep:once_cell",
 ]

--- a/compio-driver/src/sys/op/managed/fallback.rs
+++ b/compio-driver/src/sys/op/managed/fallback.rs
@@ -69,6 +69,11 @@ impl<S> RecvManaged<S> {
             op: Recv::new(fd, pool.pop()?.with_capacity(len), flags),
         })
     }
+
+    /// This method sets the `IORING_RECVSEND_POLL_FIRST` flag in the `ioprio`
+    /// of the SQE on the IO_URING driver.
+    // This method has been added here for the sake of API compatibility.
+    pub fn poll_first(&mut self) {}
 }
 
 impl<S> TakeBuffer for RecvManaged<S> {
@@ -91,6 +96,11 @@ impl<S: AsFd> RecvFromManaged<S> {
             op: RecvFrom::new(fd, pool.pop()?.with_capacity(len), flags),
         })
     }
+
+    /// This method sets the `IORING_RECVSEND_POLL_FIRST` flag in the `ioprio`
+    /// of the SQE on the IO_URING driver.
+    // This method has been added here for the sake of API compatibility.
+    pub fn poll_first(&mut self) {}
 }
 
 impl<S: AsFd> TakeBuffer for RecvFromManaged<S> {
@@ -119,6 +129,11 @@ impl<C: IoBufMut, S: AsFd> RecvMsgManaged<C, S> {
             op: RecvMsg::new(fd, [pool.pop()?.with_capacity(len)], control, flags),
         })
     }
+
+    /// This method sets the `IORING_RECVSEND_POLL_FIRST` flag in the `ioprio`
+    /// of the SQE on the IO_URING driver.
+    // This method has been added here for the sake of API compatibility.
+    pub fn poll_first(&mut self) {}
 }
 
 impl<C: IoBufMut, S: AsFd> TakeBuffer for RecvMsgManaged<C, S> {

--- a/compio-driver/src/sys/op/managed/fusion.rs
+++ b/compio-driver/src/sys/op/managed/fusion.rs
@@ -131,6 +131,39 @@ mop!(<S: AsFd> RecvMulti(fd: S, pool: &BufferPool, len: usize, flags: RecvFlags)
 mop!(<S: AsFd> RecvFromMulti(fd: S, pool: &BufferPool, flags: RecvFlags) with pool; RecvFromMultiResult);
 mop!(<S: AsFd> RecvMsgMulti(fd: S, pool: &BufferPool, control_len: usize, flags: RecvFlags) with pool; RecvMsgMultiResult);
 
+impl<S: AsFd> RecvManaged<S> {
+    /// This method sets the `IORING_RECVSEND_POLL_FIRST` flag in the `ioprio`
+    /// of the SQE on the IO_URING driver.
+    pub fn poll_first(&mut self) {
+        match self.inner {
+            RecvManagedInner::Poll(ref mut i) => i.poll_first(),
+            RecvManagedInner::IoUring(ref mut i) => i.poll_first(),
+        }
+    }
+}
+
+impl<S: AsFd> RecvFromManaged<S> {
+    /// This method sets the `IORING_RECVSEND_POLL_FIRST` flag in the `ioprio`
+    /// of the SQE on the IO_URING driver.
+    pub fn poll_first(&mut self) {
+        match self.inner {
+            RecvFromManagedInner::Poll(ref mut i) => i.poll_first(),
+            RecvFromManagedInner::IoUring(ref mut i) => i.poll_first(),
+        }
+    }
+}
+
+impl<C: IoBufMut, S: AsFd> RecvMsgManaged<C, S> {
+    /// This method sets the `IORING_RECVSEND_POLL_FIRST` flag in the `ioprio`
+    /// of the SQE on the IO_URING driver.
+    pub fn poll_first(&mut self) {
+        match self.inner {
+            RecvMsgManagedInner::Poll(ref mut i) => i.poll_first(),
+            RecvMsgManagedInner::IoUring(ref mut i) => i.poll_first(),
+        }
+    }
+}
+
 enum RecvFromMultiResultInner {
     Poll(fallback::RecvFromMultiResult),
     IoUring(iour::RecvFromMultiResult),

--- a/compio-driver/src/sys/op/managed/iour.rs
+++ b/compio-driver/src/sys/op/managed/iour.rs
@@ -12,8 +12,9 @@ use rustix::net::RecvFlags;
 use socket2::{SockAddr, SockAddrStorage, socklen_t};
 
 use crate::{
-    BufferPool, BufferRef, Extra, IourOpCode as OpCode, OpEntry, op::TakeBuffer,
-    sys::pal::is_kernel_at_least,
+    BufferPool, BufferRef, Extra, IourOpCode as OpCode, OpEntry,
+    op::TakeBuffer,
+    sys::pal::{is_kernel_at_least, set_poll_first},
 };
 
 /// Read a file at specified position into specified buffer.
@@ -143,6 +144,7 @@ pub struct RecvManaged<S> {
     buffer_group: u16,
     buffer_pool: BufferPool,
     buffer: Option<BufferRef>,
+    poll_first: bool,
 }
 
 impl<S> RecvManaged<S> {
@@ -157,7 +159,14 @@ impl<S> RecvManaged<S> {
             flags,
             buffer_pool: buffer_pool.clone(),
             buffer: None,
+            poll_first: false,
         })
+    }
+
+    /// This method sets the `IORING_RECVSEND_POLL_FIRST` flag in the `ioprio`
+    /// of the SQE on the IO_URING driver.
+    pub fn poll_first(&mut self) {
+        self.poll_first = true;
     }
 }
 
@@ -166,12 +175,13 @@ unsafe impl<S: AsFd> OpCode for RecvManaged<S> {
 
     fn create_entry(&mut self, _: &mut Self::Control) -> OpEntry {
         let fd = self.fd.as_fd().as_raw_fd();
-        opcode::Recv::new(Fd(fd), ptr::null_mut(), self.len)
+        let entry = opcode::Recv::new(Fd(fd), ptr::null_mut(), self.len)
             .flags(self.flags.bits() as _)
             .buf_group(self.buffer_group)
             .build()
-            .flags(Flags::BUFFER_SELECT)
-            .into()
+            .flags(Flags::BUFFER_SELECT);
+        let entry = set_poll_first(entry, self.poll_first);
+        entry.into()
     }
 
     unsafe fn set_result(&mut self, _: &mut Self::Control, _: &io::Result<usize>, extra: &Extra) {
@@ -205,6 +215,7 @@ pub struct RecvFromManaged<S> {
     buffer_group: u16,
     buffer_pool: BufferPool,
     buffer: Option<BufferRef>,
+    poll_first: bool,
 }
 
 #[doc(hidden)]
@@ -236,7 +247,14 @@ impl<S> RecvFromManaged<S> {
             addr,
             buffer_pool: buffer_pool.clone(),
             buffer: None,
+            poll_first: false,
         })
+    }
+
+    /// This method sets the `IORING_RECVSEND_POLL_FIRST` flag in the `ioprio`
+    /// of the SQE on the IO_URING driver.
+    pub fn poll_first(&mut self) {
+        self.poll_first = true;
     }
 }
 
@@ -262,12 +280,13 @@ unsafe impl<S: AsFd> OpCode for RecvFromManaged<S> {
     }
 
     fn create_entry(&mut self, control: &mut Self::Control) -> OpEntry {
-        opcode::RecvMsg::new(Fd(self.fd.as_fd().as_raw_fd()), &raw mut control.msg)
+        let entry = opcode::RecvMsg::new(Fd(self.fd.as_fd().as_raw_fd()), &raw mut control.msg)
             .flags(self.flags.bits() as _)
             .buf_group(self.buffer_group)
             .build()
-            .flags(Flags::BUFFER_SELECT)
-            .into()
+            .flags(Flags::BUFFER_SELECT);
+        let entry = set_poll_first(entry, self.poll_first);
+        entry.into()
     }
 
     unsafe fn set_result(
@@ -310,6 +329,12 @@ impl<C: IoBufMut, S: AsFd> RecvMsgManaged<C, S> {
             control,
             control_len: 0,
         })
+    }
+
+    /// This method sets the `IORING_RECVSEND_POLL_FIRST` flag in the `ioprio`
+    /// of the SQE on the IO_URING driver.
+    pub fn poll_first(&mut self) {
+        self.op.poll_first();
     }
 }
 

--- a/compio-driver/src/sys/op/socket/iour.rs
+++ b/compio-driver/src/sys/op/socket/iour.rs
@@ -238,14 +238,15 @@ unsafe impl<T: IoBufMut, S: AsFd> OpCode for Recv<T, S> {
         let fd = self.fd.as_fd().as_raw_fd();
         let slice = self.buffer.sys_slice_mut();
 
-        opcode::Recv::new(
+        let entry = opcode::Recv::new(
             Fd(fd),
             slice.ptr() as _,
             slice.len().try_into().unwrap_or(u32::MAX),
         )
         .flags(self.flags.bits() as _)
-        .build()
-        .into()
+        .build();
+        let entry = set_poll_first(entry, self.poll_first);
+        entry.into()
     }
 
     fn call_blocking(&mut self, _: &mut Self::Control) -> io::Result<usize> {
@@ -261,10 +262,11 @@ unsafe impl<T: IoVectoredBufMut, S: AsFd> OpCode for RecvVectored<T, S> {
     }
 
     fn create_entry(&mut self, control: &mut Self::Control) -> OpEntry {
-        opcode::RecvMsg::new(Fd(self.fd.as_fd().as_raw_fd()), &mut control.msg)
+        let entry = opcode::RecvMsg::new(Fd(self.fd.as_fd().as_raw_fd()), &mut control.msg)
             .flags(self.flags.bits() as _)
-            .build()
-            .into()
+            .build();
+        let entry = set_poll_first(entry, self.poll_first);
+        entry.into()
     }
 
     fn call_blocking(&mut self, control: &mut Self::Control) -> io::Result<usize> {
@@ -286,10 +288,11 @@ impl<S: AsFd> RecvFromHeader<S> {
     }
 
     pub fn create_entry(&mut self, control: &mut RecvMsgControl) -> OpEntry {
-        opcode::RecvMsg::new(Fd(self.fd.as_fd().as_raw_fd()), &mut control.msg)
+        let entry = opcode::RecvMsg::new(Fd(self.fd.as_fd().as_raw_fd()), &mut control.msg)
             .flags(self.flags.bits() as _)
-            .build()
-            .into()
+            .build();
+        let entry = set_poll_first(entry, self.poll_first);
+        entry.into()
     }
 
     pub fn set_result(&mut self, control: &mut RecvMsgControl) {
@@ -357,10 +360,11 @@ unsafe impl<T: IoVectoredBufMut, C: IoBufMut, S: AsFd> OpCode for RecvMsg<T, C, 
     }
 
     fn create_entry(&mut self, control: &mut Self::Control) -> OpEntry {
-        opcode::RecvMsg::new(Fd(self.header.fd.as_fd().as_raw_fd()), &mut control.msg)
+        let entry = opcode::RecvMsg::new(Fd(self.header.fd.as_fd().as_raw_fd()), &mut control.msg)
             .flags(self.header.flags.bits() as _)
-            .build()
-            .into()
+            .build();
+        let entry = set_poll_first(entry, self.poll_first);
+        entry.into()
     }
 
     unsafe fn set_result(

--- a/compio-driver/src/sys/op/socket/mod.rs
+++ b/compio-driver/src/sys/op/socket/mod.rs
@@ -83,6 +83,7 @@ pub struct Recv<T: IoBufMut, S> {
     pub(crate) fd: S,
     pub(crate) buffer: T,
     pub(crate) flags: RecvFlags,
+    poll_first: bool,
 }
 
 /// Receive data from remote into vectored buffer.
@@ -90,6 +91,7 @@ pub struct RecvVectored<T: IoVectoredBufMut, S> {
     pub(crate) fd: S,
     pub(crate) buffer: T,
     pub(crate) flags: RecvFlags,
+    poll_first: bool,
 }
 
 pub(crate) struct RecvFromHeader<S> {
@@ -97,6 +99,7 @@ pub(crate) struct RecvFromHeader<S> {
     pub(crate) flags: RecvFlags,
     pub(crate) addr: SockAddrStorage,
     pub(crate) addr_len: socklen_t,
+    poll_first: bool,
 }
 
 /// Receive data and source address.
@@ -118,6 +121,7 @@ pub struct RecvMsg<T: IoVectoredBufMut, C: IoBufMut, S> {
     pub(crate) buffer: T,
     pub(crate) control: C,
     pub(crate) control_len: usize,
+    poll_first: bool,
 }
 
 impl<S> Connect<S> {
@@ -254,7 +258,14 @@ impl<T: IoVectoredBufMut, C: IoBufMut, S> RecvMsg<T, C, S> {
             buffer,
             control,
             control_len: 0,
+            poll_first: false,
         }
+    }
+
+    /// This method sets the `IORING_RECVSEND_POLL_FIRST` flag in the `ioprio`
+    /// of the SQE on the IO_URING driver.
+    pub fn poll_first(&mut self) {
+        self.poll_first = true;
     }
 }
 
@@ -273,7 +284,18 @@ impl<T: IoVectoredBufMut, C: IoBufMut, S> IntoInner for RecvMsg<T, C, S> {
 impl<T: IoBufMut, S> Recv<T, S> {
     /// Create [`Recv`].
     pub fn new(fd: S, buffer: T, flags: RecvFlags) -> Self {
-        Self { fd, buffer, flags }
+        Self {
+            fd,
+            buffer,
+            flags,
+            poll_first: false,
+        }
+    }
+
+    /// This method sets the `IORING_RECVSEND_POLL_FIRST` flag in the `ioprio`
+    /// of the SQE on the IO_URING driver.
+    pub fn poll_first(&mut self) {
+        self.poll_first = true;
     }
 }
 
@@ -288,7 +310,18 @@ impl<T: IoBufMut, S> IntoInner for Recv<T, S> {
 impl<T: IoVectoredBufMut, S> RecvVectored<T, S> {
     /// Create [`RecvVectored`].
     pub fn new(fd: S, buffer: T, flags: RecvFlags) -> Self {
-        Self { fd, buffer, flags }
+        Self {
+            fd,
+            buffer,
+            flags,
+            poll_first: false,
+        }
+    }
+
+    /// This method sets the `IORING_RECVSEND_POLL_FIRST` flag in the `ioprio`
+    /// of the SQE on the IO_URING driver.
+    pub fn poll_first(&mut self) {
+        self.poll_first = true;
     }
 }
 
@@ -309,6 +342,7 @@ impl<S> RecvFromHeader<S> {
             addr,
             flags,
             addr_len: name_len,
+            poll_first: false,
         }
     }
 
@@ -324,6 +358,12 @@ impl<T: IoVectoredBufMut, S> RecvFromVectored<T, S> {
             header: RecvFromHeader::new(fd, flags),
             buffer,
         }
+    }
+
+    /// This method sets the `IORING_RECVSEND_POLL_FIRST` flag in the `ioprio`
+    /// of the SQE on the IO_URING driver.
+    pub fn poll_first(&mut self) {
+        self.header.poll_first = true;
     }
 }
 
@@ -343,6 +383,12 @@ impl<T: IoBufMut, S> RecvFrom<T, S> {
             header: RecvFromHeader::new(fd, flags),
             buffer,
         }
+    }
+
+    /// This method sets the `IORING_RECVSEND_POLL_FIRST` flag in the `ioprio`
+    /// of the SQE on the IO_URING driver.
+    pub fn poll_first(&mut self) {
+        self.header.poll_first = true;
     }
 }
 

--- a/compio-driver/src/sys/pal/iour/mod.rs
+++ b/compio-driver/src/sys/pal/iour/mod.rs
@@ -1,6 +1,8 @@
 #[cfg(feature = "once_cell_try")]
 use std::sync::OnceLock;
 
+use io_uring::squeue::Entry;
+use linux_raw_sys::io_uring::{IORING_RECVSEND_POLL_FIRST, io_uring_sqe};
 #[cfg(not(feature = "once_cell_try"))]
 use once_cell::sync::OnceCell as OnceLock;
 
@@ -52,4 +54,14 @@ pub fn is_kernel_at_least(v: impl Into<KernelVersion>) -> bool {
     kernel_version()
         .map(|kv| kv >= v.into())
         .unwrap_or_default()
+}
+
+pub(crate) fn set_poll_first(mut entry: Entry, flag: bool) -> Entry {
+    if flag && is_kernel_at_least((5, 19)) {
+        let sqe = &raw mut entry as *mut io_uring_sqe;
+        unsafe {
+            (*sqe).ioprio |= IORING_RECVSEND_POLL_FIRST as u16;
+        }
+    }
+    entry
 }

--- a/compio-net/src/socket/mod.rs
+++ b/compio-net/src/socket/mod.rs
@@ -243,19 +243,12 @@ impl Socket {
         }
     }
 
-    /// This method signifies whether the socket was non-empty after the last
-    /// receive operation.
-    ///
-    /// # Behavior
-    ///
-    /// It returns `Some(..)` only on the IO_URING driver and `None` on others.
-    pub fn sock_nonempty(&self) -> Option<bool> {
-        self.state.get()
-    }
-
     pub async fn recv<B: IoBufMut>(&self, buffer: B, flags: RecvFlags) -> BufResult<usize, B> {
         let fd = self.to_shared_fd();
-        let op = Recv::new(fd, buffer, flags);
+        let mut op = Recv::new(fd, buffer, flags);
+        if self.state.get() == Some(false) {
+            op.poll_first();
+        }
         let (res, extra) = compio_runtime::submit(op).with_extra().await;
         self.state.set(&extra);
         let res = res.into_inner();
@@ -268,7 +261,10 @@ impl Socket {
         flags: RecvFlags,
     ) -> BufResult<usize, V> {
         let fd = self.to_shared_fd();
-        let op = RecvVectored::new(fd, buffer, flags);
+        let mut op = RecvVectored::new(fd, buffer, flags);
+        if self.state.get() == Some(false) {
+            op.poll_first();
+        }
         let (res, extra) = compio_runtime::submit(op).with_extra().await;
         self.state.set(&extra);
         let res = res.into_inner();
@@ -283,7 +279,10 @@ impl Socket {
         let fd = self.to_shared_fd();
         let (res, extra) = Runtime::with_current(|rt| {
             let buffer_pool = rt.buffer_pool()?;
-            let op = RecvManaged::new(fd, &buffer_pool, len, flags)?;
+            let mut op = RecvManaged::new(fd, &buffer_pool, len, flags)?;
+            if self.state.get() == Some(false) {
+                op.poll_first();
+            }
             io::Result::Ok(rt.submit(op).with_extra())
         })?
         .await;
@@ -346,7 +345,10 @@ impl Socket {
         flags: RecvFlags,
     ) -> BufResult<(usize, Option<SockAddr>), T> {
         let fd = self.to_shared_fd();
-        let op = RecvFrom::new(fd, buffer, flags);
+        let mut op = RecvFrom::new(fd, buffer, flags);
+        if self.state.get() == Some(false) {
+            op.poll_first();
+        }
         let (res, extra) = compio_runtime::submit(op).with_extra().await;
         self.state.set(&extra);
         let res = res.into_inner().map_addr();
@@ -359,7 +361,10 @@ impl Socket {
         flags: RecvFlags,
     ) -> BufResult<(usize, Option<SockAddr>), T> {
         let fd = self.to_shared_fd();
-        let op = RecvFromVectored::new(fd, buffer, flags);
+        let mut op = RecvFromVectored::new(fd, buffer, flags);
+        if self.state.get() == Some(false) {
+            op.poll_first();
+        }
         let (res, extra) = compio_runtime::submit(op).with_extra().await;
         self.state.set(&extra);
         let res = res.into_inner().map_addr();
@@ -374,7 +379,10 @@ impl Socket {
         let fd = self.to_shared_fd();
         let (inner, extra) = Runtime::with_current(|rt| {
             let buffer_pool = rt.buffer_pool()?;
-            let op = RecvFromManaged::new(fd, &buffer_pool, len, flags)?;
+            let mut op = RecvFromManaged::new(fd, &buffer_pool, len, flags)?;
+            if self.state.get() == Some(false) {
+                op.poll_first();
+            }
             io::Result::Ok(rt.submit(op).with_extra())
         })?
         .await;
@@ -426,7 +434,10 @@ impl Socket {
         flags: RecvFlags,
     ) -> BufResult<(usize, usize, Option<SockAddr>), (T, C)> {
         let fd = self.to_shared_fd();
-        let op = RecvMsg::new(fd, buffer, control, flags);
+        let mut op = RecvMsg::new(fd, buffer, control, flags);
+        if self.state.get() == Some(false) {
+            op.poll_first();
+        }
         let (res, extra) = compio_runtime::submit(op).with_extra().await;
         self.state.set(&extra);
         let res = res.into_inner().map_addr();
@@ -442,7 +453,10 @@ impl Socket {
         let fd = self.to_shared_fd();
         let (inner, extra) = Runtime::with_current(|rt| {
             let buffer_pool = rt.buffer_pool()?;
-            let op = RecvMsgManaged::new(fd, &buffer_pool, len, control, flags)?;
+            let mut op = RecvMsgManaged::new(fd, &buffer_pool, len, control, flags)?;
+            if self.state.get() == Some(false) {
+                op.poll_first();
+            }
             io::Result::Ok(rt.submit(op).with_extra())
         })?
         .await;

--- a/compio-net/src/tcp.rs
+++ b/compio-net/src/tcp.rs
@@ -440,17 +440,6 @@ impl TcpStream {
             )
             .await
     }
-
-    /// Signifies whether the underlying socket was non-empty after the last
-    /// receive operation.
-    ///
-    /// # Behaviour
-    ///
-    /// Returns `Some(..)` only on the IO_URING driver and `None` on other
-    /// drivers.
-    pub fn sock_nonempty(&self) -> Option<bool> {
-        self.inner.sock_nonempty()
-    }
 }
 
 impl AsyncRead for TcpStream {

--- a/compio-net/src/udp.rs
+++ b/compio-net/src/udp.rs
@@ -196,17 +196,6 @@ impl UdpSocket {
             .map(|addr| addr.as_socket().expect("should be SocketAddr"))
     }
 
-    /// Signifies whether the underlying socket was non-empty after the last
-    /// receive operation.
-    ///
-    /// # Behaviour
-    ///
-    /// Returns `Some(..)` only on the IO-URING driver and `None` on other
-    /// drivers.
-    pub fn sock_nonempty(&self) -> Option<bool> {
-        self.inner.sock_nonempty()
-    }
-
     /// Receives a packet of data from the socket into the buffer, returning the
     /// original buffer and quantity of data received.
     pub async fn recv<T: IoBufMut>(&self, buffer: T) -> BufResult<usize, T> {

--- a/compio-net/src/unix.rs
+++ b/compio-net/src/unix.rs
@@ -302,17 +302,6 @@ impl UnixStream {
         self.inner.disconnect().await?;
         Ok(UnixSocket { inner: self.inner })
     }
-
-    /// Signifies whether the underlying socket was non-empty after the last
-    /// receive operation.
-    ///
-    /// # Behaviour
-    ///
-    /// Returns `Some(..)` only on the IO-URING driver and `None` on other
-    /// drivers.
-    pub fn sock_nonempty(&self) -> Option<bool> {
-        self.inner.sock_nonempty()
-    }
 }
 
 impl AsyncRead for UnixStream {


### PR DESCRIPTION
Adds support for setting the `IORING_RECVSEND_POLL_FIRST` flag on the IO_URING driver.

Closes #886