### PR TITLE
fix(driver): use self-pipe instead of Poller::notify() on poll backend

### DIFF
--- a/compio-driver/src/sys/driver/poll/mod.rs
+++ b/compio-driver/src/sys/driver/poll/mod.rs
@@ -132,6 +132,8 @@ pub(crate) struct Driver {
 }
 
 impl Driver {
+    const WAKER_PIPE_KEY: usize = usize::MAX - 1;
+
     pub fn new(builder: &ProactorBuilder) -> io::Result<Self> {
         instrument!(compio_log::Level::TRACE, "new", ?builder);
         trace!("new poll driver");
@@ -142,7 +144,7 @@ impl Driver {
             Events::new()
         };
         let poll = Poller::new()?;
-        let notify = Arc::new(Notify::new(poll));
+        let notify = Arc::new(Notify::new(poll)?);
         let (completed_tx, completed_rx) = flume::unbounded();
 
         Ok(Self {
@@ -450,10 +452,9 @@ impl Driver {
         if !need_wait || has_completed {
             timeout = Some(Duration::ZERO);
         }
-        // We need to poll the poller first to make sure it handles the internal notify
-        // event (if any).
         self.events.clear();
         self.notify.poll.wait(&mut self.events, timeout)?;
+        self.notify.drain_and_reregister();
         self.notify.set_awake();
         if self.events.is_empty() {
             if self.poll_completed() {
@@ -467,6 +468,9 @@ impl Driver {
         }
         self.with_events(|this, events| {
             for event in events.iter() {
+                if event.key == Self::WAKER_PIPE_KEY {
+                    continue;
+                }
                 trace!("receive {} for {:?}", event.key, event);
                 // SAFETY: user_data is promised to be valid.
                 let key = unsafe { BorrowedKey::from_raw(event.key) };
@@ -528,6 +532,7 @@ impl AsRawFd for Driver {
 
 impl Drop for Driver {
     fn drop(&mut self) {
+        self.poller().delete(self.notify.pipe_read.as_fd()).ok();
         for fd in self.registry.keys() {
             unsafe {
                 let fd = BorrowedFd::borrow_raw(*fd);
@@ -544,17 +549,73 @@ impl Entry {
 }
 
 /// A notify handle to the inner driver.
+///
+/// Uses a self-pipe registered with the [`Poller`] instead of
+/// [`Poller::notify()`] to wake the driver. This bypasses the polling
+/// crate's internal notification deduplication, which can suppress
+/// wakeups on kqueue backends (macOS).
 pub(crate) struct Notify {
     poll: Poller,
     awake: AwakeFlag,
+    pipe_read: OwnedFd,
+    pipe_write: OwnedFd,
+}
+
+impl std::fmt::Debug for Notify {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Notify")
+            .field("poll", &self.poll)
+            .field("awake", &self.awake)
+            .finish_non_exhaustive()
+    }
 }
 
 impl Notify {
-    fn new(poll: Poller) -> Self {
-        Self {
+    fn new(poll: Poller) -> io::Result<Self> {
+        let (pipe_read, pipe_write) = Self::create_pipe()?;
+        unsafe {
+            poll.add(
+                pipe_read.as_raw_fd(),
+                Event::readable(Driver::WAKER_PIPE_KEY),
+            )?;
+        }
+        Ok(Self {
             poll,
             awake: AwakeFlag::new(),
-        }
+            pipe_read,
+            pipe_write,
+        })
+    }
+
+    #[cfg(not(any(apple, target_os = "aix", target_os = "espidf",
+        target_os = "haiku", target_os = "horizon", target_os = "nto")))]
+    fn create_pipe() -> io::Result<(OwnedFd, OwnedFd)> {
+        use rustix::pipe::{PipeFlags, pipe_with};
+        Ok(pipe_with(PipeFlags::NONBLOCK | PipeFlags::CLOEXEC)?)
+    }
+
+    #[cfg(any(apple, target_os = "aix", target_os = "espidf",
+        target_os = "haiku", target_os = "horizon", target_os = "nto"))]
+    fn create_pipe() -> io::Result<(OwnedFd, OwnedFd)> {
+        use rustix::fs::{OFlags, fcntl_getfl, fcntl_setfl};
+        use rustix::io::{FdFlags, fcntl_getfd, fcntl_setfd};
+        let (r, w) = rustix::pipe::pipe()?;
+        fcntl_setfd(&r, fcntl_getfd(&r)? | FdFlags::CLOEXEC)?;
+        fcntl_setfd(&w, fcntl_getfd(&w)? | FdFlags::CLOEXEC)?;
+        fcntl_setfl(&r, fcntl_getfl(&r)? | OFlags::NONBLOCK)?;
+        fcntl_setfl(&w, fcntl_getfl(&w)? | OFlags::NONBLOCK)?;
+        Ok((r, w))
+    }
+
+    fn drain_and_reregister(&self) {
+        let mut buf = [0u8; 64];
+        while rustix::io::read(&self.pipe_read, &mut buf).is_ok() {}
+        self.poll
+            .modify(
+                self.pipe_read.as_fd(),
+                Event::readable(Driver::WAKER_PIPE_KEY),
+            )
+            .ok();
     }
 
     fn set_awake(&self) {
@@ -573,7 +634,7 @@ impl Wake for Notify {
 
     fn wake_by_ref(self: &Arc<Self>) {
         if !self.awake.wake() {
-            self.poll.notify().ok();
+            rustix::io::write(&self.pipe_write, &[1u8]).ok();
         }
     }
 }

--- a/compio-runtime/Cargo.toml
+++ b/compio-runtime/Cargo.toml
@@ -37,6 +37,9 @@ windows-sys = { workspace = true, features = ["Win32_System_IO"] }
 [target.'cfg(unix)'.dependencies]
 libc = { workspace = true }
 
+[dev-dependencies]
+flume = { workspace = true, features = ["async"] }
+
 [target.'cfg(windows)'.dev-dependencies]
 windows-sys = { workspace = true, features = ["Win32_UI_WindowsAndMessaging"] }
 
@@ -65,4 +68,8 @@ name = "event"
 
 [[test]]
 name = "drop"
+required-features = ["time"]
+
+[[test]]
+name = "waker"
 required-features = ["time"]

--- a/compio-runtime/tests/waker.rs
+++ b/compio-runtime/tests/waker.rs
@@ -1,0 +1,56 @@
+use std::time::{Duration, Instant};
+
+use compio_runtime::ResumeUnwind;
+
+#[test]
+fn cross_thread_waker_interrupts_poll() {
+    let rt = compio_runtime::Runtime::new().unwrap();
+    rt.block_on(async {
+        let (tx, rx) = flume::bounded::<u32>(1);
+
+        let handle = compio_runtime::spawn(async move {
+            rx.recv_async().await.unwrap()
+        });
+
+        std::thread::spawn(move || {
+            std::thread::sleep(Duration::from_millis(10));
+            tx.send(42).unwrap();
+        });
+
+        let start = Instant::now();
+        let val = handle.await.resume_unwind().unwrap();
+        let elapsed = start.elapsed();
+
+        assert_eq!(val, 42);
+        assert!(
+            elapsed < Duration::from_millis(200),
+            "took {elapsed:?}, expected < 200ms"
+        );
+    });
+}
+
+#[test]
+fn same_thread_waker_schedules_promptly() {
+    let rt = compio_runtime::Runtime::new().unwrap();
+    rt.block_on(async {
+        let (tx, rx) = flume::bounded::<u32>(1);
+
+        compio_runtime::spawn(async move {
+            let val = rx.recv_async().await.unwrap();
+            assert_eq!(val, 42);
+        })
+        .detach();
+
+        compio_runtime::time::sleep(Duration::from_millis(10)).await;
+
+        let start = Instant::now();
+        tx.send(42).unwrap();
+        compio_runtime::time::sleep(Duration::from_millis(200)).await;
+        let elapsed = start.elapsed();
+
+        assert!(
+            elapsed < Duration::from_millis(400),
+            "took {elapsed:?}, expected < 400ms"
+        );
+    });
+}


### PR DESCRIPTION
## Summary

`Poller::notify()` is unreliable on kqueue (macOS):

1. The internal `compare_exchange` in the polling crate can suppress notifications when the driver is already marked as notified.
2. `Events::is_empty()` filters out `NOTIFY_KEY` events, making `EVFILT_USER` wakeups invisible to the driver.

This causes task wakeups to get lost, stalling I/O completion delivery. Every TCP/IPC test in our downstream project (omq) times out on macOS with compio master because handshake I/O events are never delivered.

## Fix

Replace `Poller::notify()` with a dedicated self-pipe registered directly with the Poller:

- Create a non-blocking pipe at driver init
- Register the read end as a oneshot readable interest
- `wake()` writes a byte to the pipe instead of calling `Poller::notify()`
- After each `Poller::wait()`, drain the pipe and re-register

The `AwakeFlag` optimization is preserved: the pipe write is only issued when the driver is idle.

## Test plan

- Added `cross_thread_waker_interrupts_poll` and `same_thread_waker_schedules_promptly` tests in `compio-runtime/tests/waker.rs`
- Downstream: omq test suite passes on macOS (previously 100% TCP/IPC test failure rate)

Rebased on current master (cb8f77ea).