### PR TITLE
fix(runtime): set CURRENT_RUNTIME in Runtime::run()

### DIFF
--- a/compio-runtime/Cargo.toml
+++ b/compio-runtime/Cargo.toml
@@ -24,7 +24,7 @@ compio-io = { workspace = true, optional = true }
 criterion = { workspace = true, optional = true }
 compio-send-wrapper = { workspace = true }
 core_affinity = "0.8.3"
-futures-util = { workspace = true }
+futures-util = { workspace = true, features = ["io"] }
 scoped-tls = "1.0.1"
 pin-project-lite = { workspace = true }
 synchrony = { workspace = true, features = ["event"] }

--- a/compio-runtime/src/lib.rs
+++ b/compio-runtime/src/lib.rs
@@ -158,7 +158,7 @@ impl Runtime {
     ///
     /// The return value indicates whether there are still tasks in the queue.
     pub fn run(&self) -> bool {
-        self.executor.tick()
+        self.enter(|| self.executor.tick())
     }
 
     /// Low level API to control the runtime.

--- a/compio-runtime/tests/drop.rs
+++ b/compio-runtime/tests/drop.rs
@@ -6,6 +6,7 @@ use std::{
     sync::Arc,
     task::{Context, Poll},
     thread::{self, ThreadId},
+    time::Duration,
 };
 
 use compio_runtime::CancelToken;
@@ -120,4 +121,34 @@ fn test_task_dropped_when_runtime_drops() {
     drop(rt);
 
     assert!(flag.get(), "spawned task was not dropped: Rc cycle?");
+}
+
+#[test]
+fn test_run_enters_runtime_context() {
+    let rt = compio_runtime::Runtime::new().unwrap();
+    let waker = Arc::new(AtomicWaker::new());
+    let waker2 = waker.clone();
+
+    rt.block_on(async {
+        compio_runtime::spawn(async move {
+            let timer = compio_runtime::time::sleep(Duration::from_secs(3600));
+            futures_util::pin_mut!(timer);
+
+            std::future::poll_fn(|cx| {
+                let _ = timer.as_mut().poll(cx);
+                waker2.register(cx.waker());
+                Poll::<()>::Pending
+            })
+            .await;
+        })
+        .detach();
+
+        compio_runtime::spawn(async {}).await.unwrap();
+    });
+
+    waker.take().unwrap().wake();
+
+    // Must not panic: run() should set CURRENT_RUNTIME so that
+    // TimerFuture::poll (and TimerFuture::drop) can find the runtime.
+    rt.run();
 }


### PR DESCRIPTION
- `Runtime::run()` calls `self.executor.tick()` without `self.enter()`, so `CURRENT_RUNTIME` is not set during task execution
- Any task polled or dropped during `tick()` that calls `Runtime::with_current()` (e.g. `TimerFuture::poll`, `TimerFuture::drop`) panics with "not in a compio runtime"
- Wrap `tick()` in `self.enter()` to match what `block_on()` and `Runtime::drop()` already do
- Add regression test that wakes a timer-holding task after `block_on()` returns and ticks it via `run()`
- Also fix missing `futures-util` `"io"` feature needed for `PollFd`'s `AsyncRead`/`AsyncWrite` impls (same as #951)