### PR TITLE
fix(compio-driver): drop linux_5_11 requirement on rustix dependency

### DIFF
--- a/compio-driver/Cargo.toml
+++ b/compio-driver/Cargo.toml
@@ -58,7 +58,7 @@ compile_warning = { version = "0.1.0", optional = true }
 io-uring = { version = "0.7.12", optional = true }
 once_cell = { workspace = true, optional = true }
 polling = { version = "3.3.0", optional = true }
-rustix = { workspace = true, features = ["linux_5_11"] }
+rustix = { workspace = true }
 linux-raw-sys = { version = "0.12.1", optional = true }
 
 # Other platform dependencies


### PR DESCRIPTION
Correct me if I'm wrong, but I don't think we had any hard dependency on Linux 5.11 features. This breaks the poll driver on older kernels that does not have `epoll_pwait2` syscall: 

https://github.com/bytecodealliance/rustix/blob/9f588bc922f98d19fdb1f44cdb17f190d239b0eb/src/backend/libc/event/syscalls.rs#L556-L631

Users are free to enable the feature in downstream applications if they need it