### PR TITLE
fix(bench): avoid testing allocations

### DIFF
--- a/compio/Cargo.toml
+++ b/compio/Cargo.toml
@@ -247,7 +247,8 @@ required-features = ["fs"]
 [[bench]]
 name = "net"
 harness = false
-required-features = ["net"]
+# Windows also benchmarks named pipes, which require fs features, so we include those as well.
+required-features = ["fs", "net"]
 
 [[test]]
 name = "runtime"

--- a/compio/benches/fs.rs
+++ b/compio/benches/fs.rs
@@ -24,7 +24,7 @@ const FILE_SIZE: u64 = 1024;
 
 fn read_std(b: &mut Bencher, (path, offsets): &(&Path, &[u64])) {
     let file = std::fs::File::open(path).unwrap();
-    let mut buffer = [0u8; BUFFER_SIZE];
+    let mut buffer = vec![0u8; BUFFER_SIZE];
     b.iter(|| {
         for &offset in *offsets {
             #[cfg(windows)]
@@ -49,7 +49,7 @@ fn read_tokio(b: &mut Bencher, (path, offsets): &(&Path, &[u64])) {
     b.to_async(&runtime).iter_custom(|iter| async move {
         let mut file = tokio::fs::File::open(path).await.unwrap();
 
-        let mut buffer = [0u8; BUFFER_SIZE];
+        let mut buffer = vec![0u8; BUFFER_SIZE];
         let start = Instant::now();
         for _i in 0..iter {
             for &offset in *offsets {
@@ -66,7 +66,7 @@ fn read_compio(b: &mut Bencher, (path, offsets): &(&Path, &[u64])) {
     b.to_async(&runtime).iter_custom(|iter| async move {
         let file = compio::fs::File::open(path).await.unwrap();
 
-        let mut buffer = Box::new([0u8; BUFFER_SIZE]);
+        let mut buffer = vec![0u8; BUFFER_SIZE];
         let start = Instant::now();
         for _i in 0..iter {
             for &offset in *offsets {
@@ -83,7 +83,7 @@ fn read_monoio(b: &mut Bencher, (path, offsets): &(&Path, &[u64])) {
     b.to_async(&runtime).iter_custom(|iter| async move {
         let file = monoio::fs::File::open(path).await.unwrap();
 
-        let mut buffer = Box::new([0u8; BUFFER_SIZE]);
+        let mut buffer = vec![0u8; BUFFER_SIZE];
         let start = Instant::now();
         for _i in 0..iter {
             for &offset in *offsets {
@@ -99,7 +99,7 @@ fn read_monoio(b: &mut Bencher, (path, offsets): &(&Path, &[u64])) {
 fn read_all_std(b: &mut Bencher, (path, len): &(&Path, u64)) {
     let mut file = std::fs::File::open(path).unwrap();
     b.iter_custom(|iter| {
-        let mut buffer = [0u8; BUFFER_SIZE];
+        let mut buffer = vec![0u8; BUFFER_SIZE];
         let start = Instant::now();
         for _i in 0..iter {
             let mut read_len = 0;
@@ -120,7 +120,7 @@ fn read_all_tokio(b: &mut Bencher, (path, len): &(&Path, u64)) {
         .unwrap();
     b.to_async(&runtime).iter_custom(|iter| async move {
         let mut file = tokio::fs::File::open(path).await.unwrap();
-        let mut buffer = [0u8; BUFFER_SIZE];
+        let mut buffer = vec![0u8; BUFFER_SIZE];
 
         let start = Instant::now();
         for _i in 0..iter {
@@ -139,7 +139,7 @@ fn read_all_compio(b: &mut Bencher, (path, len): &(&Path, u64)) {
     let runtime = compio::runtime::Runtime::new().unwrap();
     b.to_async(&runtime).iter_custom(|iter| async move {
         let file = compio::fs::File::open(path).await.unwrap();
-        let mut buffer = Box::new([0u8; BUFFER_SIZE]);
+        let mut buffer = vec![0u8; BUFFER_SIZE];
 
         let start = Instant::now();
         for _i in 0..iter {
@@ -159,7 +159,7 @@ fn read_all_monoio(b: &mut Bencher, (path, len): &(&Path, u64)) {
     let runtime = MonoioRuntime::new();
     b.to_async(&runtime).iter_custom(|iter| async move {
         let file = monoio::fs::File::open(path).await.unwrap();
-        let mut buffer = Box::new([0u8; BUFFER_SIZE]);
+        let mut buffer = vec![0u8; BUFFER_SIZE];
 
         let start = Instant::now();
         for _i in 0..iter {
@@ -179,7 +179,7 @@ fn read(c: &mut Criterion) {
 
     let mut file = NamedTempFile::new().unwrap();
     for _i in 0..FILE_SIZE {
-        let mut buffer = [0u8; BUFFER_SIZE];
+        let mut buffer = vec![0u8; BUFFER_SIZE];
         rng.fill_bytes(&mut buffer);
         file.write_all(&buffer).unwrap();
     }
@@ -418,14 +418,14 @@ fn write(c: &mut Criterion) {
 
     let mut file = NamedTempFile::new().unwrap();
     for _i in 0..FILE_SIZE {
-        let mut buffer = [0u8; BUFFER_SIZE];
+        let mut buffer = vec![0u8; BUFFER_SIZE];
         rng.fill_bytes(&mut buffer);
         file.write_all(&buffer).unwrap();
     }
     file.flush().unwrap();
     let path = file.into_temp_path();
 
-    let mut single_content = [0u8; BUFFER_SIZE];
+    let mut single_content = vec![0u8; BUFFER_SIZE];
     rng.fill_bytes(&mut single_content);
 
     let mut offsets = vec![];
@@ -436,7 +436,7 @@ fn write(c: &mut Criterion) {
 
     let mut content = vec![];
     for _i in 0..WRITE_FILE_SIZE {
-        let mut buffer = [0u8; BUFFER_SIZE];
+        let mut buffer = vec![0u8; BUFFER_SIZE];
         rng.fill_bytes(&mut buffer);
         content.extend_from_slice(&buffer);
     }

--- a/compio/benches/fs.rs
+++ b/compio/benches/fs.rs
@@ -1,5 +1,4 @@
 use std::{
-    hint::black_box,
     io::{Read, Seek, SeekFrom, Write},
     path::Path,
     time::Instant,
@@ -8,7 +7,6 @@ use std::{
 use compio_buf::{IntoInner, IoBuf};
 use compio_io::{AsyncReadAt, AsyncWriteAt};
 use criterion::{Bencher, Criterion, Throughput, criterion_group, criterion_main};
-use futures_util::{StreamExt, stream::FuturesUnordered};
 use rand::{Rng, RngExt, rng};
 use tempfile::NamedTempFile;
 use tokio::io::{AsyncReadExt, AsyncSeekExt, AsyncWriteExt};
@@ -21,12 +19,13 @@ use monoio_wrap::MonoioRuntime;
 criterion_group!(fs, read, write);
 criterion_main!(fs);
 
-const BUFFER_SIZE: usize = 4096;
+const BUFFER_SIZE: usize = 524288;
+const FILE_SIZE: u64 = 1024;
 
 fn read_std(b: &mut Bencher, (path, offsets): &(&Path, &[u64])) {
     let file = std::fs::File::open(path).unwrap();
+    let mut buffer = [0u8; BUFFER_SIZE];
     b.iter(|| {
-        let mut buffer = [0u8; BUFFER_SIZE];
         for &offset in *offsets {
             #[cfg(windows)]
             {
@@ -39,7 +38,6 @@ fn read_std(b: &mut Bencher, (path, offsets): &(&Path, &[u64])) {
                 file.read_at(&mut buffer, offset).unwrap();
             }
         }
-        buffer
     })
 }
 
@@ -51,14 +49,13 @@ fn read_tokio(b: &mut Bencher, (path, offsets): &(&Path, &[u64])) {
     b.to_async(&runtime).iter_custom(|iter| async move {
         let mut file = tokio::fs::File::open(path).await.unwrap();
 
+        let mut buffer = [0u8; BUFFER_SIZE];
         let start = Instant::now();
         for _i in 0..iter {
-            let mut buffer = [0u8; BUFFER_SIZE];
             for &offset in *offsets {
                 file.seek(SeekFrom::Start(offset)).await.unwrap();
                 _ = file.read(&mut buffer).await.unwrap();
             }
-            black_box(buffer);
         }
         start.elapsed()
     })
@@ -69,36 +66,12 @@ fn read_compio(b: &mut Bencher, (path, offsets): &(&Path, &[u64])) {
     b.to_async(&runtime).iter_custom(|iter| async move {
         let file = compio::fs::File::open(path).await.unwrap();
 
+        let mut buffer = Box::new([0u8; BUFFER_SIZE]);
         let start = Instant::now();
         for _i in 0..iter {
-            let mut buffer = Box::new([0u8; BUFFER_SIZE]);
             for &offset in *offsets {
                 (_, buffer) = file.read_at(buffer, offset).await.unwrap();
             }
-            black_box(buffer);
-        }
-        start.elapsed()
-    })
-}
-
-fn read_compio_join(b: &mut Bencher, (path, offsets): &(&Path, &[u64])) {
-    let runtime = compio::runtime::Runtime::new().unwrap();
-    b.to_async(&runtime).iter_custom(|iter| async move {
-        let file = compio::fs::File::open(path).await.unwrap();
-
-        let start = Instant::now();
-        for _i in 0..iter {
-            let res = offsets
-                .iter()
-                .map(|offset| async {
-                    let buffer = Box::new([0u8; BUFFER_SIZE]);
-                    let (_, buffer) = file.read_at(buffer, *offset).await.unwrap();
-                    buffer
-                })
-                .collect::<FuturesUnordered<_>>()
-                .collect::<Vec<_>>()
-                .await;
-            black_box(res);
         }
         start.elapsed()
     })
@@ -110,15 +83,14 @@ fn read_monoio(b: &mut Bencher, (path, offsets): &(&Path, &[u64])) {
     b.to_async(&runtime).iter_custom(|iter| async move {
         let file = monoio::fs::File::open(path).await.unwrap();
 
+        let mut buffer = Box::new([0u8; BUFFER_SIZE]);
         let start = Instant::now();
         for _i in 0..iter {
-            let mut buffer = Box::new([0u8; BUFFER_SIZE]);
             for &offset in *offsets {
                 let res;
                 (res, buffer) = file.read_at(buffer, offset).await;
                 res.unwrap();
             }
-            black_box(buffer);
         }
         start.elapsed()
     })
@@ -126,15 +98,18 @@ fn read_monoio(b: &mut Bencher, (path, offsets): &(&Path, &[u64])) {
 
 fn read_all_std(b: &mut Bencher, (path, len): &(&Path, u64)) {
     let mut file = std::fs::File::open(path).unwrap();
-    b.iter(|| {
+    b.iter_custom(|iter| {
         let mut buffer = [0u8; BUFFER_SIZE];
-        let mut read_len = 0;
-        file.seek(SeekFrom::Start(0)).unwrap();
-        while read_len < *len {
-            let read = file.read(&mut buffer).unwrap();
-            read_len += read as u64;
+        let start = Instant::now();
+        for _i in 0..iter {
+            let mut read_len = 0;
+            file.seek(SeekFrom::Start(0)).unwrap();
+            while read_len < *len {
+                let read = file.read(&mut buffer).unwrap();
+                read_len += read as u64;
+            }
         }
-        buffer
+        start.elapsed()
     })
 }
 
@@ -200,8 +175,6 @@ fn read_all_monoio(b: &mut Bencher, (path, len): &(&Path, u64)) {
 }
 
 fn read(c: &mut Criterion) {
-    const FILE_SIZE: u64 = 1024;
-
     let mut rng = rng();
 
     let mut file = NamedTempFile::new().unwrap();
@@ -224,11 +197,6 @@ fn read(c: &mut Criterion) {
     group.bench_with_input::<_, _, (&Path, &[u64])>("std", &(&path, &offsets), read_std);
     group.bench_with_input::<_, _, (&Path, &[u64])>("tokio", &(&path, &offsets), read_tokio);
     group.bench_with_input::<_, _, (&Path, &[u64])>("compio", &(&path, &offsets), read_compio);
-    group.bench_with_input::<_, _, (&Path, &[u64])>(
-        "compio-join",
-        &(&path, &offsets),
-        read_compio_join,
-    );
     #[cfg(all(target_os = "linux", target_env = "gnu"))]
     group.bench_with_input::<_, _, (&Path, &[u64])>("monoio", &(&path, &offsets), read_monoio);
 
@@ -312,37 +280,6 @@ fn write_compio(b: &mut Bencher, (path, offsets, content): &(&Path, &[u64], &[u8
     })
 }
 
-fn write_compio_join(b: &mut Bencher, (path, offsets, content): &(&Path, &[u64], &[u8])) {
-    let runtime = compio::runtime::Runtime::new().unwrap();
-    let content = content.to_vec();
-    b.to_async(&runtime).iter_custom(|iter| {
-        let content = content.clone();
-        async move {
-            let file = compio::fs::OpenOptions::new()
-                .write(true)
-                .open(path)
-                .await
-                .unwrap();
-
-            let start = Instant::now();
-            for _i in 0..iter {
-                let res = offsets
-                    .iter()
-                    .map(|offset| {
-                        let mut file = &file;
-                        let content = content.clone();
-                        async move { file.write_at(content, *offset).await.unwrap() }
-                    })
-                    .collect::<FuturesUnordered<_>>()
-                    .collect::<Vec<_>>()
-                    .await;
-                black_box(res);
-            }
-            start.elapsed()
-        }
-    })
-}
-
 #[cfg(all(target_os = "linux", target_env = "gnu"))]
 fn write_monoio(b: &mut Bencher, (path, offsets, content): &(&Path, &[u64], &[u8])) {
     let runtime = MonoioRuntime::new();
@@ -363,42 +300,6 @@ fn write_monoio(b: &mut Bencher, (path, offsets, content): &(&Path, &[u64], &[u8
                     (res, content) = file.write_at(content, offset).await;
                     res.unwrap();
                 }
-            }
-            start.elapsed()
-        }
-    })
-}
-
-#[cfg(all(target_os = "linux", target_env = "gnu"))]
-fn write_monoio_join(b: &mut Bencher, (path, offsets, content): &(&Path, &[u64], &[u8])) {
-    let runtime = MonoioRuntime::new();
-    let content = content.to_vec();
-    b.to_async(&runtime).iter_custom(|iter| {
-        let content = content.clone();
-        async move {
-            let file = monoio::fs::OpenOptions::new()
-                .write(true)
-                .open(path)
-                .await
-                .unwrap();
-
-            let start = Instant::now();
-            for _i in 0..iter {
-                let res = offsets
-                    .iter()
-                    .map(|offset| {
-                        let file = &file;
-                        let content = content.clone();
-                        async move {
-                            let (res, content) = file.write_at(content, *offset).await;
-                            res.unwrap();
-                            content
-                        }
-                    })
-                    .collect::<FuturesUnordered<_>>()
-                    .collect::<Vec<_>>()
-                    .await;
-                black_box(res);
             }
             start.elapsed()
         }
@@ -511,7 +412,6 @@ fn write_all_monoio(b: &mut Bencher, (path, content): &(&Path, &[u8])) {
 }
 
 fn write(c: &mut Criterion) {
-    const FILE_SIZE: u64 = 1024;
     const WRITE_FILE_SIZE: u64 = 16;
 
     let mut rng = rng();
@@ -558,22 +458,11 @@ fn write(c: &mut Criterion) {
         &(&path, &offsets, &single_content),
         write_compio,
     );
-    group.bench_with_input::<_, _, (&Path, &[u64], &[u8])>(
-        "compio-join",
-        &(&path, &offsets, &single_content),
-        write_compio_join,
-    );
     #[cfg(all(target_os = "linux", target_env = "gnu"))]
     group.bench_with_input::<_, _, (&Path, &[u64], &[u8])>(
         "monoio",
         &(&path, &offsets, &single_content),
         write_monoio,
-    );
-    #[cfg(all(target_os = "linux", target_env = "gnu"))]
-    group.bench_with_input::<_, _, (&Path, &[u64], &[u8])>(
-        "monoio-join",
-        &(&path, &offsets, &single_content),
-        write_monoio_join,
     );
 
     group.finish();

--- a/compio/benches/net.rs
+++ b/compio/benches/net.rs
@@ -1,4 +1,4 @@
-use std::{net::Ipv4Addr, rc::Rc, time::Instant};
+use std::{net::Ipv4Addr, time::Instant};
 
 use criterion::{Bencher, Criterion, Throughput, criterion_group, criterion_main};
 use rand::{Rng, rng};
@@ -14,31 +14,40 @@ criterion_main!(net);
 const BUFFER_SIZE: usize = 524288;
 const BUFFER_COUNT: usize = 8;
 
-async fn echo_tokio_impl<T, R>(mut tx: T, mut rx: R, content: &[u8; BUFFER_SIZE])
-where
+async fn echo_tokio_impl<T, R>(
+    mut tx: T,
+    mut rx: R,
+    content: &[u8],
+    client_buffer: &mut [u8],
+    server_buffer: &mut [u8],
+) where
     T: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin,
     R: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin,
 {
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
     let client = async move {
-        let mut buffer = [0u8; BUFFER_SIZE];
         for _i in 0..BUFFER_COUNT {
             tx.write_all(content).await.unwrap();
-            tx.read_exact(&mut buffer).await.unwrap();
+            tx.read_exact(client_buffer).await.unwrap();
         }
     };
     let server = async move {
-        let mut buffer = [0u8; BUFFER_SIZE];
         for _i in 0..BUFFER_COUNT {
-            rx.read_exact(&mut buffer).await.unwrap();
-            rx.write_all(&buffer).await.unwrap();
+            rx.read_exact(server_buffer).await.unwrap();
+            rx.write_all(server_buffer).await.unwrap();
         }
     };
     tokio::join!(client, server);
 }
 
-async fn echo_compio_impl<T, R>(mut tx: T, mut rx: R, mut content: Rc<[u8; BUFFER_SIZE]>)
+async fn echo_compio_impl<T, R>(
+    mut tx: T,
+    mut rx: R,
+    mut content: Vec<u8>,
+    mut client_buffer: Vec<u8>,
+    mut server_buffer: Vec<u8>,
+) -> (Vec<u8>, Vec<u8>, Vec<u8>)
 where
     T: compio::io::AsyncRead + compio::io::AsyncWrite,
     R: compio::io::AsyncRead + compio::io::AsyncWrite,
@@ -46,24 +55,31 @@ where
     use compio::io::{AsyncReadExt, AsyncWriteExt};
 
     let client = async move {
-        let mut buffer = Box::new([0u8; BUFFER_SIZE]);
         for _i in 0..BUFFER_COUNT {
             (_, content) = tx.write_all(content).await.unwrap();
-            (_, buffer) = tx.read_exact(buffer).await.unwrap();
+            (_, client_buffer) = tx.read_exact(client_buffer).await.unwrap();
         }
+        (content, client_buffer)
     };
     let server = async move {
-        let mut buffer = Box::new([0u8; BUFFER_SIZE]);
         for _i in 0..BUFFER_COUNT {
-            (_, buffer) = rx.read_exact(buffer).await.unwrap();
-            (_, buffer) = rx.write_all(buffer).await.unwrap();
+            (_, server_buffer) = rx.read_exact(server_buffer).await.unwrap();
+            (_, server_buffer) = rx.write_all(server_buffer).await.unwrap();
         }
+        server_buffer
     };
-    futures_util::join!(client, server);
+    let ((content, client_buffer), server_buffer) = futures_util::join!(client, server);
+    (content, client_buffer, server_buffer)
 }
 
 #[cfg(all(target_os = "linux", target_env = "gnu"))]
-async fn echo_monoio_impl<T, R>(mut tx: T, mut rx: R, mut content: Box<[u8; BUFFER_SIZE]>)
+async fn echo_monoio_impl<T, R>(
+    mut tx: T,
+    mut rx: R,
+    mut content: Vec<u8>,
+    mut client_buffer: Vec<u8>,
+    mut server_buffer: Vec<u8>,
+) -> (Vec<u8>, Vec<u8>, Vec<u8>)
 where
     T: monoio::io::AsyncReadRent + monoio::io::AsyncWriteRent,
     R: monoio::io::AsyncReadRent + monoio::io::AsyncWriteRent,
@@ -71,29 +87,30 @@ where
     use monoio::io::{AsyncReadRentExt, AsyncWriteRentExt};
 
     let client = async {
-        let mut buffer = Box::new([0u8; BUFFER_SIZE]);
         let mut res;
         for _i in 0..BUFFER_COUNT {
             (res, content) = tx.write_all(content).await;
             res.unwrap();
-            (res, buffer) = tx.read_exact(buffer).await;
+            (res, client_buffer) = tx.read_exact(client_buffer).await;
             res.unwrap();
         }
+        (content, client_buffer)
     };
     let server = async move {
-        let mut buffer = Box::new([0u8; BUFFER_SIZE]);
         let mut res;
         for _i in 0..BUFFER_COUNT {
-            (res, buffer) = rx.read_exact(buffer).await;
+            (res, server_buffer) = rx.read_exact(server_buffer).await;
             res.unwrap();
-            (res, buffer) = rx.write_all(buffer).await;
+            (res, server_buffer) = rx.write_all(server_buffer).await;
             res.unwrap();
         }
+        server_buffer
     };
-    futures_util::join!(client, server);
+    let ((content, client_buffer), server_buffer) = futures_util::join!(client, server);
+    (content, client_buffer, server_buffer)
 }
 
-fn echo_tokio_tcp(b: &mut Bencher, content: &[u8; BUFFER_SIZE]) {
+fn echo_tokio_tcp(b: &mut Bencher, content: &[u8]) {
     use tokio::net::{TcpListener, TcpStream};
 
     let runtime = tokio::runtime::Builder::new_current_thread()
@@ -104,31 +121,38 @@ fn echo_tokio_tcp(b: &mut Bencher, content: &[u8; BUFFER_SIZE]) {
         let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).await.unwrap();
         let addr = listener.local_addr().unwrap();
 
+        let mut client_buffer = vec![0u8; BUFFER_SIZE];
+        let mut server_buffer = vec![0u8; BUFFER_SIZE];
+
         let start = Instant::now();
         for _i in 0..iter {
             let (tx, (rx, _)) =
                 tokio::try_join!(TcpStream::connect(addr), listener.accept()).unwrap();
-            echo_tokio_impl(tx, rx, content).await;
+            echo_tokio_impl(tx, rx, content, &mut client_buffer, &mut server_buffer).await;
         }
         start.elapsed()
     })
 }
 
-fn echo_compio_tcp(b: &mut Bencher, content: Rc<[u8; BUFFER_SIZE]>) {
+fn echo_compio_tcp(b: &mut Bencher, content: Vec<u8>) {
     use compio::net::{TcpListener, TcpStream};
 
     let runtime = compio::runtime::Runtime::new().unwrap();
     b.to_async(&runtime).iter_custom(|iter| {
-        let content = content.clone();
+        let mut content = content.clone();
         async move {
             let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).await.unwrap();
             let addr = listener.local_addr().unwrap();
+
+            let mut client_buffer = vec![0u8; BUFFER_SIZE];
+            let mut server_buffer = vec![0u8; BUFFER_SIZE];
 
             let start = Instant::now();
             for _i in 0..iter {
                 let (tx, (rx, _)) =
                     futures_util::try_join!(TcpStream::connect(addr), listener.accept()).unwrap();
-                echo_compio_impl(tx, rx, content.clone()).await;
+                (content, client_buffer, server_buffer) =
+                    echo_compio_impl(tx, rx, content, client_buffer, server_buffer).await;
             }
             start.elapsed()
         }
@@ -136,21 +160,25 @@ fn echo_compio_tcp(b: &mut Bencher, content: Rc<[u8; BUFFER_SIZE]>) {
 }
 
 #[cfg(all(target_os = "linux", target_env = "gnu"))]
-fn echo_monoio_tcp(b: &mut Bencher, content: &[u8; BUFFER_SIZE]) {
+fn echo_monoio_tcp(b: &mut Bencher, content: Vec<u8>) {
     use monoio::net::{TcpListener, TcpStream};
 
     let runtime = MonoioRuntime::new();
     b.to_async(&runtime).iter_custom(|iter| {
-        let content = Box::new(*content);
+        let mut content = content.clone();
         async move {
             let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).unwrap();
             let addr = listener.local_addr().unwrap();
+
+            let mut client_buffer = vec![0u8; BUFFER_SIZE];
+            let mut server_buffer = vec![0u8; BUFFER_SIZE];
 
             let start = Instant::now();
             for _i in 0..iter {
                 let (tx, (rx, _)) =
                     futures_util::try_join!(TcpStream::connect(addr), listener.accept()).unwrap();
-                echo_monoio_impl(tx, rx, content.clone()).await;
+                (content, client_buffer, server_buffer) =
+                    echo_monoio_impl(tx, rx, content, client_buffer, server_buffer).await;
             }
             start.elapsed()
         }
@@ -158,7 +186,7 @@ fn echo_monoio_tcp(b: &mut Bencher, content: &[u8; BUFFER_SIZE]) {
 }
 
 #[cfg(windows)]
-fn echo_tokio_win_named_pipe(b: &mut Bencher, content: &[u8; BUFFER_SIZE]) {
+fn echo_tokio_win_named_pipe(b: &mut Bencher, content: &[u8]) {
     use tokio::net::windows::named_pipe::{ClientOptions, ServerOptions};
 
     let runtime = tokio::runtime::Builder::new_current_thread()
@@ -168,6 +196,9 @@ fn echo_tokio_win_named_pipe(b: &mut Bencher, content: &[u8; BUFFER_SIZE]) {
     b.to_async(&runtime).iter_custom(|iter| async move {
         const PIPE_NAME: &str = r"\\.\pipe\tokio-named-pipe";
 
+        let mut client_buffer = vec![0u8; BUFFER_SIZE];
+        let mut server_buffer = vec![0u8; BUFFER_SIZE];
+
         let start = Instant::now();
         for _i in 0..iter {
             let rx = ServerOptions::new().create(PIPE_NAME).unwrap();
@@ -175,21 +206,24 @@ fn echo_tokio_win_named_pipe(b: &mut Bencher, content: &[u8; BUFFER_SIZE]) {
 
             rx.connect().await.unwrap();
 
-            echo_tokio_impl(tx, rx, content).await;
+            echo_tokio_impl(tx, rx, content, &mut client_buffer, &mut server_buffer).await;
         }
         start.elapsed()
     })
 }
 
 #[cfg(windows)]
-fn echo_compio_win_named_pipe(b: &mut Bencher, content: Rc<[u8; BUFFER_SIZE]>) {
+fn echo_compio_win_named_pipe(b: &mut Bencher, content: Vec<u8>) {
     use compio::fs::named_pipe::{ClientOptions, ServerOptions};
 
     let runtime = compio::runtime::Runtime::new().unwrap();
     b.to_async(&runtime).iter_custom(|iter| {
-        let content = content.clone();
+        let mut content = content.clone();
         async move {
             const PIPE_NAME: &str = r"\\.\pipe\compio-named-pipe";
+
+            let mut client_buffer = vec![0u8; BUFFER_SIZE];
+            let mut server_buffer = vec![0u8; BUFFER_SIZE];
 
             let start = Instant::now();
             let options = ClientOptions::new();
@@ -197,7 +231,8 @@ fn echo_compio_win_named_pipe(b: &mut Bencher, content: Rc<[u8; BUFFER_SIZE]>) {
                 let rx = ServerOptions::new().create(PIPE_NAME).unwrap();
                 let (tx, ()) =
                     futures_util::try_join!(options.open(PIPE_NAME), rx.connect()).unwrap();
-                echo_compio_impl(tx, rx, content.clone()).await;
+                (content, client_buffer, server_buffer) =
+                    echo_compio_impl(tx, rx, content, client_buffer, server_buffer).await;
             }
             start.elapsed()
         }
@@ -205,7 +240,7 @@ fn echo_compio_win_named_pipe(b: &mut Bencher, content: Rc<[u8; BUFFER_SIZE]>) {
 }
 
 #[cfg(unix)]
-fn echo_tokio_unix(b: &mut Bencher, content: &[u8; BUFFER_SIZE]) {
+fn echo_tokio_unix(b: &mut Bencher, content: &[u8]) {
     use tokio::net::{UnixListener, UnixStream};
 
     let runtime = tokio::runtime::Builder::new_current_thread()
@@ -220,22 +255,25 @@ fn echo_tokio_unix(b: &mut Bencher, content: &[u8; BUFFER_SIZE]) {
         let sock_path = dir.path().join("connect.sock");
         let listener = UnixListener::bind(&sock_path).unwrap();
 
+        let mut client_buffer = vec![0u8; BUFFER_SIZE];
+        let mut server_buffer = vec![0u8; BUFFER_SIZE];
+
         let start = Instant::now();
         for _i in 0..iter {
             let (tx, (rx, _)) =
                 tokio::try_join!(UnixStream::connect(&sock_path), listener.accept()).unwrap();
-            echo_tokio_impl(tx, rx, content).await;
+            echo_tokio_impl(tx, rx, content, &mut client_buffer, &mut server_buffer).await;
         }
         start.elapsed()
     })
 }
 
-fn echo_compio_unix(b: &mut Bencher, content: Rc<[u8; BUFFER_SIZE]>) {
+fn echo_compio_unix(b: &mut Bencher, content: Vec<u8>) {
     use compio::net::{UnixListener, UnixStream};
 
     let runtime = compio::runtime::Runtime::new().unwrap();
     b.to_async(&runtime).iter_custom(|iter| {
-        let content = content.clone();
+        let mut content = content.clone();
         async move {
             let dir = tempfile::Builder::new()
                 .prefix("compio-uds")
@@ -244,12 +282,16 @@ fn echo_compio_unix(b: &mut Bencher, content: Rc<[u8; BUFFER_SIZE]>) {
             let sock_path = dir.path().join("connect.sock");
             let listener = UnixListener::bind(&sock_path).await.unwrap();
 
+            let mut client_buffer = vec![0u8; BUFFER_SIZE];
+            let mut server_buffer = vec![0u8; BUFFER_SIZE];
+
             let start = Instant::now();
             for _i in 0..iter {
                 let (tx, (rx, _)) =
                     futures_util::try_join!(UnixStream::connect(&sock_path), listener.accept())
                         .unwrap();
-                echo_compio_impl(tx, rx, content.clone()).await;
+                (content, client_buffer, server_buffer) =
+                    echo_compio_impl(tx, rx, content, client_buffer, server_buffer).await;
             }
             start.elapsed()
         }
@@ -257,12 +299,12 @@ fn echo_compio_unix(b: &mut Bencher, content: Rc<[u8; BUFFER_SIZE]>) {
 }
 
 #[cfg(all(target_os = "linux", target_env = "gnu"))]
-fn echo_monoio_unix(b: &mut Bencher, content: &[u8; BUFFER_SIZE]) {
+fn echo_monoio_unix(b: &mut Bencher, content: Vec<u8>) {
     use monoio::net::{ListenerOpts, UnixListener, UnixStream};
 
     let runtime = MonoioRuntime::new();
     b.to_async(&runtime).iter_custom(|iter| {
-        let content = Box::new(*content);
+        let mut content = content.clone();
         async move {
             let dir = tempfile::Builder::new()
                 .prefix("monoio-uds")
@@ -275,12 +317,16 @@ fn echo_monoio_unix(b: &mut Bencher, content: &[u8; BUFFER_SIZE]) {
             )
             .unwrap();
 
+            let mut client_buffer = vec![0u8; BUFFER_SIZE];
+            let mut server_buffer = vec![0u8; BUFFER_SIZE];
+
             let start = Instant::now();
             for _i in 0..iter {
                 let (tx, (rx, _)) =
                     futures_util::try_join!(UnixStream::connect(&sock_path), listener.accept())
                         .unwrap();
-                echo_monoio_impl(tx, rx, content.clone()).await;
+                (content, client_buffer, server_buffer) =
+                    echo_monoio_impl(tx, rx, content, client_buffer, server_buffer).await;
             }
             start.elapsed()
         }
@@ -290,9 +336,8 @@ fn echo_monoio_unix(b: &mut Bencher, content: &[u8; BUFFER_SIZE]) {
 fn echo(c: &mut Criterion) {
     let mut rng = rng();
 
-    let mut content = [0u8; BUFFER_SIZE];
+    let mut content = vec![0u8; BUFFER_SIZE];
     rng.fill_bytes(&mut content);
-    let content = Rc::new(content);
 
     let mut group = c.benchmark_group("echo");
     group.throughput(Throughput::Bytes((BUFFER_SIZE * BUFFER_COUNT * 2) as u64));
@@ -300,7 +345,7 @@ fn echo(c: &mut Criterion) {
     group.bench_function("tokio-tcp", |b| echo_tokio_tcp(b, &content));
     group.bench_function("compio-tcp", |b| echo_compio_tcp(b, content.clone()));
     #[cfg(all(target_os = "linux", target_env = "gnu"))]
-    group.bench_function("monoio-tcp", |b| echo_monoio_tcp(b, &content));
+    group.bench_function("monoio-tcp", |b| echo_monoio_tcp(b, content.clone()));
 
     #[cfg(windows)]
     group.bench_function("tokio-pipe", |b| echo_tokio_win_named_pipe(b, &content));
@@ -313,7 +358,7 @@ fn echo(c: &mut Criterion) {
     group.bench_function("tokio-unix", |b| echo_tokio_unix(b, &content));
     group.bench_function("compio-unix", |b| echo_compio_unix(b, content.clone()));
     #[cfg(all(target_os = "linux", target_env = "gnu"))]
-    group.bench_function("monoio-unix", |b| echo_monoio_unix(b, &content));
+    group.bench_function("monoio-unix", |b| echo_monoio_unix(b, content.clone()));
 
     group.finish();
 }


### PR DESCRIPTION
I removed all possible allocations out of the benchmark region, and enlarged the buffer.