### PR TITLE
docs: add more targets for docs.rs

### DIFF
--- a/compio-driver/Cargo.toml
+++ b/compio-driver/Cargo.toml
@@ -12,6 +12,11 @@ repository = { workspace = true }
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
+targets = [
+    "x86_64-unknown-linux-gnu",
+    "x86_64-pc-windows-msvc",
+    "aarch64-apple-darwin",
+]
 
 [dependencies]
 # Workspace dependencies

--- a/compio-fs/Cargo.toml
+++ b/compio-fs/Cargo.toml
@@ -12,6 +12,11 @@ repository = { workspace = true }
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
+targets = [
+    "x86_64-unknown-linux-gnu",
+    "x86_64-pc-windows-msvc",
+    "aarch64-apple-darwin",
+]
 
 [dependencies]
 # Workspace dependencies

--- a/compio-net/Cargo.toml
+++ b/compio-net/Cargo.toml
@@ -12,6 +12,11 @@ repository = { workspace = true }
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
+targets = [
+    "x86_64-unknown-linux-gnu",
+    "x86_64-pc-windows-msvc",
+    "aarch64-apple-darwin",
+]
 
 [dependencies]
 # Workspace dependencies

--- a/compio-process/Cargo.toml
+++ b/compio-process/Cargo.toml
@@ -12,6 +12,11 @@ repository = { workspace = true }
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
+targets = [
+    "x86_64-unknown-linux-gnu",
+    "x86_64-pc-windows-msvc",
+    "aarch64-apple-darwin",
+]
 
 [dependencies]
 compio-buf = { workspace = true }

--- a/compio-quic/Cargo.toml
+++ b/compio-quic/Cargo.toml
@@ -12,6 +12,11 @@ repository = { workspace = true }
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
+targets = [
+    "x86_64-unknown-linux-gnu",
+    "x86_64-pc-windows-msvc",
+    "aarch64-apple-darwin",
+]
 
 [dependencies]
 # Workspace dependencies

--- a/compio-signal/Cargo.toml
+++ b/compio-signal/Cargo.toml
@@ -12,6 +12,11 @@ repository = { workspace = true }
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
+targets = [
+    "x86_64-unknown-linux-gnu",
+    "x86_64-pc-windows-msvc",
+    "aarch64-apple-darwin",
+]
 
 [dependencies]
 slab = { workspace = true }

--- a/compio/Cargo.toml
+++ b/compio/Cargo.toml
@@ -12,6 +12,11 @@ repository = { workspace = true }
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
+targets = [
+    "x86_64-unknown-linux-gnu",
+    "x86_64-pc-windows-msvc",
+    "aarch64-apple-darwin",
+]
 
 # Shared dependencies for all platforms
 [dependencies]


### PR DESCRIPTION
Closes #893

Only the crates that introduce platform-specific features need it.