### PR TITLE
fix(driver,iour): set IORING_ENTER_NO_IOWAIT on CQE wait

### DIFF
--- a/compio-driver/Cargo.toml
+++ b/compio-driver/Cargo.toml
@@ -55,7 +55,7 @@ windows-sys = { workspace = true, features = [
 # Linux specific dependencies
 [target.'cfg(target_os = "linux")'.dependencies]
 compile_warning = { version = "0.1.0", optional = true }
-io-uring = { version = "0.7.12", optional = true }
+io-uring = { version = "0.7.13", optional = true }
 once_cell = { workspace = true, optional = true }
 polling = { version = "3.3.0", optional = true }
 rustix = { workspace = true }

--- a/compio-driver/src/sys/driver/iour/mod.rs
+++ b/compio-driver/src/sys/driver/iour/mod.rs
@@ -27,7 +27,7 @@ cfg_select! {
 
 use flume::{Receiver, Sender};
 use io_uring::{
-    IoUring,
+    EnterFlags, IoUring,
     cqueue::more,
     opcode::{AsyncCancel, PollAdd},
     types::{Fd, SubmitArgs, Timespec},
@@ -51,6 +51,10 @@ pub(crate) struct Driver {
     completed_tx: Sender<Entry>,
     completed_rx: Receiver<Entry>,
     need_push_notifier: bool,
+    /// Set `IORING_ENTER_NO_IOWAIT` on blocking waits so an idle ring is not
+    /// charged as iowait. Disabled when SQPOLL is in use, and flipped off
+    /// permanently after the first `EINVAL` on kernels older than 6.15.
+    no_iowait: bool,
     /// Keys leaked via `into_raw()` into io_uring user_data, freed on drop.
     in_flight: HashSet<usize>,
     _p: PhantomData<ErasedKey>,
@@ -114,6 +118,7 @@ impl Driver {
             completed_rx,
             pool: builder.create_or_get_thread_pool(),
             need_push_notifier: true,
+            no_iowait: builder.sqpoll_idle.is_none(),
             in_flight: HashSet::new(),
             _p: PhantomData,
         })
@@ -167,15 +172,23 @@ impl Driver {
             1
         };
 
-        let res = {
-            // Last part of submission queue, wait till timeout.
-            if let Some(duration) = timeout {
-                let timespec = timespec(duration);
-                let args = SubmitArgs::new().timespec(&timespec);
-                self.inner.submitter().submit_with_args(want_sqe, &args)
-            } else {
-                self.inner.submit_and_wait(want_sqe)
+        // About to block: opt out of iowait accounting (see the `no_iowait`
+        // field). Flush first so a submit error is mapped below like any other;
+        // only the wait-only enter returning EINVAL means the kernel lacks the
+        // flag, so only that disables it permanently.
+        let res = if self.no_iowait && want_sqe > 0 {
+            match self.inner.submit() {
+                Ok(_) => match self.wait_no_iowait(want_sqe, timeout) {
+                    Err(e) if e.raw_os_error() == Some(libc::EINVAL) => {
+                        self.no_iowait = false;
+                        self.submit_blocking(want_sqe, timeout)
+                    }
+                    other => other,
+                },
+                Err(e) => Err(e),
             }
+        } else {
+            self.submit_blocking(want_sqe, timeout)
         };
         trace!("submit result: {res:?}");
         match res {
@@ -191,6 +204,37 @@ impl Driver {
                 Some(libc::EBUSY) | Some(libc::EAGAIN) => Err(io::ErrorKind::Interrupted.into()),
                 _ => Err(e),
             },
+        }
+    }
+
+    /// The original submit+wait, used when `NO_IOWAIT` is unavailable.
+    fn submit_blocking(&self, want_sqe: usize, timeout: Option<Duration>) -> io::Result<usize> {
+        if let Some(duration) = timeout {
+            let timespec = timespec(duration);
+            let args = SubmitArgs::new().timespec(&timespec);
+            self.inner.submitter().submit_with_args(want_sqe, &args)
+        } else {
+            self.inner.submit_and_wait(want_sqe)
+        }
+    }
+
+    /// Wait on completions with `IORING_ENTER_NO_IOWAIT` so the wait is not
+    /// charged as iowait (see the `no_iowait` field). SQEs must already be
+    /// flushed: this issues a wait-only `enter` with `to_submit = 0`, one extra
+    /// syscall paid only on the path where the ring is about to sleep anyway.
+    fn wait_no_iowait(&self, want_sqe: usize, timeout: Option<Duration>) -> io::Result<usize> {
+        let submitter = self.inner.submitter();
+        if let Some(duration) = timeout {
+            let timespec = timespec(duration);
+            let args = SubmitArgs::new().timespec(&timespec);
+            let flags = EnterFlags::EXT_ARG | EnterFlags::GETEVENTS | EnterFlags::NO_IOWAIT;
+            // SAFETY: `args` outlives the call and `to_submit` is 0, so the kernel
+            // reads no submission entries and only the timeout arg we pass.
+            unsafe { submitter.enter(0, want_sqe as u32, flags.bits(), Some(&args)) }
+        } else {
+            let flags = EnterFlags::GETEVENTS | EnterFlags::NO_IOWAIT;
+            // SAFETY: `to_submit` is 0 and no arg payload is referenced.
+            unsafe { submitter.enter::<libc::sigset_t>(0, want_sqe as u32, flags.bits(), None) }
         }
     }
 

--- a/compio-driver/src/sys/driver/iour/mod.rs
+++ b/compio-driver/src/sys/driver/iour/mod.rs
@@ -39,6 +39,23 @@ use crate::{
     panic::catch_unwind_io,
 };
 
+bitflags::bitflags! {
+    /// Mutable driver state tracked as a small bit set.
+    #[derive(Clone, Copy)]
+    struct DriverFlags: u8 {
+        /// The multishot notifier `PollAdd` is no longer armed and must be
+        /// re-pushed before the next wait.
+        const NEED_PUSH_NOTIFIER = 1 << 0;
+        /// Set `IORING_ENTER_NO_IOWAIT` on blocking waits so an idle ring is not
+        /// charged as iowait. Cleared when SQPOLL is in use, and cleared
+        /// permanently after the first `EINVAL` on kernels older than 6.15.
+        ///
+        /// See io_uring_enter(2):
+        /// <https://man7.org/linux/man-pages/man2/io_uring_enter.2.html>
+        const NO_IOWAIT = 1 << 1;
+    }
+}
+
 /// Low-level driver of io-uring.
 pub(crate) struct Driver {
     // Wrapped in `ManuallyDrop` so that `Drop` can close the ring *before*
@@ -50,14 +67,7 @@ pub(crate) struct Driver {
     pool: AsyncifyPool,
     completed_tx: Sender<Entry>,
     completed_rx: Receiver<Entry>,
-    need_push_notifier: bool,
-    /// Set `IORING_ENTER_NO_IOWAIT` on blocking waits so an idle ring is not
-    /// charged as iowait. Disabled when SQPOLL is in use, and flipped off
-    /// permanently after the first `EINVAL` on kernels older than 6.15.
-    ///
-    /// See io_uring_enter(2):
-    /// <https://man7.org/linux/man-pages/man2/io_uring_enter.2.html>
-    no_iowait: bool,
+    flags: DriverFlags,
     /// Keys leaked via `into_raw()` into io_uring user_data, freed on drop.
     in_flight: HashSet<usize>,
     _p: PhantomData<ErasedKey>,
@@ -114,14 +124,18 @@ impl Driver {
 
         let (completed_tx, completed_rx) = flume::unbounded();
 
+        // NO_IOWAIT is meaningless under SQPOLL: the polling thread, not an
+        // `enter` wait, drives submission, so there is no CQE wait to mark.
+        let mut flags = DriverFlags::NEED_PUSH_NOTIFIER;
+        flags.set(DriverFlags::NO_IOWAIT, builder.sqpoll_idle.is_none());
+
         Ok(Self {
             inner: ManuallyDrop::new(inner),
             notifier,
             completed_tx,
             completed_rx,
             pool: builder.create_or_get_thread_pool(),
-            need_push_notifier: true,
-            no_iowait: builder.sqpoll_idle.is_none(),
+            flags,
             in_flight: HashSet::new(),
             _p: PhantomData,
         })
@@ -179,16 +193,17 @@ impl Driver {
         // timeout (the drain calls from `push_raw`/`flush`) returns immediately,
         // so it keeps the combined path and pays no extra syscall.
         //
-        // On the sleeping path, opt out of iowait accounting (see `no_iowait`):
+        // On the sleeping path, opt out of iowait accounting (see
+        // `DriverFlags::NO_IOWAIT`):
         // flush first so a submit error is mapped below like any other; only the
         // wait-only enter returning EINVAL means the kernel lacks the flag, so
         // only that disables it permanently.
         let can_block = want_sqe > 0 && timeout != Some(Duration::ZERO);
-        let res = if self.no_iowait && can_block {
+        let res = if self.flags.contains(DriverFlags::NO_IOWAIT) && can_block {
             match self.inner.submit() {
                 Ok(_) => match self.submit_no_iowait(want_sqe, timeout) {
                     Err(e) if e.raw_os_error() == Some(libc::EINVAL) => {
-                        self.no_iowait = false;
+                        self.flags.remove(DriverFlags::NO_IOWAIT);
                         self.submit_and_wait(want_sqe, timeout)
                     }
                     other => other,
@@ -227,7 +242,7 @@ impl Driver {
     }
 
     /// Wait on completions with `IORING_ENTER_NO_IOWAIT` so the wait is not
-    /// charged as iowait (see the `no_iowait` field). SQEs must already be
+    /// charged as iowait (see `DriverFlags::NO_IOWAIT`). SQEs must already be
     /// flushed: this issues a wait-only `enter` with `to_submit = 0`, one extra
     /// syscall paid only on the path where the ring is about to sleep anyway.
     fn submit_no_iowait(&self, want_sqe: usize, timeout: Option<Duration>) -> io::Result<usize> {
@@ -264,7 +279,7 @@ impl Driver {
                 Self::NOTIFY => {
                     let flags = entry.flags();
                     if !more(flags) {
-                        self.need_push_notifier = true;
+                        self.flags.insert(DriverFlags::NEED_PUSH_NOTIFIER);
                     }
                     if let Err(e) = self.notifier.clear() {
                         error!("failed to clear notifier: {e:?}");
@@ -431,7 +446,7 @@ impl Driver {
 
         let need_wait = !self.notifier.reset();
 
-        if self.need_push_notifier {
+        if self.flags.contains(DriverFlags::NEED_PUSH_NOTIFIER) {
             #[allow(clippy::useless_conversion)]
             self.push_raw(
                 PollAdd::new(Fd(self.notifier.as_raw_fd()), libc::POLLIN as _)
@@ -440,7 +455,7 @@ impl Driver {
                     .user_data(Self::NOTIFY)
                     .into(),
             )?;
-            self.need_push_notifier = false;
+            self.flags.remove(DriverFlags::NEED_PUSH_NOTIFIER);
         }
 
         self.submit_auto(timeout, need_wait)?;

--- a/compio-driver/src/sys/driver/iour/mod.rs
+++ b/compio-driver/src/sys/driver/iour/mod.rs
@@ -195,16 +195,14 @@ impl Driver {
 
         // Only a wait that can actually sleep is charged as iowait; a zero
         // timeout (the drain calls from `push_raw`/`flush`) returns immediately,
-        // so it keeps the combined path and pays no extra syscall.
+        // so it keeps the plain combined path.
         //
         // On the sleeping path, opt out of iowait accounting (see
-        // `DriverFlags::NO_IOWAIT`): flush the SQ with `submit()` first, then
-        // issue a wait-only `enter` carrying NO_IOWAIT.
+        // `DriverFlags::NO_IOWAIT`) by carrying NO_IOWAIT on the same
+        // submit-and-wait `enter`.
         let can_block = want_sqe > 0 && timeout != Some(Duration::ZERO);
         let res = if self.flags.contains(DriverFlags::NO_IOWAIT) && can_block {
-            self.inner
-                .submit()
-                .and_then(|_| self.submit_no_iowait(want_sqe, timeout))
+            self.submit_and_wait_no_iowait(want_sqe, timeout)
         } else {
             self.submit_and_wait(want_sqe, timeout)
         };
@@ -237,23 +235,33 @@ impl Driver {
         }
     }
 
-    /// Wait on completions with `IORING_ENTER_NO_IOWAIT` so the wait is not
-    /// charged as iowait (see `DriverFlags::NO_IOWAIT`). SQEs must already be
-    /// flushed: this issues a wait-only `enter` with `to_submit = 0`, one extra
-    /// syscall paid only on the path where the ring is about to sleep anyway.
-    fn submit_no_iowait(&self, want_sqe: usize, timeout: Option<Duration>) -> io::Result<usize> {
+    /// Submit the pending SQEs and wait on completions in a single `enter`
+    /// carrying `IORING_ENTER_NO_IOWAIT` so the wait is not charged as iowait
+    /// (see `DriverFlags::NO_IOWAIT`). The crate's `submit_*` helpers cannot add
+    /// custom `EnterFlags`, so this drops to the raw `enter` with
+    /// `to_submit = sq_len()` instead of the combined `submit_and_wait`.
+    fn submit_and_wait_no_iowait(
+        &mut self,
+        want_sqe: usize,
+        timeout: Option<Duration>,
+    ) -> io::Result<usize> {
+        // Publish the SQ tail and read how many staged SQEs to submit this call.
+        let to_submit = self.inner.submission().len() as u32;
         let submitter = self.inner.submitter();
         if let Some(duration) = timeout {
             let timespec = timespec(duration);
             let args = SubmitArgs::new().timespec(&timespec);
             let flags = EnterFlags::EXT_ARG | EnterFlags::GETEVENTS | EnterFlags::NO_IOWAIT;
-            // SAFETY: `args` outlives the call and `to_submit` is 0, so the kernel
-            // reads no submission entries and only the timeout arg we pass.
-            unsafe { submitter.enter(0, want_sqe as u32, flags.bits(), Some(&args)) }
+            // SAFETY: `args` outlives the call; the SQ is synced and holds
+            // `to_submit` valid SQEs.
+            unsafe { submitter.enter(to_submit, want_sqe as u32, flags.bits(), Some(&args)) }
         } else {
             let flags = EnterFlags::GETEVENTS | EnterFlags::NO_IOWAIT;
-            // SAFETY: `to_submit` is 0 and no arg payload is referenced.
-            unsafe { submitter.enter::<libc::sigset_t>(0, want_sqe as u32, flags.bits(), None) }
+            // SAFETY: the SQ is synced and holds `to_submit` valid SQEs; no arg
+            // payload is referenced.
+            unsafe {
+                submitter.enter::<libc::sigset_t>(to_submit, want_sqe as u32, flags.bits(), None)
+            }
         }
     }
 

--- a/compio-driver/src/sys/driver/iour/mod.rs
+++ b/compio-driver/src/sys/driver/iour/mod.rs
@@ -54,6 +54,9 @@ pub(crate) struct Driver {
     /// Set `IORING_ENTER_NO_IOWAIT` on blocking waits so an idle ring is not
     /// charged as iowait. Disabled when SQPOLL is in use, and flipped off
     /// permanently after the first `EINVAL` on kernels older than 6.15.
+    ///
+    /// See io_uring_enter(2):
+    /// <https://man7.org/linux/man-pages/man2/io_uring_enter.2.html>
     no_iowait: bool,
     /// Keys leaked via `into_raw()` into io_uring user_data, freed on drop.
     in_flight: HashSet<usize>,
@@ -172,23 +175,28 @@ impl Driver {
             1
         };
 
-        // About to block: opt out of iowait accounting (see the `no_iowait`
-        // field). Flush first so a submit error is mapped below like any other;
-        // only the wait-only enter returning EINVAL means the kernel lacks the
-        // flag, so only that disables it permanently.
-        let res = if self.no_iowait && want_sqe > 0 {
+        // Only a wait that can actually sleep is charged as iowait; a zero
+        // timeout (the drain calls from `push_raw`/`flush`) returns immediately,
+        // so it keeps the combined path and pays no extra syscall.
+        //
+        // On the sleeping path, opt out of iowait accounting (see `no_iowait`):
+        // flush first so a submit error is mapped below like any other; only the
+        // wait-only enter returning EINVAL means the kernel lacks the flag, so
+        // only that disables it permanently.
+        let can_block = want_sqe > 0 && timeout != Some(Duration::ZERO);
+        let res = if self.no_iowait && can_block {
             match self.inner.submit() {
-                Ok(_) => match self.wait_no_iowait(want_sqe, timeout) {
+                Ok(_) => match self.submit_no_iowait(want_sqe, timeout) {
                     Err(e) if e.raw_os_error() == Some(libc::EINVAL) => {
                         self.no_iowait = false;
-                        self.submit_blocking(want_sqe, timeout)
+                        self.submit_and_wait(want_sqe, timeout)
                     }
                     other => other,
                 },
                 Err(e) => Err(e),
             }
         } else {
-            self.submit_blocking(want_sqe, timeout)
+            self.submit_and_wait(want_sqe, timeout)
         };
         trace!("submit result: {res:?}");
         match res {
@@ -208,7 +216,7 @@ impl Driver {
     }
 
     /// The original submit+wait, used when `NO_IOWAIT` is unavailable.
-    fn submit_blocking(&self, want_sqe: usize, timeout: Option<Duration>) -> io::Result<usize> {
+    fn submit_and_wait(&self, want_sqe: usize, timeout: Option<Duration>) -> io::Result<usize> {
         if let Some(duration) = timeout {
             let timespec = timespec(duration);
             let args = SubmitArgs::new().timespec(&timespec);
@@ -222,7 +230,7 @@ impl Driver {
     /// charged as iowait (see the `no_iowait` field). SQEs must already be
     /// flushed: this issues a wait-only `enter` with `to_submit = 0`, one extra
     /// syscall paid only on the path where the ring is about to sleep anyway.
-    fn wait_no_iowait(&self, want_sqe: usize, timeout: Option<Duration>) -> io::Result<usize> {
+    fn submit_no_iowait(&self, want_sqe: usize, timeout: Option<Duration>) -> io::Result<usize> {
         let submitter = self.inner.submitter();
         if let Some(duration) = timeout {
             let timespec = timespec(duration);

--- a/compio-driver/src/sys/driver/iour/mod.rs
+++ b/compio-driver/src/sys/driver/iour/mod.rs
@@ -47,8 +47,8 @@ bitflags::bitflags! {
         /// re-pushed before the next wait.
         const NEED_PUSH_NOTIFIER = 1 << 0;
         /// Set `IORING_ENTER_NO_IOWAIT` on blocking waits so an idle ring is not
-        /// charged as iowait. Cleared when SQPOLL is in use, and cleared
-        /// permanently after the first `EINVAL` on kernels older than 6.15.
+        /// charged as iowait. Enabled only when SQPOLL is unused and the kernel
+        /// reports `IORING_FEAT_NO_IOWAIT` (since 6.15).
         ///
         /// See io_uring_enter(2):
         /// <https://man7.org/linux/man-pages/man2/io_uring_enter.2.html>
@@ -124,10 +124,14 @@ impl Driver {
 
         let (completed_tx, completed_rx) = flume::unbounded();
 
-        // NO_IOWAIT is meaningless under SQPOLL: the polling thread, not an
-        // `enter` wait, drives submission, so there is no CQE wait to mark.
+        // NO_IOWAIT needs kernel 6.15+ (the IORING_FEAT_NO_IOWAIT feature bit)
+        // and is meaningless under SQPOLL: the polling thread, not an `enter`
+        // wait, drives submission, so there is no CQE wait to mark.
         let mut flags = DriverFlags::NEED_PUSH_NOTIFIER;
-        flags.set(DriverFlags::NO_IOWAIT, builder.sqpoll_idle.is_none());
+        flags.set(
+            DriverFlags::NO_IOWAIT,
+            builder.sqpoll_idle.is_none() && inner.params().is_feature_no_iowait(),
+        );
 
         Ok(Self {
             inner: ManuallyDrop::new(inner),
@@ -194,22 +198,13 @@ impl Driver {
         // so it keeps the combined path and pays no extra syscall.
         //
         // On the sleeping path, opt out of iowait accounting (see
-        // `DriverFlags::NO_IOWAIT`):
-        // flush first so a submit error is mapped below like any other; only the
-        // wait-only enter returning EINVAL means the kernel lacks the flag, so
-        // only that disables it permanently.
+        // `DriverFlags::NO_IOWAIT`): flush the SQ with `submit()` first, then
+        // issue a wait-only `enter` carrying NO_IOWAIT.
         let can_block = want_sqe > 0 && timeout != Some(Duration::ZERO);
         let res = if self.flags.contains(DriverFlags::NO_IOWAIT) && can_block {
-            match self.inner.submit() {
-                Ok(_) => match self.submit_no_iowait(want_sqe, timeout) {
-                    Err(e) if e.raw_os_error() == Some(libc::EINVAL) => {
-                        self.flags.remove(DriverFlags::NO_IOWAIT);
-                        self.submit_and_wait(want_sqe, timeout)
-                    }
-                    other => other,
-                },
-                Err(e) => Err(e),
-            }
+            self.inner
+                .submit()
+                .and_then(|_| self.submit_no_iowait(want_sqe, timeout))
         } else {
             self.submit_and_wait(want_sqe, timeout)
         };
@@ -230,7 +225,8 @@ impl Driver {
         }
     }
 
-    /// The original submit+wait, used when `NO_IOWAIT` is unavailable.
+    /// The combined submit+wait. Used for zero-timeout drains and when
+    /// `NO_IOWAIT` is unavailable.
     fn submit_and_wait(&self, want_sqe: usize, timeout: Option<Duration>) -> io::Result<usize> {
         if let Some(duration) = timeout {
             let timespec = timespec(duration);


### PR DESCRIPTION
The proactor keeps a multishot PollAdd armed on the internal notifier
eventfd, so the ring always has a request in flight. On Linux >= 6.5
io_uring_enter runs its CQE wait under io_schedule(), and since 6.6
that wait is marked in_iowait whenever a request is pending. The
always-armed notifier poll satisfies that condition, so an idle ring
parked on the CQE wait is accounted as iowait with no I/O outstanding.
This inflates per-task iowait and drives /proc/pressure/io toward 100%
on an idle runtime, making PSI and iowait useless as health signals
(reported downstream as apache/iggy#3507).

Linux 6.15 added IORING_ENTER_NO_IOWAIT, an opt-out that suppresses the
marking for that wait. It is off by default. Set it on the blocking
wait by splitting the combined submit-and-wait into a submit() followed
by a wait-only enter() carrying GETEVENTS | NO_IOWAIT (plus EXT_ARG when
a timeout is given). A DriverFlags::NO_IOWAIT flag gates this: it is
enabled only when SQPOLL is unused and the kernel reports
IORING_FEAT_NO_IOWAIT (6.15+), so older kernels keep the combined wait.
The non-blocking path (want == 0) is unchanged.

io-uring 0.7.13 adds Parameters::is_feature_no_iowait(), so support is
read from the feature bit at ring init rather than probed (accessor
contributed in tokio-rs/io-uring#399).
