### PR TITLE
fix(executor): reduce panic on drop

### DIFF
--- a/compio-executor/src/queue.rs
+++ b/compio-executor/src/queue.rs
@@ -237,8 +237,10 @@ impl Inner {
         item.next = None;
         item.is_hot = HOT;
 
-        if let Some(tail_key) = old_tail {
-            self.map.get_mut(tail_key).expect("tail exists").next = Some(key);
+        if let Some(tail_key) = old_tail
+            && let Some(tail_item) = self.map.get_mut(tail_key)
+        {
+            tail_item.next = Some(key);
         }
     }
 
@@ -258,11 +260,15 @@ impl Inner {
             list.tail = prev;
         }
 
-        if let Some(prev_key) = prev {
-            self.map.get_mut(prev_key).expect("prev exists").next = next;
+        if let Some(prev_key) = prev
+            && let Some(prev_item) = self.map.get_mut(prev_key)
+        {
+            prev_item.next = next;
         }
-        if let Some(next_key) = next {
-            self.map.get_mut(next_key).expect("next exists").prev = prev;
+        if let Some(next_key) = next
+            && let Some(next_item) = self.map.get_mut(next_key)
+        {
+            next_item.prev = prev;
         }
     }
 


### PR DESCRIPTION
Closes #936 

The calling chain:
* `TaskQueue::clear` calls `map.drain()` to drop each task.
* `task.drop()` drops the task A, but makes the task B to be scheduled.
* `Inner::unlink` tries to pop B from the linked list, and make A.next pointing to B.next.
* Task A has been drained. BOOM.