### PR TITLE
feat(driver): method to flush the operations

### DIFF
--- a/compio-driver/src/lib.rs
+++ b/compio-driver/src/lib.rs
@@ -272,6 +272,22 @@ impl Proactor {
         }
     }
 
+    /// Flush the pushed operations to the kernel. If is roughly equivalent to
+    /// calling [`poll`](Proactor::poll) with `Some(Duration::ZERO)` on
+    /// io-uring, but is only needed if you're waiting the driver fd with an
+    /// external event loop.
+    ///
+    /// The return value indicates if the driver is in notified state, which
+    /// means the driver is already notified by the user and should not be
+    /// waited infinitely.
+    ///
+    /// This method resets the internal notified state, so that the waker to the
+    /// driver will wake up the driver fd through syscalls after this method is
+    /// called.
+    pub fn flush(&mut self) -> bool {
+        self.driver.flush()
+    }
+
     /// Poll the driver and get completed entries.
     /// You need to call [`Proactor::pop`] to get the pushed
     /// operations.

--- a/compio-driver/src/lib.rs
+++ b/compio-driver/src/lib.rs
@@ -272,9 +272,9 @@ impl Proactor {
         }
     }
 
-    /// Flush the pushed operations to the kernel. If is roughly equivalent to
+    /// Flush the pushed operations to the kernel. It is roughly equivalent to
     /// calling [`poll`](Proactor::poll) with `Some(Duration::ZERO)` on
-    /// io-uring, but is only needed if you're waiting the driver fd with an
+    /// io-uring, but is only needed if you're waiting on the driver fd with an
     /// external event loop.
     ///
     /// The return value indicates if the driver is in notified state, which

--- a/compio-driver/src/sys/driver/fusion/mod.rs
+++ b/compio-driver/src/sys/driver/fusion/mod.rs
@@ -101,6 +101,13 @@ impl Driver {
         }
     }
 
+    pub fn flush(&mut self) -> bool {
+        match &mut self.fuse {
+            FuseDriver::Poll(driver) => driver.flush(),
+            FuseDriver::IoUring(driver) => driver.flush(),
+        }
+    }
+
     pub fn poll(&mut self, timeout: Option<Duration>) -> io::Result<()> {
         match &mut self.fuse {
             FuseDriver::Poll(driver) => driver.poll(timeout),

--- a/compio-driver/src/sys/driver/iocp/mod.rs
+++ b/compio-driver/src/sys/driver/iocp/mod.rs
@@ -141,6 +141,10 @@ impl Driver {
         }
     }
 
+    pub fn flush(&mut self) -> bool {
+        self.notify.reset()
+    }
+
     fn create_entry(
         notify: *const Overlapped,
         waits: &mut HashMap<usize, wait::Wait>,

--- a/compio-driver/src/sys/driver/iour/mod.rs
+++ b/compio-driver/src/sys/driver/iour/mod.rs
@@ -355,6 +355,12 @@ impl Driver {
         }
     }
 
+    pub fn flush(&mut self) -> bool {
+        let succeed = self.submit_auto(Some(Duration::ZERO), false).is_ok();
+        // If submission failed, return true to let the driver wake up immediately.
+        !succeed | self.notifier.reset()
+    }
+
     pub fn poll(&mut self, timeout: Option<Duration>) -> io::Result<()> {
         instrument!(compio_log::Level::TRACE, "poll", ?timeout);
 
@@ -382,6 +388,7 @@ impl Driver {
 
         self.notifier.set_awake();
         self.poll_entries();
+        self.notifier.set_awake();
 
         Ok(())
     }

--- a/compio-driver/src/sys/driver/mod.rs
+++ b/compio-driver/src/sys/driver/mod.rs
@@ -39,7 +39,7 @@ impl AwakeFlag {
     /// Set the awake flag. It is true before the driver sleeps, and false after
     /// it wakes up.
     pub fn set(&self) {
-        self.0.fetch_or(AWAKE, Ordering::AcqRel);
+        self.0.store(AWAKE, Ordering::Release);
     }
 
     /// Reset the flags. Returns true if it was notified.

--- a/compio-driver/src/sys/driver/mod.rs
+++ b/compio-driver/src/sys/driver/mod.rs
@@ -36,8 +36,8 @@ impl AwakeFlag {
         Self(AtomicU8::new(IDLE))
     }
 
-    /// Set the awake flag. It is true before the driver sleeps, and false after
-    /// it wakes up.
+    /// Mark the driver as awake by overwriting the flag byte with `AWAKE`.
+    /// This intentionally clears any previously set `NOTIFIED` flag.
     pub fn set(&self) {
         self.0.store(AWAKE, Ordering::Release);
     }

--- a/compio-driver/src/sys/driver/poll/mod.rs
+++ b/compio-driver/src/sys/driver/poll/mod.rs
@@ -389,6 +389,10 @@ impl Driver {
         }
     }
 
+    pub fn flush(&mut self) -> bool {
+        self.notify.reset()
+    }
+
     fn poll_completed(&mut self) -> bool {
         let mut ret = false;
         while let Ok(entry) = self.completed_rx.try_recv() {
@@ -501,6 +505,7 @@ impl Driver {
                 }
             }
 
+            this.notify.set_awake();
             Ok(())
         })
     }

--- a/compio-driver/src/sys/driver/poll/mod.rs
+++ b/compio-driver/src/sys/driver/poll/mod.rs
@@ -173,6 +173,8 @@ impl Driver {
     {
         let mut events = std::mem::take(&mut self.events);
         let res = f(self, &mut events);
+        // Clear the notification state to avoid empty loops.
+        self.notify.set_awake();
         self.events = events;
         res
     }
@@ -505,7 +507,6 @@ impl Driver {
                 }
             }
 
-            this.notify.set_awake();
             Ok(())
         })
     }

--- a/compio-driver/src/sys/driver/stub/mod.rs
+++ b/compio-driver/src/sys/driver/stub/mod.rs
@@ -61,6 +61,10 @@ impl Driver {
         Poll::Ready(Err(stub_error()))
     }
 
+    pub fn flush(&mut self) -> bool {
+        false
+    }
+
     pub fn poll(&mut self, _: Option<Duration>) -> io::Result<()> {
         Ok(())
     }

--- a/compio-runtime/src/lib.rs
+++ b/compio-runtime/src/lib.rs
@@ -267,6 +267,13 @@ impl Runtime {
         SubmitMulti::new(self.clone(), op)
     }
 
+    /// Flush the driver and return whether the driver has been notified.
+    ///
+    /// See [`Proactor::flush`] for more details.
+    pub fn flush(&self) -> bool {
+        self.driver.borrow_mut().flush()
+    }
+
     pub(crate) fn cancel<T: OpCode>(&self, key: Key<T>) {
         self.driver.borrow_mut().cancel(key);
     }


### PR DESCRIPTION
Introduce a new method `Proactor::flush`, which is only used in an external event loop, e.g., `compio-compat`. It does 2 tasks:
* If it is io-uring, submit the pushed sqes.
* Reset the awake flag. It is helpful if the user wants to wait for the driver fd with other syscalls rather than `Proactor::poll`.

I also fixed the `poll` method of io-uring & polling driver, to set the awake flag to `AWAKE` (0x10) after processing received entries. When processing the entries, `Entry::notify()` may set the awake flag to `AWAKE | NOTIFIED` (0x11), which will make the next call to `Proactor::poll` return immediately.

If there are some wakers on the other thread woken during the processing, it is OK because:
* If the waker is from `Runtime::block_on`, anyway the future will be polled after `Proactor::poll` returns;
* If the waker is from `Runtime::spawn`, the executor will schedule the future and it will be executed after `Proactor::poll` returns.

@George-Miao Please review this PR first and I will publish a release for compio after this PR.