### PR TITLE
feat(io)!: use shared ref in *_at

### DIFF
--- a/compio-io/src/read/ext.rs
+++ b/compio-io/src/read/ext.rs
@@ -304,7 +304,7 @@ pub trait AsyncReadAtExt: AsyncReadAt {
 
     /// Read all bytes as [`String`] until EOF in this source, placing them into
     /// `buffer`.
-    async fn read_to_string_at(&mut self, buf: String, pos: u64) -> BufResult<usize, String> {
+    async fn read_to_string_at(&self, buf: String, pos: u64) -> BufResult<usize, String> {
         let BufResult(res, buf) = self.read_to_end_at(buf.into_bytes(), pos).await;
         after_read_to_string(res, buf)
     }

--- a/compio-io/tests/io.rs
+++ b/compio-io/tests/io.rs
@@ -461,7 +461,7 @@ fn read_to_string_at() {
     block_on(async {
         let mut src = vec![1, 1];
         src.extend_from_slice("test".as_bytes());
-        let mut src = ReadOneAt(src);
+        let src = ReadOneAt(src);
 
         let (len, buf) = src.read_to_string_at(String::new(), 2).await.unwrap();
         assert_eq!(len, 4);


### PR DESCRIPTION
I don't know why we required `&mut` in read_to_string_at before... It's just... I think we should make it consistent.