### PR TITLE
feat(driver): add CPU affinity support for SQPOLL in ProactorBuilder

### DIFF
--- a/compio-driver/src/lib.rs
+++ b/compio-driver/src/lib.rs
@@ -545,6 +545,7 @@ pub struct ProactorBuilder {
     capacity: u32,
     pool_builder: ThreadPoolBuilder,
     sqpoll_idle: Option<Duration>,
+    sqpoll_cpu_affinity: Option<u32>,
     cqsize: Option<u32>,
     coop_taskrun: bool,
     taskrun_flag: bool,
@@ -574,6 +575,7 @@ impl ProactorBuilder {
             capacity: 1024,
             pool_builder: ThreadPoolBuilder::new(),
             sqpoll_idle: None,
+            sqpoll_cpu_affinity: None,
             cqsize: None,
             coop_taskrun: false,
             taskrun_flag: false,
@@ -657,6 +659,22 @@ impl ProactorBuilder {
     /// - `idle` will be rounded down
     pub fn sqpoll_idle(&mut self, idle: Duration) -> &mut Self {
         self.sqpoll_idle = Some(idle);
+        self
+    }
+
+    /// Set CPU affinity for the `io-uring` SQPOLL thread when SQPOLL is
+    /// enabled.
+    ///
+    /// This is only applied when SQPOLL is enabled with
+    /// [`sqpoll_idle`](Self::sqpoll_idle).
+    ///
+    /// # Notes
+    ///
+    /// - Only effective when the `io-uring` feature is enabled
+    /// - `cpu` must be less than the number of cpus in the system, otherwise it
+    ///   will return an error when building the proactor.
+    pub fn sqpoll_cpu_affinity(&mut self, cpu: u32) -> &mut Self {
+        self.sqpoll_cpu_affinity = Some(cpu);
         self
     }
 

--- a/compio-driver/src/lib.rs
+++ b/compio-driver/src/lib.rs
@@ -545,7 +545,7 @@ pub struct ProactorBuilder {
     capacity: u32,
     pool_builder: ThreadPoolBuilder,
     sqpoll_idle: Option<Duration>,
-    sqpoll_cpu_affinity: Option<u32>,
+    sqpoll_cpu: Option<u32>,
     cqsize: Option<u32>,
     coop_taskrun: bool,
     taskrun_flag: bool,
@@ -575,7 +575,7 @@ impl ProactorBuilder {
             capacity: 1024,
             pool_builder: ThreadPoolBuilder::new(),
             sqpoll_idle: None,
-            sqpoll_cpu_affinity: None,
+            sqpoll_cpu: None,
             cqsize: None,
             coop_taskrun: false,
             taskrun_flag: false,
@@ -673,8 +673,8 @@ impl ProactorBuilder {
     /// - Only effective when the `io-uring` feature is enabled
     /// - `cpu` must be less than the number of cpus in the system, otherwise it
     ///   will return an error when building the proactor.
-    pub fn sqpoll_cpu_affinity(&mut self, cpu: u32) -> &mut Self {
-        self.sqpoll_cpu_affinity = Some(cpu);
+    pub fn sqpoll_cpu(&mut self, cpu: u32) -> &mut Self {
+        self.sqpoll_cpu = Some(cpu);
         self
     }
 

--- a/compio-driver/src/sys/driver/iour/mod.rs
+++ b/compio-driver/src/sys/driver/iour/mod.rs
@@ -69,7 +69,7 @@ impl Driver {
         let mut io_uring_builder = IoUring::builder();
         if let Some(sqpoll_idle) = builder.sqpoll_idle {
             io_uring_builder.setup_sqpoll(sqpoll_idle.as_millis() as _);
-            if let Some(cpu) = builder.sqpoll_cpu_affinity {
+            if let Some(cpu) = builder.sqpoll_cpu {
                 io_uring_builder.setup_sqpoll_cpu(cpu);
             }
         }

--- a/compio-driver/src/sys/driver/iour/mod.rs
+++ b/compio-driver/src/sys/driver/iour/mod.rs
@@ -69,6 +69,9 @@ impl Driver {
         let mut io_uring_builder = IoUring::builder();
         if let Some(sqpoll_idle) = builder.sqpoll_idle {
             io_uring_builder.setup_sqpoll(sqpoll_idle.as_millis() as _);
+            if let Some(cpu) = builder.sqpoll_cpu_affinity {
+                io_uring_builder.setup_sqpoll_cpu(cpu);
+            }
         }
         if builder.coop_taskrun {
             io_uring_builder.setup_coop_taskrun();


### PR DESCRIPTION
Add builder support for configuring io-uring SQPOLL CPU affinity.

The new `sqpoll_cpu_affinity(cpu)` option is applied only when SQPOLL is enabled via `sqpoll_idle(...)`, keeping `sqpoll_idle` as the SQPOLL feature switch. Docs were updated to make that contract explicit.