### PR TITLE
feat(executor): implement is_finished for JoinHandle

### DIFF
--- a/compio-executor/src/join_handle.rs
+++ b/compio-executor/src/join_handle.rs
@@ -53,6 +53,15 @@ impl<T> JoinHandle<T> {
     pub fn detach(self) {
         unsafe { ptr::drop_in_place(&raw mut ManuallyDrop::new(self).task) };
     }
+
+    /// Returns true if this JoinHandle has been finalized, either because
+    /// it's been completed or canceled.
+    pub fn is_finished(&self) -> bool {
+        match &self.task {
+            Some(task) => task.is_finished(),
+            None => true,
+        }
+    }
 }
 
 /// Task failed to execute to completion.

--- a/compio-executor/src/task/mod.rs
+++ b/compio-executor/src/task/mod.rs
@@ -333,6 +333,13 @@ impl Task {
         trace!("Completed");
     }
 
+    /// Returns true if this Task has been finalized, either because it's been
+    /// completed or canceled.
+    pub(crate) fn is_finished(&self) -> bool {
+        let state = self.header().state.load::<Strong>();
+        state.is_completed() || state.is_cancelled()
+    }
+
     /// Wait for wakers to finish scheduling, if any. This is necessary for
     /// `Executor` to drop `Shared` since scheduling requires it.
     pub(crate) fn wait_for_scheduling(&self) {


### PR DESCRIPTION
Like it says on the tin, this PR extends JoinHandle with `is_finished` to allow consumers to check the granular state of a JoinHandle.