### PR TITLE
fix(executor): remove is_scheduling() guard from Remote::schedule

### DIFF
--- a/compio-executor/src/task/remote.rs
+++ b/compio-executor/src/task/remote.rs
@@ -39,11 +39,7 @@ impl<'a> Remote<'a> {
 
         trace!(?state);
 
-        if state.is_scheduled()
-            || state.is_scheduling()
-            || state.is_completed()
-            || state.is_cancelled()
-        {
+        if state.is_scheduled() || state.is_completed() || state.is_cancelled() {
             self.header().state.finish_scheduling();
             return;
         }

--- a/compio-executor/tests/loom.rs
+++ b/compio-executor/tests/loom.rs
@@ -106,6 +106,73 @@ fn test_cross_thread_wake() {
     });
 }
 
+/// Regression test for <https://github.com/compio-rs/compio/issues/948>.
+///
+/// Exercises the real `Executor` / `Remote::schedule` path with two
+/// concurrent cross-thread wakes. A message-pump task parks after each
+/// wake; loom exhaustively checks that no interleaving strands the task
+/// (W2's wake lost because W1 is still inside `finish_scheduling`).
+#[test]
+fn test_no_lost_cross_thread_wake() {
+    use std::{
+        cell::{Cell, RefCell},
+        future::poll_fn,
+        rc::Rc,
+    };
+
+    loom::model(|| {
+        let exe = Executor::new();
+        let polls = Rc::new(Cell::new(0));
+        let waker = Rc::new(RefCell::new(None));
+
+        let handle = exe.spawn({
+            let (polls, waker) = (polls.clone(), waker.clone());
+            poll_fn(move |cx| {
+                let n = polls.get() + 1;
+                polls.set(n);
+                *waker.borrow_mut() = Some(cx.waker().clone());
+                if n >= 3 {
+                    Poll::Ready(())
+                } else {
+                    Poll::Pending
+                }
+            })
+        });
+
+        exe.tick();
+        assert_eq!(polls.get(), 1, "spawned task did not run on first tick");
+
+        let w1: Waker = waker.borrow().clone().unwrap();
+        let t1 = thread::spawn(move || w1.wake());
+
+        loop {
+            exe.tick();
+            if polls.get() >= 2 {
+                break;
+            }
+            thread::yield_now();
+        }
+
+        let w2: Waker = waker.borrow().clone().unwrap();
+        let t2 = thread::spawn(move || w2.wake());
+        t2.join().unwrap();
+        t1.join().unwrap();
+
+        for _ in 0..4 {
+            exe.tick();
+        }
+
+        assert_eq!(
+            polls.get(),
+            3,
+            "lost wake: both wake() calls returned, yet the task was never re-polled (parked \
+             forever with a message pending)",
+        );
+
+        drop(handle);
+    });
+}
+
 #[test]
 fn test_join_while_complete() {
     loom::model(|| {


### PR DESCRIPTION
Fixes #948.

- Removes the `state.is_scheduling()` check from the early-return guard in `Remote::schedule`
- `SCHEDULING` bit is still set/cleared (needed by `wait_for_scheduling` during teardown); only the guard check is removed

### Why `is_scheduling()` is wrong here

`start_scheduling` does `fetch_or(SCHEDULED | SCHEDULING)` and returns the **previous** snapshot. The guard then early-returns (skips pushing to the sync queue) if that snapshot has `SCHEDULED`, `SCHEDULING`, `COMPLETED`, or `CANCELLED` set.

`SCHEDULED` is safe for dedup: it is cleared by `unschedule()` right before the executor polls, so `SCHEDULED=1` guarantees a pending or forthcoming push. A second waker can skip.

`SCHEDULING` is **not** safe: it means "another waker is between `start_scheduling` and `finish_scheduling`," but that window can span across an executor poll:

```
W1:  fetch_or(S|Sing)  →  pushes id  →  [preempted before finish_scheduling]
Exec:  pops id, clears S, polls task  →  task re-parks
W2:  fetch_or(S|Sing)  →  prev has Sing from W1  →  early-return (BUG)
     W2's fetch_or re-set S=1, W2's finish_scheduling cleared Sing
W1:  finish_scheduling: no-op (Sing already 0)
```

Result: `SCHEDULED=1`, `SCHEDULING=0`, sync queue empty. The task is stranded forever. Every subsequent `Remote::schedule` sees `SCHEDULED=1` and early-returns without pushing.

### No duplicate-push risk

`fetch_or(SCHEDULED | SCHEDULING)` is atomic. Among concurrent wakers, only one sees `SCHEDULED=0` in the returned snapshot and proceeds to push. All others see `SCHEDULED=1` (set by the first waker's `fetch_or`) and early-return on `is_scheduled()`. Two wakers both push only if `unschedule()` cleared `SCHEDULED` between their `fetch_or` calls, meaning the first push was consumed. That is exactly when the second push is needed.

### Loom proof

Three threads (W1, executor, W2). The buggy version fails deterministically; the fixed version passes all interleavings (~48s exhaustive search).

```rust
use loom::sync::atomic::AtomicUsize;
use loom::sync::atomic::Ordering::*;
use loom::sync::{Arc, Mutex};
use std::collections::VecDeque;

const SCHEDULED: usize = 1 << 0;
const SCHEDULING: usize = 1 << 1;

struct Task {
    state: AtomicUsize,
    queue: Mutex<VecDeque<()>>,
    poll_count: AtomicUsize,
}

impl Task {
    fn new() -> Self {
        Self {
            state: AtomicUsize::new(0),
            queue: Mutex::new(VecDeque::new()),
            poll_count: AtomicUsize::new(0),
        }
    }

    /// Remote::schedule as of compio-executor 0.1.1 / e5083db.
    fn remote_schedule_buggy(&self) {
        let prev = self.state.fetch_or(SCHEDULED | SCHEDULING, AcqRel);
        if prev & SCHEDULED != 0 || prev & SCHEDULING != 0 {
            self.state.fetch_and(!SCHEDULING, Release);
            return;
        }
        self.queue.lock().unwrap().push_back(());
        self.state.fetch_and(!SCHEDULING, Release);
    }

    /// Fixed: SCHEDULING check removed.
    fn remote_schedule_fixed(&self) {
        let prev = self.state.fetch_or(SCHEDULED | SCHEDULING, AcqRel);
        if prev & SCHEDULED != 0 {
            self.state.fetch_and(!SCHEDULING, Release);
            return;
        }
        self.queue.lock().unwrap().push_back(());
        self.state.fetch_and(!SCHEDULING, Release);
    }

    fn try_tick(&self) -> bool {
        let popped = self.queue.lock().unwrap().pop_front().is_some();
        if popped {
            self.state.fetch_and(!SCHEDULED, AcqRel);
            self.poll_count.fetch_add(1, Relaxed);
        }
        popped
    }

    fn drain(&self) { while self.try_tick() {} }

    fn assert_no_stranded_task(&self) {
        let bits = self.state.load(Acquire);
        let empty = self.queue.lock().unwrap().is_empty();
        assert_eq!(bits & SCHEDULING, 0);
        assert!(
            !(bits & SCHEDULED != 0 && empty),
            "lost wake: SCHEDULED=1 but queue empty (polls: {}, state: {:#04x})",
            self.poll_count.load(Relaxed), bits,
        );
    }
}

#[test]
fn second_remote_wake_lost_buggy() {
    loom::model(|| {
        let task = Arc::new(Task::new());
        let t1 = task.clone();
        let w1 = loom::thread::spawn(move || t1.remote_schedule_buggy());
        let te = task.clone();
        let exec = loom::thread::spawn(move || { for _ in 0..2 { te.try_tick(); } });
        let t2 = task.clone();
        let w2 = loom::thread::spawn(move || t2.remote_schedule_buggy());
        w1.join().unwrap(); w2.join().unwrap(); exec.join().unwrap();
        task.drain();
        task.assert_no_stranded_task();
    });
}
// -> FAILED: lost wake: SCHEDULED=1 but queue empty (polls: 1, state: 0x01)

#[test]
fn second_remote_wake_not_lost_fixed() {
    loom::model(|| {
        let task = Arc::new(Task::new());
        let t1 = task.clone();
        let w1 = loom::thread::spawn(move || t1.remote_schedule_fixed());
        let te = task.clone();
        let exec = loom::thread::spawn(move || { for _ in 0..2 { te.try_tick(); } });
        let t2 = task.clone();
        let w2 = loom::thread::spawn(move || t2.remote_schedule_fixed());
        w1.join().unwrap(); w2.join().unwrap(); exec.join().unwrap();
        task.drain();
        task.assert_no_stranded_task();
    });
}
// -> ok (all interleavings pass)
```