### PR TITLE
fix(driver): bounds-check buffer_id in Shared::reset

### DIFF
--- a/compio-driver/src/buffer_pool.rs
+++ b/compio-driver/src/buffer_pool.rs
@@ -351,6 +351,7 @@ impl Shared {
     fn reset(&self, buffer_id: u16, ptr: BufPtr) {
         unsafe {
             self.with(|inner| {
+                // This method might be called after `BufferPoolRoot::release`.
                 if let Some(slot) = inner.bufs.get_mut(buffer_id as usize) {
                     *slot = Some(ptr);
                     inner.ctrl.reset(buffer_id, ptr, inner.size);

--- a/compio-driver/src/buffer_pool.rs
+++ b/compio-driver/src/buffer_pool.rs
@@ -351,8 +351,12 @@ impl Shared {
     fn reset(&self, buffer_id: u16, ptr: BufPtr) {
         unsafe {
             self.with(|inner| {
-                inner.bufs[buffer_id as usize] = Some(ptr);
-                inner.ctrl.reset(buffer_id, ptr, inner.size);
+                if let Some(slot) = inner.bufs.get_mut(buffer_id as usize) {
+                    *slot = Some(ptr);
+                    inner.ctrl.reset(buffer_id, ptr, inner.size);
+                } else {
+                    (inner.alloc.deallocate)(ptr, inner.size);
+                }
             })
         }
     }


### PR DESCRIPTION
Reproduces under macOS kqueue when closing sockets under backpressure (OMQ PUSH socket saturating a PULL socket with low HWM).