### PR TITLE
feat(io,net)!: expose recvmsg return flags

### DIFF
--- a/compio-driver/src/sys/driver/iocp/cp/mod.rs
+++ b/compio-driver/src/sys/driver/iocp/cp/mod.rs
@@ -24,8 +24,9 @@ use compio_log::*;
 use windows_sys::Win32::{
     Foundation::{
         ERROR_BAD_COMMAND, ERROR_BROKEN_PIPE, ERROR_HANDLE_EOF, ERROR_IO_INCOMPLETE,
-        ERROR_NETNAME_DELETED, ERROR_NO_DATA, ERROR_PIPE_CONNECTED, ERROR_PIPE_NOT_CONNECTED,
-        FACILITY_NTWIN32, INVALID_HANDLE_VALUE, NTSTATUS, RtlNtStatusToDosError, STATUS_SUCCESS,
+        ERROR_MORE_DATA, ERROR_NETNAME_DELETED, ERROR_NO_DATA, ERROR_PIPE_CONNECTED,
+        ERROR_PIPE_NOT_CONNECTED, FACILITY_NTWIN32, INVALID_HANDLE_VALUE, NTSTATUS,
+        RtlNtStatusToDosError, STATUS_SUCCESS,
     },
     Storage::FileSystem::SetFileCompletionNotificationModes,
     System::{
@@ -193,7 +194,8 @@ impl CompletionPort {
                     | ERROR_BROKEN_PIPE
                     | ERROR_PIPE_CONNECTED
                     | ERROR_PIPE_NOT_CONNECTED
-                    | ERROR_NO_DATA => Ok(0),
+                    | ERROR_NO_DATA
+                    | ERROR_MORE_DATA => Ok(0),
                     _ => Err(io::Error::from_raw_os_error(error as _)),
                 }
             };

--- a/compio-driver/src/sys/op/ext.rs
+++ b/compio-driver/src/sys/op/ext.rs
@@ -1,5 +1,7 @@
 //! Extension traits
 
+use rustix::net::ReturnFlags;
+
 use crate::sys::prelude::*;
 
 /// Take buffer out of an operation.
@@ -164,6 +166,38 @@ impl<T: SetLen + IoVectoredBuf, C: SetLen + IoBuf, O> VecBufResultExt
     }
 }
 
+impl<T: SetLen + IoBuf, C: SetLen + IoBuf, O1, O2> BufResultExt
+    for BufResult<(usize, usize, O1, O2), (T, C)>
+{
+    unsafe fn map_advanced(self) -> Self {
+        self.map(
+            |(init_buffer, init_control, obj1, obj2), (mut buffer, mut control)| {
+                unsafe {
+                    buffer.advance_to(init_buffer);
+                    control.advance_to(init_control);
+                }
+                ((init_buffer, init_control, obj1, obj2), (buffer, control))
+            },
+        )
+    }
+}
+
+impl<T: SetLen + IoVectoredBuf, C: SetLen + IoBuf, O1, O2> VecBufResultExt
+    for BufResult<(usize, usize, O1, O2), (T, C)>
+{
+    unsafe fn map_vec_advanced(self) -> Self {
+        self.map(
+            |(init_buffer, init_control, obj1, obj2), (mut buffer, mut control)| {
+                unsafe {
+                    buffer.advance_vec_to(init_buffer);
+                    control.advance_to(init_control);
+                }
+                ((init_buffer, init_control, obj1, obj2), (buffer, control))
+            },
+        )
+    }
+}
+
 /// Helper trait for [`RecvFrom`], [`RecvFromVectored`] and [`RecvMsg`].
 ///
 /// [`RecvFrom`]: crate::op::RecvFrom
@@ -193,6 +227,17 @@ impl<T> RecvResultExt for BufResult<usize, (T, Option<SockAddr>, usize)> {
     fn map_addr(self) -> Self::RecvResult {
         self.map2(
             |res, (buffer, addr, len)| ((res, len, addr), buffer),
+            |(buffer, ..)| buffer,
+        )
+    }
+}
+
+impl<T> RecvResultExt for BufResult<usize, (T, Option<SockAddr>, usize, ReturnFlags)> {
+    type RecvResult = BufResult<(usize, usize, Option<SockAddr>, ReturnFlags), T>;
+
+    fn map_addr(self) -> Self::RecvResult {
+        self.map2(
+            |res, (buffer, addr, len, flags)| ((res, len, addr, flags), buffer),
             |(buffer, ..)| buffer,
         )
     }

--- a/compio-driver/src/sys/op/managed/fallback.rs
+++ b/compio-driver/src/sys/op/managed/fallback.rs
@@ -140,11 +140,11 @@ impl<C: IoBufMut, S: AsFd> PollFirst for RecvMsgManaged<C, S> {
 }
 
 impl<C: IoBufMut, S: AsFd> TakeBuffer for RecvMsgManaged<C, S> {
-    type Buffer = ((BufferRef, C), Option<SockAddr>, usize);
+    type Buffer = ((BufferRef, C), Option<SockAddr>, usize, ReturnFlags);
 
     fn take_buffer(self) -> Option<Self::Buffer> {
-        let (([buf], control), addr, len, _flags) = self.op.into_inner();
-        Some(((buf, control), addr, len))
+        let (([buf], control), addr, len, flags) = self.op.into_inner();
+        Some(((buf, control), addr, len, flags))
     }
 }
 
@@ -276,8 +276,7 @@ impl<S: AsFd> TakeBuffer for RecvMsgMulti<S> {
     type Buffer = RecvMsgMultiResult;
 
     fn take_buffer(self) -> Option<Self::Buffer> {
-        let (([mut buffer], mut control), addr, control_len, return_flags) =
-            self.op.op.into_inner();
+        let ((mut buffer, mut control), addr, control_len, return_flags) = self.op.take_buffer()?;
         unsafe { buffer.advance_to(self.len) };
         unsafe { control.advance_to(control_len) };
         Some(RecvMsgMultiResult {

--- a/compio-driver/src/sys/op/managed/fallback.rs
+++ b/compio-driver/src/sys/op/managed/fallback.rs
@@ -1,7 +1,7 @@
 use std::io;
 
 use compio_buf::{IntoInner, IoBuf, IoBufMut, SetLen};
-use rustix::net::RecvFlags;
+use rustix::net::{RecvFlags, ReturnFlags};
 use socket2::SockAddr;
 
 use crate::{
@@ -217,6 +217,7 @@ pub struct RecvMsgMultiResult {
     buffer: BufferRef,
     control: BufferRef,
     addr: Option<SockAddr>,
+    return_flags: ReturnFlags,
 }
 
 impl RecvMsgMultiResult {
@@ -238,6 +239,11 @@ impl RecvMsgMultiResult {
     /// Get the ancillary data.
     pub fn ancillary(&self) -> &[u8] {
         self.control.as_init()
+    }
+
+    /// Get flags returned by `recvmsg`.
+    pub fn flags(&self) -> ReturnFlags {
+        self.return_flags
     }
 }
 
@@ -270,13 +276,15 @@ impl<S: AsFd> TakeBuffer for RecvMsgMulti<S> {
     type Buffer = RecvMsgMultiResult;
 
     fn take_buffer(self) -> Option<Self::Buffer> {
-        let ((mut buffer, mut control), addr, control_len) = self.op.take_buffer()?;
+        let (([mut buffer], mut control), addr, control_len, return_flags) =
+            self.op.op.into_inner();
         unsafe { buffer.advance_to(self.len) };
         unsafe { control.advance_to(control_len) };
         Some(RecvMsgMultiResult {
             buffer,
             control,
             addr,
+            return_flags,
         })
     }
 }

--- a/compio-driver/src/sys/op/managed/fallback.rs
+++ b/compio-driver/src/sys/op/managed/fallback.rs
@@ -143,7 +143,7 @@ impl<C: IoBufMut, S: AsFd> TakeBuffer for RecvMsgManaged<C, S> {
     type Buffer = ((BufferRef, C), Option<SockAddr>, usize);
 
     fn take_buffer(self) -> Option<Self::Buffer> {
-        let (([buf], control), addr, len) = self.op.into_inner();
+        let (([buf], control), addr, len, _flags) = self.op.into_inner();
         Some(((buf, control), addr, len))
     }
 }

--- a/compio-driver/src/sys/op/managed/fusion.rs
+++ b/compio-driver/src/sys/op/managed/fusion.rs
@@ -1,5 +1,5 @@
 use compio_buf::*;
-use rustix::net::RecvFlags;
+use rustix::net::{RecvFlags, ReturnFlags};
 use socket2::SockAddr;
 
 use super::{fallback, iour};
@@ -293,6 +293,14 @@ impl RecvMsgMultiResult {
         match &self.inner {
             RecvMsgMultiResultInner::Poll(result) => result.addr(),
             RecvMsgMultiResultInner::IoUring(result) => result.addr(),
+        }
+    }
+
+    /// Get flags returned by `recvmsg`.
+    pub fn flags(&self) -> ReturnFlags {
+        match &self.inner {
+            RecvMsgMultiResultInner::Poll(result) => result.flags(),
+            RecvMsgMultiResultInner::IoUring(result) => result.flags(),
         }
     }
 }

--- a/compio-driver/src/sys/op/managed/fusion.rs
+++ b/compio-driver/src/sys/op/managed/fusion.rs
@@ -126,7 +126,7 @@ mop!(<S: AsFd> ReadManagedAt(fd: S, offset: u64, pool: &BufferPool, len: usize) 
 mop!(<S: AsFd> ReadManaged(fd: S, pool: &BufferPool, len: usize) with pool);
 mop!(<S: AsFd> RecvManaged(fd: S, pool: &BufferPool, len: usize, flags: RecvFlags) with pool);
 mop!(<S: AsFd> RecvFromManaged(fd: S, pool: &BufferPool, len: usize, flags: RecvFlags) with pool; (BufferRef, Option<SockAddr>));
-mop!(<C: IoBufMut, S: AsFd> RecvMsgManaged(fd: S, pool: &BufferPool, len: usize, control: C, flags: RecvFlags) with pool; ((BufferRef, C), Option<SockAddr>, usize));
+mop!(<C: IoBufMut, S: AsFd> RecvMsgManaged(fd: S, pool: &BufferPool, len: usize, control: C, flags: RecvFlags) with pool; ((BufferRef, C), Option<SockAddr>, usize, ReturnFlags));
 mop!(<S: AsFd> ReadMultiAt(fd: S, offset: u64, pool: &BufferPool, len: usize) with pool);
 mop!(<S: AsFd> ReadMulti(fd: S, pool: &BufferPool, len: usize) with pool);
 mop!(<S: AsFd> RecvMulti(fd: S, pool: &BufferPool, len: usize, flags: RecvFlags) with pool);

--- a/compio-driver/src/sys/op/managed/iour.rs
+++ b/compio-driver/src/sys/op/managed/iour.rs
@@ -367,11 +367,11 @@ unsafe impl<C: IoBufMut, S: AsFd> OpCode for RecvMsgManaged<C, S> {
 }
 
 impl<C: IoBufMut, S: AsFd> TakeBuffer for RecvMsgManaged<C, S> {
-    type Buffer = ((BufferRef, C), Option<SockAddr>, usize);
+    type Buffer = ((BufferRef, C), Option<SockAddr>, usize, ReturnFlags);
 
     fn take_buffer(self) -> Option<Self::Buffer> {
         let (buffer, addr) = self.op.take_buffer()?;
-        Some(((buffer, self.control), addr, self.control_len))
+        Some(((buffer, self.control), addr, self.control_len, self.return_flags))
     }
 }
 
@@ -867,13 +867,7 @@ impl<S: AsFd> TakeBuffer for RecvMsgMultiFallback<S> {
     type Buffer = RecvMsgMultiResultFallback;
 
     fn take_buffer(self) -> Option<Self::Buffer> {
-        let RecvMsgManaged {
-            op,
-            mut control,
-            control_len,
-            return_flags,
-        } = self.op;
-        let (mut buffer, addr) = op.take_buffer()?;
+        let ((mut buffer, mut control), addr, control_len, return_flags) = self.op.take_buffer()?;
         unsafe { buffer.advance_to(self.len) };
         unsafe { control.advance_to(control_len) };
         Some(RecvMsgMultiResultFallback {

--- a/compio-driver/src/sys/op/managed/iour.rs
+++ b/compio-driver/src/sys/op/managed/iour.rs
@@ -8,7 +8,7 @@ use std::{
 
 use compio_buf::{BufResult, IntoInner, IoBuf, IoBufMut, SetLen};
 use io_uring::{opcode, squeue::Flags, types::Fd};
-use rustix::net::RecvFlags;
+use rustix::net::{RecvFlags, ReturnFlags};
 use socket2::{SockAddr, SockAddrStorage, socklen_t};
 
 use crate::{
@@ -313,6 +313,7 @@ pub struct RecvMsgManaged<C: IoBufMut, S: AsFd> {
     op: RecvFromManaged<S>,
     control: C,
     control_len: usize,
+    return_flags: ReturnFlags,
 }
 
 impl<C: IoBufMut, S: AsFd> RecvMsgManaged<C, S> {
@@ -328,6 +329,7 @@ impl<C: IoBufMut, S: AsFd> RecvMsgManaged<C, S> {
             op: RecvFromManaged::new(fd, pool, len, flags)?,
             control,
             control_len: 0,
+            return_flags: ReturnFlags::empty(),
         })
     }
 }
@@ -360,6 +362,7 @@ unsafe impl<C: IoBufMut, S: AsFd> OpCode for RecvMsgManaged<C, S> {
     ) {
         unsafe { self.op.set_result(control, result, extra) };
         self.control_len = control.msg.msg_controllen as _;
+        self.return_flags = ReturnFlags::from_bits_retain(control.msg.msg_flags as _);
     }
 }
 
@@ -699,6 +702,10 @@ impl RecvMsgMultiResultImpl {
         let offset = size_of::<io_uring_recvmsg_out>() + NLEN;
         &self.buffer.as_init()[offset..offset + header.controllen as usize]
     }
+
+    fn flags(&self) -> ReturnFlags {
+        ReturnFlags::from_bits_retain(self.header().flags as _)
+    }
 }
 
 impl IntoInner for RecvMsgMultiResultImpl {
@@ -813,6 +820,7 @@ struct RecvMsgMultiResultFallback {
     buffer: BufferRef,
     control: BufferRef,
     addr: Option<SockAddr>,
+    return_flags: ReturnFlags,
 }
 
 impl RecvMsgMultiResultFallback {
@@ -826,6 +834,10 @@ impl RecvMsgMultiResultFallback {
 
     fn ancillary(&self) -> &[u8] {
         self.control.as_init()
+    }
+
+    fn flags(&self) -> ReturnFlags {
+        self.return_flags
     }
 }
 
@@ -855,13 +867,20 @@ impl<S: AsFd> TakeBuffer for RecvMsgMultiFallback<S> {
     type Buffer = RecvMsgMultiResultFallback;
 
     fn take_buffer(self) -> Option<Self::Buffer> {
-        let ((mut buffer, mut control), addr, control_len) = self.op.take_buffer()?;
+        let RecvMsgManaged {
+            op,
+            mut control,
+            control_len,
+            return_flags,
+        } = self.op;
+        let (mut buffer, addr) = op.take_buffer()?;
         unsafe { buffer.advance_to(self.len) };
         unsafe { control.advance_to(control_len) };
         Some(RecvMsgMultiResultFallback {
             buffer,
             control,
             addr,
+            return_flags,
         })
     }
 }
@@ -920,6 +939,13 @@ impl RecvMsgMultiResultInner {
             Self::Fallback(inner) => inner.ancillary(),
         }
     }
+
+    fn flags(&self) -> ReturnFlags {
+        match self {
+            Self::Impl(inner) => inner.flags(),
+            Self::Fallback(inner) => inner.flags(),
+        }
+    }
 }
 
 impl IntoInner for RecvMsgMultiResultInner {
@@ -965,6 +991,11 @@ impl RecvMsgMultiResult {
     /// Get the ancillary data.
     pub fn ancillary(&self) -> &[u8] {
         self.inner.ancillary()
+    }
+
+    /// Get flags returned by `recvmsg`.
+    pub fn flags(&self) -> ReturnFlags {
+        self.inner.flags()
     }
 }
 

--- a/compio-driver/src/sys/op/mod.rs
+++ b/compio-driver/src/sys/op/mod.rs
@@ -27,4 +27,4 @@ cfg_select! {
     _ => {}
 }
 
-pub use rustix::net::{RecvFlags, SendFlags};
+pub use rustix::net::{RecvFlags, ReturnFlags, SendFlags};

--- a/compio-driver/src/sys/op/socket/iocp.rs
+++ b/compio-driver/src/sys/op/socket/iocp.rs
@@ -595,7 +595,7 @@ unsafe impl<T: IoVectoredBufMut, C: IoBufMut, S: AsFd> OpCode for RecvMsg<T, C, 
         _: &io::Result<usize>,
         _: &crate::Extra,
     ) {
-        self.header.flags = RecvFlags::from_bits_retain(control.msg.dwFlags);
+        self.return_flags = ReturnFlags::from_bits_retain(control.msg.dwFlags);
         self.header.addr_len = control.msg.namelen as socklen_t;
         self.control_len = control.msg.Control.len as _;
     }

--- a/compio-driver/src/sys/op/socket/iocp.rs
+++ b/compio-driver/src/sys/op/socket/iocp.rs
@@ -1,4 +1,3 @@
-use rustix::net::RecvFlags;
 use windows_sys::Win32::{
     Networking::WinSock::{
         LPFN_ACCEPTEX, LPFN_CONNECTEX, LPFN_DISCONNECTEX, LPFN_GETACCEPTEXSOCKADDRS,

--- a/compio-driver/src/sys/op/socket/mod.rs
+++ b/compio-driver/src/sys/op/socket/mod.rs
@@ -13,7 +13,7 @@ mod_use![poll];
 #[cfg(stub)]
 mod_use![stub];
 
-use rustix::net::{RecvFlags, SendFlags};
+use rustix::net::{RecvFlags, ReturnFlags, SendFlags};
 
 use crate::{PollFirst, sys::prelude::*};
 
@@ -121,6 +121,7 @@ pub struct RecvMsg<T: IoVectoredBufMut, C: IoBufMut, S> {
     pub(crate) buffer: T,
     pub(crate) control: C,
     pub(crate) control_len: usize,
+    pub(crate) return_flags: ReturnFlags,
     poll_first: bool,
 }
 
@@ -258,8 +259,14 @@ impl<T: IoVectoredBufMut, C: IoBufMut, S> RecvMsg<T, C, S> {
             buffer,
             control,
             control_len: 0,
+            return_flags: ReturnFlags::empty(),
             poll_first: false,
         }
+    }
+
+    /// Get flags returned by `recvmsg`.
+    pub fn return_flags(&self) -> ReturnFlags {
+        self.return_flags
     }
 }
 

--- a/compio-driver/src/sys/op/socket/mod.rs
+++ b/compio-driver/src/sys/op/socket/mod.rs
@@ -263,7 +263,6 @@ impl<T: IoVectoredBufMut, C: IoBufMut, S> RecvMsg<T, C, S> {
             poll_first: false,
         }
     }
-
 }
 
 impl<T: IoVectoredBufMut, C: IoBufMut, S> PollFirst for RecvMsg<T, C, S> {

--- a/compio-driver/src/sys/op/socket/mod.rs
+++ b/compio-driver/src/sys/op/socket/mod.rs
@@ -264,10 +264,6 @@ impl<T: IoVectoredBufMut, C: IoBufMut, S> RecvMsg<T, C, S> {
         }
     }
 
-    /// Get flags returned by `recvmsg`.
-    pub fn return_flags(&self) -> ReturnFlags {
-        self.return_flags
-    }
 }
 
 impl<T: IoVectoredBufMut, C: IoBufMut, S> PollFirst for RecvMsg<T, C, S> {
@@ -277,13 +273,14 @@ impl<T: IoVectoredBufMut, C: IoBufMut, S> PollFirst for RecvMsg<T, C, S> {
 }
 
 impl<T: IoVectoredBufMut, C: IoBufMut, S> IntoInner for RecvMsg<T, C, S> {
-    type Inner = ((T, C), Option<SockAddr>, usize);
+    type Inner = ((T, C), Option<SockAddr>, usize, ReturnFlags);
 
     fn into_inner(self) -> Self::Inner {
         (
             (self.buffer, self.control),
             self.header.into_addr(),
             self.control_len,
+            self.return_flags,
         )
     }
 }

--- a/compio-driver/src/sys/op/socket/unix.rs
+++ b/compio-driver/src/sys/op/socket/unix.rs
@@ -461,5 +461,6 @@ impl<T: IoVectoredBufMut, C: IoBufMut, S> RecvMsg<T, C, S> {
     pub(crate) fn update_control(&mut self, control: &RecvMsgControl) {
         self.header.addr_len = control.msg.msg_namelen as _;
         self.control_len = control.msg.msg_controllen as _;
+        self.return_flags = ReturnFlags::from_bits_retain(control.msg.msg_flags as _);
     }
 }

--- a/compio-driver/src/sys/pal/windows/mod.rs
+++ b/compio-driver/src/sys/pal/windows/mod.rs
@@ -5,8 +5,8 @@ use windows_sys::{
     Win32::{
         Foundation::{
             ERROR_BROKEN_PIPE, ERROR_HANDLE_EOF, ERROR_IO_INCOMPLETE, ERROR_IO_PENDING,
-            ERROR_NETNAME_DELETED, ERROR_NO_DATA, ERROR_NOT_FOUND, ERROR_PIPE_CONNECTED,
-            ERROR_PIPE_NOT_CONNECTED, GetLastError,
+            ERROR_MORE_DATA, ERROR_NETNAME_DELETED, ERROR_NO_DATA, ERROR_NOT_FOUND,
+            ERROR_PIPE_CONNECTED, ERROR_PIPE_NOT_CONNECTED, GetLastError,
         },
         Networking::WinSock::{SIO_GET_EXTENSION_FUNCTION_POINTER, WSAIoctl},
         System::IO::{CancelIoEx, OVERLAPPED},
@@ -65,7 +65,8 @@ pub fn winapi_result(transferred: u32) -> Poll<io::Result<usize>> {
         | ERROR_BROKEN_PIPE
         | ERROR_PIPE_CONNECTED
         | ERROR_PIPE_NOT_CONNECTED
-        | ERROR_NO_DATA => Poll::Ready(Ok(transferred as _)),
+        | ERROR_NO_DATA
+        | ERROR_MORE_DATA => Poll::Ready(Ok(transferred as _)),
         _ => Poll::Ready(Err(io::Error::from_raw_os_error(error as _))),
     }
 }

--- a/compio-io/Cargo.toml
+++ b/compio-io/Cargo.toml
@@ -14,6 +14,7 @@ compio-buf = { workspace = true, features = ["arrayvec"] }
 futures-util = { workspace = true, features = ["sink"] }
 paste = { workspace = true }
 pin-project-lite = { workspace = true, optional = true }
+rustix = { workspace = true, features = ["net"], optional = true }
 synchrony = { workspace = true, features = ["bilock"] }
 
 thiserror = { workspace = true, optional = true }
@@ -40,7 +41,7 @@ futures-executor = { workspace = true }
 default = ["bytes"]
 compat = ["futures-util/io", "dep:pin-project-lite"]
 sync = []
-ancillary = ["dep:libc", "dep:windows-sys"]
+ancillary = ["dep:libc", "dep:rustix", "dep:windows-sys"]
 bytes = ["compio-buf/bytes"]
 
 # Codecs

--- a/compio-io/src/ancillary/io.rs
+++ b/compio-io/src/ancillary/io.rs
@@ -3,6 +3,7 @@ use std::alloc::Allocator;
 
 use compio_buf::{BufResult, IoBuf, IoBufMut, IoVectoredBuf, IoVectoredBufMut, t_alloc};
 use futures_util::Stream;
+use rustix::net::ReturnFlags;
 
 use crate::{AsyncReadManaged, IoResult};
 
@@ -10,19 +11,21 @@ use crate::{AsyncReadManaged, IoResult};
 /// Intended for connected stream sockets (TCP, Unix streams) where no source
 /// address is needed.
 pub trait AsyncReadAncillary {
-    /// Read data with ancillary data into an owned buffer.
+    /// Read data with ancillary data into an owned buffer, returning bytes
+    /// read, control length, and `recvmsg` flags.
     async fn read_with_ancillary<T: IoBufMut, C: IoBufMut>(
         &mut self,
         buffer: T,
         control: C,
-    ) -> BufResult<(usize, usize), (T, C)>;
+    ) -> BufResult<(usize, usize, ReturnFlags), (T, C)>;
 
-    /// Read data with ancillary data into a vectored buffer.
+    /// Read data with ancillary data into a vectored buffer, returning bytes
+    /// read, control length, and `recvmsg` flags.
     async fn read_vectored_with_ancillary<T: IoVectoredBufMut, C: IoBufMut>(
         &mut self,
         buffer: T,
         control: C,
-    ) -> BufResult<(usize, usize), (T, C)>;
+    ) -> BufResult<(usize, usize, ReturnFlags), (T, C)>;
 }
 
 impl<A: AsyncReadAncillary + ?Sized> AsyncReadAncillary for &mut A {
@@ -31,7 +34,7 @@ impl<A: AsyncReadAncillary + ?Sized> AsyncReadAncillary for &mut A {
         &mut self,
         buffer: T,
         control: C,
-    ) -> BufResult<(usize, usize), (T, C)> {
+    ) -> BufResult<(usize, usize, ReturnFlags), (T, C)> {
         (**self).read_with_ancillary(buffer, control).await
     }
 
@@ -40,7 +43,7 @@ impl<A: AsyncReadAncillary + ?Sized> AsyncReadAncillary for &mut A {
         &mut self,
         buffer: T,
         control: C,
-    ) -> BufResult<(usize, usize), (T, C)> {
+    ) -> BufResult<(usize, usize, ReturnFlags), (T, C)> {
         (**self).read_vectored_with_ancillary(buffer, control).await
     }
 }
@@ -53,7 +56,7 @@ impl<A: AsyncReadAncillary + ?Sized, #[cfg(feature = "allocator_api")] Alloc: Al
         &mut self,
         buffer: T,
         control: C,
-    ) -> BufResult<(usize, usize), (T, C)> {
+    ) -> BufResult<(usize, usize, ReturnFlags), (T, C)> {
         (**self).read_with_ancillary(buffer, control).await
     }
 
@@ -62,7 +65,7 @@ impl<A: AsyncReadAncillary + ?Sized, #[cfg(feature = "allocator_api")] Alloc: Al
         &mut self,
         buffer: T,
         control: C,
-    ) -> BufResult<(usize, usize), (T, C)> {
+    ) -> BufResult<(usize, usize, ReturnFlags), (T, C)> {
         (**self).read_vectored_with_ancillary(buffer, control).await
     }
 }

--- a/compio-io/src/ancillary/io.rs
+++ b/compio-io/src/ancillary/io.rs
@@ -225,7 +225,7 @@ pub trait AsyncReadAncillaryManaged: AsyncReadManaged {
         &mut self,
         len: usize,
         control: C,
-    ) -> IoResult<Option<(Self::Buffer, C)>>;
+    ) -> IoResult<Option<(Self::Buffer, C, ReturnFlags)>>;
 }
 
 /// Trait for asynchronous read with ancillary (control) data that returns

--- a/compio-io/src/ancillary/mod.rs
+++ b/compio-io/src/ancillary/mod.rs
@@ -40,8 +40,9 @@ use compio_buf::{IoBuf, IoBufMut, SetLen};
 
 mod io;
 
-pub use self::io::*;
 pub use rustix::net::ReturnFlags;
+
+pub use self::io::*;
 
 #[cfg(feature = "bytemuck")]
 pub mod bytemuck_ext;

--- a/compio-io/src/ancillary/mod.rs
+++ b/compio-io/src/ancillary/mod.rs
@@ -41,6 +41,7 @@ use compio_buf::{IoBuf, IoBufMut, SetLen};
 mod io;
 
 pub use self::io::*;
+pub use rustix::net::ReturnFlags;
 
 #[cfg(feature = "bytemuck")]
 pub mod bytemuck_ext;

--- a/compio-net/src/socket/mod.rs
+++ b/compio-net/src/socket/mod.rs
@@ -406,12 +406,8 @@ impl Socket {
         self.state.set_recv_op(&mut op);
         let (res, extra) = compio_runtime::submit(op).with_extra().await;
         self.state.set_recv(&extra);
-        let res = res.into_inner().map2(
-            |res, (buffer, addr, control_len, flags)| ((res, control_len, (addr, flags)), buffer),
-            |(buffer, ..)| buffer,
-        );
+        let res = res.into_inner().map_addr();
         unsafe { res.map_vec_advanced() }
-            .map_res(|(res, control_len, (addr, flags))| (res, control_len, addr, flags))
     }
 
     pub async fn recv_msg_managed<C: IoBufMut>(

--- a/compio-net/src/socket/mod.rs
+++ b/compio-net/src/socket/mod.rs
@@ -19,9 +19,9 @@ use compio_driver::{
     op::{
         Accept, BufResultExt, CloseSocket, Connect, Recv, RecvFlags, RecvFrom, RecvFromManaged,
         RecvFromMulti, RecvFromMultiResult, RecvFromVectored, RecvManaged, RecvMsg, RecvMsgManaged,
-        RecvMsgMulti, RecvMsgMultiResult, RecvMulti, RecvResultExt, RecvVectored, Send, SendFlags,
-        SendMsg, SendMsgZc, SendTo, SendToVectored, SendToVectoredZc, SendToZc, SendVectored,
-        SendVectoredZc, SendZc, VecBufResultExt,
+        RecvMsgMulti, RecvMsgMultiResult, RecvMulti, RecvResultExt, RecvVectored, ReturnFlags,
+        Send, SendFlags, SendMsg, SendMsgZc, SendTo, SendToVectored, SendToVectoredZc, SendToZc,
+        SendVectored, SendVectoredZc, SendZc, VecBufResultExt,
     },
     syscall,
 };
@@ -384,30 +384,31 @@ impl Socket {
         .unwrap_or_else(|e| Either::Right(futures_util::stream::once(std::future::ready(Err(e)))))
     }
 
-    pub async fn recv_msg<T: IoBufMut, C: IoBufMut>(
+    pub async fn recv_msg_with_flags<T: IoBufMut, C: IoBufMut>(
         &self,
         buffer: T,
         control: C,
         flags: RecvFlags,
-    ) -> BufResult<(usize, usize, Option<SockAddr>), (T, C)> {
-        self.recv_msg_vectored([buffer], control, flags)
+    ) -> BufResult<(usize, usize, Option<SockAddr>, ReturnFlags), (T, C)> {
+        self.recv_msg_vectored_with_flags([buffer], control, flags)
             .await
             .map_buffer(|([buffer], control)| (buffer, control))
     }
 
-    pub async fn recv_msg_vectored<T: IoVectoredBufMut, C: IoBufMut>(
+    pub async fn recv_msg_vectored_with_flags<T: IoVectoredBufMut, C: IoBufMut>(
         &self,
         buffer: T,
         control: C,
         flags: RecvFlags,
-    ) -> BufResult<(usize, usize, Option<SockAddr>), (T, C)> {
+    ) -> BufResult<(usize, usize, Option<SockAddr>, ReturnFlags), (T, C)> {
         let fd = self.to_shared_fd();
         let mut op = RecvMsg::new(fd, buffer, control, flags);
         self.state.set_recv_op(&mut op);
         let (res, extra) = compio_runtime::submit(op).with_extra().await;
         self.state.set_recv(&extra);
+        let flags = res.1.return_flags();
         let res = res.into_inner().map_addr();
-        unsafe { res.map_vec_advanced() }
+        unsafe { res.map_vec_advanced() }.map_res(|(res, len, addr)| (res, len, addr, flags))
     }
 
     pub async fn recv_msg_managed<C: IoBufMut>(

--- a/compio-net/src/socket/mod.rs
+++ b/compio-net/src/socket/mod.rs
@@ -384,18 +384,18 @@ impl Socket {
         .unwrap_or_else(|e| Either::Right(futures_util::stream::once(std::future::ready(Err(e)))))
     }
 
-    pub async fn recv_msg_with_flags<T: IoBufMut, C: IoBufMut>(
+    pub async fn recv_msg<T: IoBufMut, C: IoBufMut>(
         &self,
         buffer: T,
         control: C,
         flags: RecvFlags,
     ) -> BufResult<(usize, usize, Option<SockAddr>, ReturnFlags), (T, C)> {
-        self.recv_msg_vectored_with_flags([buffer], control, flags)
+        self.recv_msg_vectored([buffer], control, flags)
             .await
             .map_buffer(|([buffer], control)| (buffer, control))
     }
 
-    pub async fn recv_msg_vectored_with_flags<T: IoVectoredBufMut, C: IoBufMut>(
+    pub async fn recv_msg_vectored<T: IoVectoredBufMut, C: IoBufMut>(
         &self,
         buffer: T,
         control: C,
@@ -406,9 +406,12 @@ impl Socket {
         self.state.set_recv_op(&mut op);
         let (res, extra) = compio_runtime::submit(op).with_extra().await;
         self.state.set_recv(&extra);
-        let flags = res.1.return_flags();
-        let res = res.into_inner().map_addr();
-        unsafe { res.map_vec_advanced() }.map_res(|(res, len, addr)| (res, len, addr, flags))
+        let res = res.into_inner().map2(
+            |res, (buffer, addr, control_len, flags)| ((res, control_len, (addr, flags)), buffer),
+            |(buffer, ..)| buffer,
+        );
+        unsafe { res.map_vec_advanced() }
+            .map_res(|(res, control_len, (addr, flags))| (res, control_len, addr, flags))
     }
 
     pub async fn recv_msg_managed<C: IoBufMut>(

--- a/compio-net/src/socket/mod.rs
+++ b/compio-net/src/socket/mod.rs
@@ -419,7 +419,7 @@ impl Socket {
         len: usize,
         control: C,
         flags: RecvFlags,
-    ) -> io::Result<Option<(BufferRef, C, Option<SockAddr>)>> {
+    ) -> io::Result<Option<(BufferRef, C, Option<SockAddr>, ReturnFlags)>> {
         let fd = self.to_shared_fd();
         let (inner, extra) = Runtime::with_current(|rt| {
             let buffer_pool = rt.buffer_pool()?;
@@ -434,7 +434,7 @@ impl Socket {
         if len == 0 {
             return Ok(None);
         }
-        let Some(((mut buf, mut control), addr, control_len)) = op.take_buffer() else {
+        let Some(((mut buf, mut control), addr, control_len, flags)) = op.take_buffer() else {
             return Err(io::Error::new(
                 io::ErrorKind::UnexpectedEof,
                 format!("Read {len} bytes, but no buffer was selected by kernel"),
@@ -442,7 +442,7 @@ impl Socket {
         };
         unsafe { buf.advance_to(len) };
         unsafe { control.advance_to(control_len) };
-        Ok(Some((buf, control, addr)))
+        Ok(Some((buf, control, addr, flags)))
     }
 
     pub fn recv_msg_multi(

--- a/compio-net/src/tcp.rs
+++ b/compio-net/src/tcp.rs
@@ -521,7 +521,7 @@ impl AsyncReadAncillary for &TcpStream {
         control: C,
     ) -> BufResult<(usize, usize, ReturnFlags), (T, C)> {
         self.inner
-            .recv_msg_with_flags(buffer, control, RecvFlags::empty())
+            .recv_msg(buffer, control, RecvFlags::empty())
             .await
             .map_res(|(res, len, _addr, flags)| (res, len, flags))
     }
@@ -533,7 +533,7 @@ impl AsyncReadAncillary for &TcpStream {
         control: C,
     ) -> BufResult<(usize, usize, ReturnFlags), (T, C)> {
         self.inner
-            .recv_msg_vectored_with_flags(buffer, control, RecvFlags::empty())
+            .recv_msg_vectored(buffer, control, RecvFlags::empty())
             .await
             .map_res(|(res, len, _addr, flags)| (res, len, flags))
     }

--- a/compio-net/src/tcp.rs
+++ b/compio-net/src/tcp.rs
@@ -16,7 +16,7 @@ use compio_io::{
     AsyncRead, AsyncReadManaged, AsyncReadMulti, AsyncWrite, AsyncWriteZerocopy,
     ancillary::{
         AsyncReadAncillary, AsyncReadAncillaryManaged, AsyncReadAncillaryMulti,
-        AsyncWriteAncillary, AsyncWriteAncillaryZerocopy,
+        AsyncWriteAncillary, AsyncWriteAncillaryZerocopy, ReturnFlags,
     },
     util::Splittable,
 };
@@ -499,7 +499,7 @@ impl AsyncReadAncillary for TcpStream {
         &mut self,
         buffer: T,
         control: C,
-    ) -> BufResult<(usize, usize), (T, C)> {
+    ) -> BufResult<(usize, usize, ReturnFlags), (T, C)> {
         (&*self).read_with_ancillary(buffer, control).await
     }
 
@@ -508,7 +508,7 @@ impl AsyncReadAncillary for TcpStream {
         &mut self,
         buffer: T,
         control: C,
-    ) -> BufResult<(usize, usize), (T, C)> {
+    ) -> BufResult<(usize, usize, ReturnFlags), (T, C)> {
         (&*self).read_vectored_with_ancillary(buffer, control).await
     }
 }
@@ -519,11 +519,11 @@ impl AsyncReadAncillary for &TcpStream {
         &mut self,
         buffer: T,
         control: C,
-    ) -> BufResult<(usize, usize), (T, C)> {
+    ) -> BufResult<(usize, usize, ReturnFlags), (T, C)> {
         self.inner
-            .recv_msg(buffer, control, RecvFlags::empty())
+            .recv_msg_with_flags(buffer, control, RecvFlags::empty())
             .await
-            .map_res(|(res, len, _addr)| (res, len))
+            .map_res(|(res, len, _addr, flags)| (res, len, flags))
     }
 
     #[inline]
@@ -531,11 +531,11 @@ impl AsyncReadAncillary for &TcpStream {
         &mut self,
         buffer: T,
         control: C,
-    ) -> BufResult<(usize, usize), (T, C)> {
+    ) -> BufResult<(usize, usize, ReturnFlags), (T, C)> {
         self.inner
-            .recv_msg_vectored(buffer, control, RecvFlags::empty())
+            .recv_msg_vectored_with_flags(buffer, control, RecvFlags::empty())
             .await
-            .map_res(|(res, len, _addr)| (res, len))
+            .map_res(|(res, len, _addr, flags)| (res, len, flags))
     }
 }
 

--- a/compio-net/src/tcp.rs
+++ b/compio-net/src/tcp.rs
@@ -545,7 +545,7 @@ impl AsyncReadAncillaryManaged for TcpStream {
         &mut self,
         len: usize,
         control: C,
-    ) -> io::Result<Option<(Self::Buffer, C)>> {
+    ) -> io::Result<Option<(Self::Buffer, C, ReturnFlags)>> {
         (&*self).read_managed_with_ancillary(len, control).await
     }
 }
@@ -556,11 +556,11 @@ impl AsyncReadAncillaryManaged for &TcpStream {
         &mut self,
         len: usize,
         control: C,
-    ) -> io::Result<Option<(Self::Buffer, C)>> {
+    ) -> io::Result<Option<(Self::Buffer, C, ReturnFlags)>> {
         self.inner
             .recv_msg_managed(len, control, RecvFlags::empty())
             .await
-            .map(|res| res.map(|(res, len, _addr)| (res, len)))
+            .map(|res| res.map(|(res, len, _addr, flags)| (res, len, flags)))
     }
 }
 

--- a/compio-net/src/udp.rs
+++ b/compio-net/src/udp.rs
@@ -353,18 +353,18 @@ impl UdpSocket {
         &self,
         len: usize,
         control: C,
-    ) -> io::Result<Option<(BufferRef, C, SocketAddr)>> {
+    ) -> io::Result<Option<(BufferRef, C, SocketAddr, ReturnFlags)>> {
         let res = self
             .inner
             .recv_msg_managed(len, control, RecvFlags::empty())
             .await?;
         let ret = match res {
-            Some((buffer, control, addr)) => {
+            Some((buffer, control, addr, flags)) => {
                 let addr = addr
                     .expect("should have addr")
                     .as_socket()
                     .expect("should be SocketAddr");
-                Some((buffer, control, addr))
+                Some((buffer, control, addr, flags))
             }
             None => None,
         };

--- a/compio-net/src/udp.rs
+++ b/compio-net/src/udp.rs
@@ -9,6 +9,7 @@ use compio_driver::{
     BufferRef, impl_raw_fd,
     op::{RecvFlags, RecvFromMultiResult, RecvMsgMultiResult},
 };
+use compio_io::ancillary::ReturnFlags;
 use futures_util::Stream;
 use socket2::{Protocol, SockAddr, Socket as Socket2, Type};
 
@@ -303,40 +304,68 @@ impl UdpSocket {
     }
 
     /// Receives a single datagram message and ancillary data on the socket. On
-    /// success, returns the number of bytes received and the origin.
+    /// success, returns the number of bytes received, control length and the
+    /// origin.
     pub async fn recv_msg<T: IoBufMut, C: IoBufMut>(
         &self,
         buffer: T,
         control: C,
     ) -> BufResult<(usize, usize, SocketAddr), (T, C)> {
-        self.inner
-            .recv_msg(buffer, control, RecvFlags::empty())
+        self.recv_msg_with_flags(buffer, control)
             .await
-            .map_res(|(n, m, addr)| {
+            .map_res(|(n, m, addr, _flags)| (n, m, addr))
+    }
+
+    /// Receives a single datagram message and ancillary data on the socket. On
+    /// success, returns the number of bytes received, control length, the
+    /// origin and `recvmsg` flags.
+    pub async fn recv_msg_with_flags<T: IoBufMut, C: IoBufMut>(
+        &self,
+        buffer: T,
+        control: C,
+    ) -> BufResult<(usize, usize, SocketAddr, ReturnFlags), (T, C)> {
+        self.inner
+            .recv_msg_with_flags(buffer, control, RecvFlags::empty())
+            .await
+            .map_res(|(n, m, addr, flags)| {
                 let addr = addr
                     .expect("should have addr")
                     .as_socket()
                     .expect("should be SocketAddr");
-                (n, m, addr)
+                (n, m, addr, flags)
             })
     }
 
     /// Receives a single datagram message and ancillary data on the socket. On
-    /// success, returns the number of bytes received and the origin.
+    /// success, returns the number of bytes received, control length and the
+    /// origin.
     pub async fn recv_msg_vectored<T: IoVectoredBufMut, C: IoBufMut>(
         &self,
         buffer: T,
         control: C,
     ) -> BufResult<(usize, usize, SocketAddr), (T, C)> {
-        self.inner
-            .recv_msg_vectored(buffer, control, RecvFlags::empty())
+        self.recv_msg_vectored_with_flags(buffer, control)
             .await
-            .map_res(|(n, m, addr)| {
+            .map_res(|(n, m, addr, _flags)| (n, m, addr))
+    }
+
+    /// Receives a single datagram message and ancillary data on the socket. On
+    /// success, returns the number of bytes received, control length, the
+    /// origin and `recvmsg` flags.
+    pub async fn recv_msg_vectored_with_flags<T: IoVectoredBufMut, C: IoBufMut>(
+        &self,
+        buffer: T,
+        control: C,
+    ) -> BufResult<(usize, usize, SocketAddr, ReturnFlags), (T, C)> {
+        self.inner
+            .recv_msg_vectored_with_flags(buffer, control, RecvFlags::empty())
+            .await
+            .map_res(|(n, m, addr, flags)| {
                 let addr = addr
                     .expect("should have addr")
                     .as_socket()
                     .expect("should be SocketAddr");
-                (n, m, addr)
+                (n, m, addr, flags)
             })
     }
 

--- a/compio-net/src/udp.rs
+++ b/compio-net/src/udp.rs
@@ -304,28 +304,15 @@ impl UdpSocket {
     }
 
     /// Receives a single datagram message and ancillary data on the socket. On
-    /// success, returns the number of bytes received, control length and the
-    /// origin.
-    pub async fn recv_msg<T: IoBufMut, C: IoBufMut>(
-        &self,
-        buffer: T,
-        control: C,
-    ) -> BufResult<(usize, usize, SocketAddr), (T, C)> {
-        self.recv_msg_with_flags(buffer, control)
-            .await
-            .map_res(|(n, m, addr, _flags)| (n, m, addr))
-    }
-
-    /// Receives a single datagram message and ancillary data on the socket. On
     /// success, returns the number of bytes received, control length, the
     /// origin and `recvmsg` flags.
-    pub async fn recv_msg_with_flags<T: IoBufMut, C: IoBufMut>(
+    pub async fn recv_msg<T: IoBufMut, C: IoBufMut>(
         &self,
         buffer: T,
         control: C,
     ) -> BufResult<(usize, usize, SocketAddr, ReturnFlags), (T, C)> {
         self.inner
-            .recv_msg_with_flags(buffer, control, RecvFlags::empty())
+            .recv_msg(buffer, control, RecvFlags::empty())
             .await
             .map_res(|(n, m, addr, flags)| {
                 let addr = addr
@@ -337,28 +324,15 @@ impl UdpSocket {
     }
 
     /// Receives a single datagram message and ancillary data on the socket. On
-    /// success, returns the number of bytes received, control length and the
-    /// origin.
-    pub async fn recv_msg_vectored<T: IoVectoredBufMut, C: IoBufMut>(
-        &self,
-        buffer: T,
-        control: C,
-    ) -> BufResult<(usize, usize, SocketAddr), (T, C)> {
-        self.recv_msg_vectored_with_flags(buffer, control)
-            .await
-            .map_res(|(n, m, addr, _flags)| (n, m, addr))
-    }
-
-    /// Receives a single datagram message and ancillary data on the socket. On
     /// success, returns the number of bytes received, control length, the
     /// origin and `recvmsg` flags.
-    pub async fn recv_msg_vectored_with_flags<T: IoVectoredBufMut, C: IoBufMut>(
+    pub async fn recv_msg_vectored<T: IoVectoredBufMut, C: IoBufMut>(
         &self,
         buffer: T,
         control: C,
     ) -> BufResult<(usize, usize, SocketAddr, ReturnFlags), (T, C)> {
         self.inner
-            .recv_msg_vectored_with_flags(buffer, control, RecvFlags::empty())
+            .recv_msg_vectored(buffer, control, RecvFlags::empty())
             .await
             .map_res(|(n, m, addr, flags)| {
                 let addr = addr

--- a/compio-net/src/unix.rs
+++ b/compio-net/src/unix.rs
@@ -405,7 +405,7 @@ impl AsyncReadAncillaryManaged for UnixStream {
         &mut self,
         len: usize,
         control: C,
-    ) -> io::Result<Option<(Self::Buffer, C)>> {
+    ) -> io::Result<Option<(Self::Buffer, C, ReturnFlags)>> {
         (&*self).read_managed_with_ancillary(len, control).await
     }
 }
@@ -416,11 +416,11 @@ impl AsyncReadAncillaryManaged for &UnixStream {
         &mut self,
         len: usize,
         control: C,
-    ) -> io::Result<Option<(Self::Buffer, C)>> {
+    ) -> io::Result<Option<(Self::Buffer, C, ReturnFlags)>> {
         self.inner
             .recv_msg_managed(len, control, RecvFlags::empty())
             .await
-            .map(|res| res.map(|(res, len, _addr)| (res, len)))
+            .map(|res| res.map(|(res, len, _addr, flags)| (res, len, flags)))
     }
 }
 

--- a/compio-net/src/unix.rs
+++ b/compio-net/src/unix.rs
@@ -15,7 +15,7 @@ use compio_io::{
     AsyncRead, AsyncReadManaged, AsyncReadMulti, AsyncWrite, AsyncWriteZerocopy,
     ancillary::{
         AsyncReadAncillary, AsyncReadAncillaryManaged, AsyncReadAncillaryMulti,
-        AsyncWriteAncillary, AsyncWriteAncillaryZerocopy,
+        AsyncWriteAncillary, AsyncWriteAncillaryZerocopy, ReturnFlags,
     },
     util::Splittable,
 };
@@ -359,7 +359,7 @@ impl AsyncReadAncillary for UnixStream {
         &mut self,
         buffer: T,
         control: C,
-    ) -> BufResult<(usize, usize), (T, C)> {
+    ) -> BufResult<(usize, usize, ReturnFlags), (T, C)> {
         (&*self).read_with_ancillary(buffer, control).await
     }
 
@@ -368,7 +368,7 @@ impl AsyncReadAncillary for UnixStream {
         &mut self,
         buffer: T,
         control: C,
-    ) -> BufResult<(usize, usize), (T, C)> {
+    ) -> BufResult<(usize, usize, ReturnFlags), (T, C)> {
         (&*self).read_vectored_with_ancillary(buffer, control).await
     }
 }
@@ -379,11 +379,11 @@ impl AsyncReadAncillary for &UnixStream {
         &mut self,
         buffer: T,
         control: C,
-    ) -> BufResult<(usize, usize), (T, C)> {
+    ) -> BufResult<(usize, usize, ReturnFlags), (T, C)> {
         self.inner
-            .recv_msg(buffer, control, RecvFlags::empty())
+            .recv_msg_with_flags(buffer, control, RecvFlags::empty())
             .await
-            .map_res(|(res, len, _addr)| (res, len))
+            .map_res(|(res, len, _addr, flags)| (res, len, flags))
     }
 
     #[inline]
@@ -391,11 +391,11 @@ impl AsyncReadAncillary for &UnixStream {
         &mut self,
         buffer: T,
         control: C,
-    ) -> BufResult<(usize, usize), (T, C)> {
+    ) -> BufResult<(usize, usize, ReturnFlags), (T, C)> {
         self.inner
-            .recv_msg_vectored(buffer, control, RecvFlags::empty())
+            .recv_msg_vectored_with_flags(buffer, control, RecvFlags::empty())
             .await
-            .map_res(|(res, len, _addr)| (res, len))
+            .map_res(|(res, len, _addr, flags)| (res, len, flags))
     }
 }
 
@@ -619,7 +619,7 @@ impl AsyncWriteAncillaryZerocopy for &UnixStream {
 /// // Receive on the other end.
 /// let payload = Vec::with_capacity(5);
 /// let ctrl_recv = AncillaryBuf::<BUF_SIZE>::new();
-/// let ((_, ctrl_len), (payload, ctrl_recv)) =
+/// let ((_, ctrl_len, _flags), (payload, ctrl_recv)) =
 ///     b.read_with_ancillary(payload, ctrl_recv).await.unwrap();
 ///
 /// assert_eq!(&payload[..], b"hello");

--- a/compio-net/src/unix.rs
+++ b/compio-net/src/unix.rs
@@ -381,7 +381,7 @@ impl AsyncReadAncillary for &UnixStream {
         control: C,
     ) -> BufResult<(usize, usize, ReturnFlags), (T, C)> {
         self.inner
-            .recv_msg_with_flags(buffer, control, RecvFlags::empty())
+            .recv_msg(buffer, control, RecvFlags::empty())
             .await
             .map_res(|(res, len, _addr, flags)| (res, len, flags))
     }
@@ -393,7 +393,7 @@ impl AsyncReadAncillary for &UnixStream {
         control: C,
     ) -> BufResult<(usize, usize, ReturnFlags), (T, C)> {
         self.inner
-            .recv_msg_vectored_with_flags(buffer, control, RecvFlags::empty())
+            .recv_msg_vectored(buffer, control, RecvFlags::empty())
             .await
             .map_res(|(res, len, _addr, flags)| (res, len, flags))
     }

--- a/compio-net/tests/buffer_pool.rs
+++ b/compio-net/tests/buffer_pool.rs
@@ -1,6 +1,6 @@
 use std::net::Ipv6Addr;
 
-use compio_io::{AsyncReadManaged, AsyncReadMulti, AsyncWriteExt};
+use compio_io::{AsyncReadManaged, AsyncReadMulti, AsyncWriteExt, ancillary::ReturnFlags};
 use compio_net::{TcpListener, TcpStream, UdpSocket, UnixListener, UnixStream};
 use futures_util::{StreamExt, TryStreamExt};
 
@@ -174,6 +174,25 @@ async fn test_udp_recv_msg_multi() {
     let result = connected.recv_msg_multi(64).next().await.unwrap().unwrap();
     assert_eq!(result.data(), b"test");
     assert_eq!(result.addr().and_then(|a| a.as_socket()), Some(server_addr));
+    assert_eq!(result.flags(), ReturnFlags::empty());
+}
+
+#[cfg(target_os = "linux")]
+#[compio_macros::test(with_proactor(buffer_pool_buffer_len = 256))]
+async fn test_udp_recv_msg_multi_truncated_datagram() {
+    let listener = UdpSocket::bind((Ipv6Addr::LOCALHOST, 0)).await.unwrap();
+    let server_addr = listener.local_addr().unwrap();
+    let connected = UdpSocket::bind((Ipv6Addr::LOCALHOST, 0)).await.unwrap();
+    let addr = connected.local_addr().unwrap();
+
+    compio_runtime::spawn(async move {
+        listener.send_to(vec![0; 1024], addr).await.unwrap();
+    })
+    .detach();
+
+    let result = connected.recv_msg_multi(64).next().await.unwrap().unwrap();
+    assert_eq!(result.addr().and_then(|a| a.as_socket()), Some(server_addr));
+    assert!(result.flags().contains(ReturnFlags::TRUNC));
 }
 
 #[compio_macros::test]

--- a/compio-net/tests/buffer_pool.rs
+++ b/compio-net/tests/buffer_pool.rs
@@ -28,6 +28,7 @@ async fn test_tcp_read_buffer_pool() {
     assert!(matches!(res, Ok(None)));
 }
 
+#[cfg_attr(windows, ignore)]
 #[compio_macros::test]
 async fn test_tcp_read_managed_with_ancillary() {
     let listener = TcpListener::bind((Ipv6Addr::LOCALHOST, 0)).await.unwrap();
@@ -133,7 +134,7 @@ async fn test_uds_recv_buffer_pool() {
     assert!(matches!(stream.read_managed(0).await, Ok(None)));
 }
 
-#[cfg_attr(windows, ignore = "UDS support on Windows is incomplete")]
+#[cfg_attr(windows, ignore)]
 #[compio_macros::test]
 async fn test_uds_read_managed_with_ancillary() {
     let dir = tempfile::Builder::new()

--- a/compio-net/tests/buffer_pool.rs
+++ b/compio-net/tests/buffer_pool.rs
@@ -1,6 +1,9 @@
 use std::net::Ipv6Addr;
 
-use compio_io::{AsyncReadManaged, AsyncReadMulti, AsyncWriteExt, ancillary::ReturnFlags};
+use compio_io::{
+    AsyncReadManaged, AsyncReadMulti, AsyncWriteExt,
+    ancillary::{AncillaryBuf, AsyncReadAncillaryManaged, ReturnFlags},
+};
 use compio_net::{TcpListener, TcpStream, UdpSocket, UnixListener, UnixStream};
 use futures_util::{StreamExt, TryStreamExt};
 
@@ -23,6 +26,28 @@ async fn test_tcp_read_buffer_pool() {
     );
     let res = stream.read_managed(0).await;
     assert!(matches!(res, Ok(None)));
+}
+
+#[compio_macros::test]
+async fn test_tcp_read_managed_with_ancillary() {
+    let listener = TcpListener::bind((Ipv6Addr::LOCALHOST, 0)).await.unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    compio_runtime::spawn(async move {
+        let mut stream = listener.accept().await.unwrap().0;
+        stream.write_all(b"test").await.unwrap();
+    })
+    .detach();
+
+    let mut stream = TcpStream::connect(addr).await.unwrap();
+
+    let (buffer, _control, flags) = stream
+        .read_managed_with_ancillary(0, AncillaryBuf::<64>::new())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(buffer.as_ref(), b"test");
+    assert_eq!(flags, ReturnFlags::empty());
 }
 
 #[compio_macros::test]
@@ -73,13 +98,14 @@ async fn test_udp_recv_msg_buffer_pool() {
     })
     .detach();
 
-    let (buffer, _, addr) = listener
+    let (buffer, _, addr, flags) = listener
         .recv_msg_managed(0, Vec::with_capacity(64))
         .await
         .unwrap()
         .unwrap();
     assert_eq!(buffer.as_ref(), b"test");
     assert_eq!(addr, connected_addr);
+    assert_eq!(flags, ReturnFlags::empty());
 }
 
 #[compio_macros::test]
@@ -105,6 +131,34 @@ async fn test_uds_recv_buffer_pool() {
         b"test"
     );
     assert!(matches!(stream.read_managed(0).await, Ok(None)));
+}
+
+#[cfg_attr(windows, ignore = "UDS support on Windows is incomplete")]
+#[compio_macros::test]
+async fn test_uds_read_managed_with_ancillary() {
+    let dir = tempfile::Builder::new()
+        .prefix("compio-uds-anc-buf")
+        .tempdir()
+        .unwrap();
+    let sock_path = dir.path().join("connect.sock");
+
+    let listener = UnixListener::bind(&sock_path).await.unwrap();
+
+    compio_runtime::spawn(async move {
+        let mut stream = listener.accept().await.unwrap().0;
+        stream.write_all(b"test").await.unwrap();
+    })
+    .detach();
+
+    let mut stream = UnixStream::connect(&sock_path).await.unwrap();
+
+    let (buffer, _control, flags) = stream
+        .read_managed_with_ancillary(0, AncillaryBuf::<64>::new())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(buffer.as_ref(), b"test");
+    assert_eq!(flags, ReturnFlags::empty());
 }
 
 #[compio_macros::test]

--- a/compio-net/tests/buffer_pool.rs
+++ b/compio-net/tests/buffer_pool.rs
@@ -232,7 +232,6 @@ async fn test_udp_recv_msg_multi() {
     assert_eq!(result.flags(), ReturnFlags::empty());
 }
 
-#[cfg(target_os = "linux")]
 #[compio_macros::test(with_proactor(buffer_pool_buffer_len = 256))]
 async fn test_udp_recv_msg_multi_truncated_datagram() {
     let listener = UdpSocket::bind((Ipv6Addr::LOCALHOST, 0)).await.unwrap();

--- a/compio-net/tests/tcp_connect.rs
+++ b/compio-net/tests/tcp_connect.rs
@@ -149,6 +149,7 @@ async fn connect_invalid_dst() {
     assert!(TcpStream::connect("127.0.0.0:0").await.is_err());
 }
 
+#[cfg_attr(windows, ignore)]
 #[compio_macros::test]
 async fn read_with_ancillary_flags() {
     const MSG: &[u8] = b"test";

--- a/compio-net/tests/tcp_connect.rs
+++ b/compio-net/tests/tcp_connect.rs
@@ -2,6 +2,10 @@
 
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
 
+use compio_io::{
+    AsyncWriteExt,
+    ancillary::{AncillaryBuf, AsyncReadAncillary, ReturnFlags},
+};
 use compio_net::{TcpListener, TcpSocket, TcpStream, ToSocketAddrsAsync};
 use compio_runtime::ResumeUnwind;
 
@@ -143,4 +147,28 @@ test_connect! {
 #[compio_macros::test]
 async fn connect_invalid_dst() {
     assert!(TcpStream::connect("127.0.0.0:0").await.is_err());
+}
+
+#[compio_macros::test]
+async fn read_with_ancillary_flags() {
+    const MSG: &[u8] = b"test";
+
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    compio_runtime::spawn(async move {
+        let mut stream = listener.accept().await.unwrap().0;
+        stream.write_all(MSG).await.unwrap();
+    })
+    .detach();
+
+    let mut stream = TcpStream::connect(addr).await.unwrap();
+    let ((n, control_len, flags), (buffer, _control)) = stream
+        .read_with_ancillary(Vec::with_capacity(8), AncillaryBuf::<64>::new())
+        .await
+        .unwrap();
+    assert_eq!(buffer.as_slice(), MSG);
+    assert_eq!(n, MSG.len());
+    assert_eq!(control_len, 0);
+    assert_eq!(flags, ReturnFlags::empty());
 }

--- a/compio-net/tests/udp.rs
+++ b/compio-net/tests/udp.rs
@@ -1,3 +1,4 @@
+use compio_io::ancillary::{AncillaryBuf, ReturnFlags};
 use compio_net::UdpSocket;
 
 #[compio_macros::test]
@@ -90,4 +91,76 @@ async fn send_recv_vectored() {
     assert_eq!(MSG2, buffer.1.0.as_slice());
     assert_eq!(active.local_addr().unwrap(), active_addr);
     assert_eq!(active.peer_addr().unwrap(), passive_addr);
+}
+
+#[compio_macros::test]
+async fn recv_msg_with_flags() {
+    const MSG: &str = "foo bar baz";
+
+    let passive = UdpSocket::bind("127.0.0.1:0").await.unwrap();
+    let passive_addr = passive.local_addr().unwrap();
+
+    let active = UdpSocket::bind("127.0.0.1:0").await.unwrap();
+    let active_addr = active.local_addr().unwrap();
+
+    active.send_to(MSG, passive_addr).await.0.unwrap();
+
+    let ((n, control_len, addr, flags), (buffer, _control)) = passive
+        .recv_msg_with_flags(Vec::with_capacity(20), AncillaryBuf::<64>::new())
+        .await
+        .unwrap();
+    assert_eq!(MSG.as_bytes(), &buffer);
+    assert_eq!(n, MSG.len());
+    assert_eq!(control_len, 0);
+    assert_eq!(addr, active_addr);
+    assert_eq!(flags, ReturnFlags::empty());
+
+    active.send_to(MSG, passive_addr).await.0.unwrap();
+
+    let ((n, control_len, addr, flags), (buffer, _control)) = passive
+        .recv_msg_vectored_with_flags(
+            ([0; 4], (Vec::with_capacity(20),)),
+            AncillaryBuf::<64>::new(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(&buffer.0, &MSG.as_bytes()[..4]);
+    assert_eq!(buffer.1.0.as_slice(), &MSG.as_bytes()[4..]);
+    assert_eq!(n, MSG.len());
+    assert_eq!(control_len, 0);
+    assert_eq!(addr, active_addr);
+    assert_eq!(flags, ReturnFlags::empty());
+
+    active.send_to(MSG, passive_addr).await.0.unwrap();
+
+    let ((n, control_len, addr), (buffer, _control)) = passive
+        .recv_msg(Vec::with_capacity(20), AncillaryBuf::<64>::new())
+        .await
+        .unwrap();
+    assert_eq!(MSG.as_bytes(), &buffer);
+    assert_eq!(n, MSG.len());
+    assert_eq!(control_len, 0);
+    assert_eq!(addr, active_addr);
+}
+
+#[cfg(any(target_os = "linux", target_os = "android"))]
+#[compio_macros::test]
+async fn recv_msg_with_flags_truncated_datagram() {
+    const MSG: &[u8] = b"foo bar baz";
+
+    let passive = UdpSocket::bind("127.0.0.1:0").await.unwrap();
+    let passive_addr = passive.local_addr().unwrap();
+
+    let active = UdpSocket::bind("127.0.0.1:0").await.unwrap();
+    let active_addr = active.local_addr().unwrap();
+
+    active.send_to(MSG, passive_addr).await.0.unwrap();
+
+    let ((_n, _control_len, addr, flags), (buffer, _control)) = passive
+        .recv_msg_with_flags(Vec::with_capacity(3), AncillaryBuf::<64>::new())
+        .await
+        .unwrap();
+    assert_eq!(&MSG[..buffer.len()], buffer.as_slice());
+    assert_eq!(addr, active_addr);
+    assert!(flags.contains(ReturnFlags::TRUNC));
 }

--- a/compio-net/tests/udp.rs
+++ b/compio-net/tests/udp.rs
@@ -94,7 +94,7 @@ async fn send_recv_vectored() {
 }
 
 #[compio_macros::test]
-async fn recv_msg_with_flags() {
+async fn recv_msg_flags() {
     const MSG: &str = "foo bar baz";
 
     let passive = UdpSocket::bind("127.0.0.1:0").await.unwrap();
@@ -106,7 +106,7 @@ async fn recv_msg_with_flags() {
     active.send_to(MSG, passive_addr).await.0.unwrap();
 
     let ((n, control_len, addr, flags), (buffer, _control)) = passive
-        .recv_msg_with_flags(Vec::with_capacity(20), AncillaryBuf::<64>::new())
+        .recv_msg(Vec::with_capacity(20), AncillaryBuf::<64>::new())
         .await
         .unwrap();
     assert_eq!(MSG.as_bytes(), &buffer);
@@ -118,7 +118,7 @@ async fn recv_msg_with_flags() {
     active.send_to(MSG, passive_addr).await.0.unwrap();
 
     let ((n, control_len, addr, flags), (buffer, _control)) = passive
-        .recv_msg_vectored_with_flags(
+        .recv_msg_vectored(
             ([0; 4], (Vec::with_capacity(20),)),
             AncillaryBuf::<64>::new(),
         )
@@ -130,22 +130,11 @@ async fn recv_msg_with_flags() {
     assert_eq!(control_len, 0);
     assert_eq!(addr, active_addr);
     assert_eq!(flags, ReturnFlags::empty());
-
-    active.send_to(MSG, passive_addr).await.0.unwrap();
-
-    let ((n, control_len, addr), (buffer, _control)) = passive
-        .recv_msg(Vec::with_capacity(20), AncillaryBuf::<64>::new())
-        .await
-        .unwrap();
-    assert_eq!(MSG.as_bytes(), &buffer);
-    assert_eq!(n, MSG.len());
-    assert_eq!(control_len, 0);
-    assert_eq!(addr, active_addr);
 }
 
 #[cfg(any(target_os = "linux", target_os = "android"))]
 #[compio_macros::test]
-async fn recv_msg_with_flags_truncated_datagram() {
+async fn recv_msg_flags_truncated_datagram() {
     const MSG: &[u8] = b"foo bar baz";
 
     let passive = UdpSocket::bind("127.0.0.1:0").await.unwrap();
@@ -157,7 +146,7 @@ async fn recv_msg_with_flags_truncated_datagram() {
     active.send_to(MSG, passive_addr).await.0.unwrap();
 
     let ((_n, _control_len, addr, flags), (buffer, _control)) = passive
-        .recv_msg_with_flags(Vec::with_capacity(3), AncillaryBuf::<64>::new())
+        .recv_msg(Vec::with_capacity(3), AncillaryBuf::<64>::new())
         .await
         .unwrap();
     assert_eq!(&MSG[..buffer.len()], buffer.as_slice());

--- a/compio-net/tests/unix_stream.rs
+++ b/compio-net/tests/unix_stream.rs
@@ -1,4 +1,7 @@
-use compio_io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
+use compio_io::{
+    AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt,
+    ancillary::{AncillaryBuf, AsyncReadAncillary, ReturnFlags},
+};
 use compio_net::{UnixListener, UnixStream};
 
 #[compio_macros::test]
@@ -43,5 +46,34 @@ async fn shutdown() -> std::io::Result<()> {
     // Read from the server should return 0 to indicate the channel has been closed.
     let n = server.read(Vec::with_capacity(1)).await.0?;
     assert_eq!(n, 0);
+    Ok(())
+}
+
+#[compio_macros::test]
+async fn read_with_ancillary_flags() -> std::io::Result<()> {
+    const MSG: &[u8] = b"hello";
+
+    let dir = tempfile::Builder::new()
+        .prefix("compio-uds-tests")
+        .tempdir()
+        .unwrap();
+    let sock_path = dir.path().join("connect.sock");
+
+    let listener = UnixListener::bind(&sock_path).await?;
+
+    let (mut client, (mut server, _)) =
+        futures_util::try_join!(UnixStream::connect(&sock_path), listener.accept()).unwrap();
+
+    client.write_all(MSG).await.0?;
+
+    let ((n, control_len, flags), (buffer, _control)) = server
+        .read_with_ancillary(Vec::with_capacity(8), AncillaryBuf::<64>::new())
+        .await
+        .unwrap();
+    assert_eq!(buffer.as_slice(), MSG);
+    assert_eq!(n, MSG.len());
+    assert_eq!(control_len, 0);
+    assert_eq!(flags, ReturnFlags::empty());
+
     Ok(())
 }

--- a/compio-net/tests/unix_stream.rs
+++ b/compio-net/tests/unix_stream.rs
@@ -49,7 +49,7 @@ async fn shutdown() -> std::io::Result<()> {
     Ok(())
 }
 
-#[cfg_attr(windows, ignore = "UDS support on Windows is incomplete")]
+#[cfg_attr(windows, ignore)]
 #[compio_macros::test]
 async fn read_with_ancillary_flags() -> std::io::Result<()> {
     const MSG: &[u8] = b"hello";

--- a/compio-net/tests/unix_stream.rs
+++ b/compio-net/tests/unix_stream.rs
@@ -49,6 +49,7 @@ async fn shutdown() -> std::io::Result<()> {
     Ok(())
 }
 
+#[cfg_attr(windows, ignore = "UDS support on Windows is incomplete")]
 #[compio_macros::test]
 async fn read_with_ancillary_flags() -> std::io::Result<()> {
     const MSG: &[u8] = b"hello";

--- a/compio-quic/src/socket.rs
+++ b/compio-quic/src/socket.rs
@@ -283,7 +283,7 @@ impl Socket {
         let control = AncillaryBuf::<CMSG_LEN>::new();
 
         let BufResult(res, (buffer, control)) = self.inner.recv_msg(buffer, control).await;
-        let ((len, _, remote), buffer) = buf_try!(res, buffer);
+        let ((len, _, remote, _flags), buffer) = buf_try!(res, buffer);
 
         let mut ecn_bits = 0u8;
         let mut local_ip = None;


### PR DESCRIPTION
Expose `recvmsg` return flags from ancillary receive APIs.

This is preparation for KTLS support in `compio-tls`. KTLS receive handling needs
access to `msghdr.msg_flags` after `recvmsg`, especially to detect control-message
truncation via `MSG_CTRUNC`.

Relevant references:
- OpenSSL KTLS receive handling checks `msg.msg_flags` for flags such as
  `MSG_CTRUNC`: https://github.com/openssl/openssl/blob/0c1194718301808d48db78355c03c6f5e884e4a3/include/internal/ktls.h#L171
- Linux `recvmsg(2)` documents `msg_flags` as flags on the received message,
  including `MSG_CTRUNC`: https://man7.org/linux/man-pages/man2/recv.2.html