### PR TITLE
fix(net): avoid potential hang in runtime thread on blocking socket operations

### DIFF
--- a/compio-net/src/tcp.rs
+++ b/compio-net/src/tcp.rs
@@ -20,7 +20,7 @@ use compio_io::{
     },
     util::Splittable,
 };
-use compio_runtime::fd::PollFd;
+use compio_runtime::{Runtime, fd::PollFd};
 use futures_util::{Stream, StreamExt, stream::FusedStream};
 use socket2::{Protocol, SockAddr, Socket as Socket2, Type};
 
@@ -92,6 +92,10 @@ impl TcpListener {
 
     /// Creates new TcpListener from a [`std::net::TcpListener`].
     pub fn from_std(stream: std::net::TcpListener) -> io::Result<Self> {
+        if Runtime::with_current(|r| r.driver_type().is_polling()) {
+            stream.set_nonblocking(true)?;
+        }
+
         Ok(Self {
             inner: Socket::from_socket2(Socket2::from(stream))?,
         })
@@ -271,6 +275,10 @@ impl TcpStream {
 
     /// Creates new TcpStream from a [`std::net::TcpStream`].
     pub fn from_std(stream: std::net::TcpStream) -> io::Result<Self> {
+        if Runtime::with_current(|r| r.driver_type().is_polling()) {
+            stream.set_nonblocking(true)?;
+        }
+
         Ok(Self {
             inner: Socket::from_socket2(Socket2::from(stream))?,
         })
@@ -1079,6 +1087,10 @@ impl TcpSocket {
     /// function is typically used together with crates such as [`socket2`] to
     /// configure socket options that are not available on [`TcpSocket`].
     pub fn from_std_stream(stream: std::net::TcpStream) -> io::Result<TcpSocket> {
+        if Runtime::with_current(|r| r.driver_type().is_polling()) {
+            stream.set_nonblocking(true)?;
+        }
+
         Ok(Self {
             inner: Socket::from_socket2(Socket2::from(stream))?,
         })

--- a/compio-net/src/udp.rs
+++ b/compio-net/src/udp.rs
@@ -10,6 +10,7 @@ use compio_driver::{
     op::{RecvFlags, RecvFromMultiResult, RecvMsgMultiResult},
 };
 use compio_io::ancillary::ReturnFlags;
+use compio_runtime::Runtime;
 use futures_util::Stream;
 use socket2::{Protocol, SockAddr, Socket as Socket2, Type};
 
@@ -127,6 +128,10 @@ impl UdpSocket {
 
     /// Creates new UdpSocket from a std::net::UdpSocket.
     pub fn from_std(socket: std::net::UdpSocket) -> io::Result<Self> {
+        if Runtime::with_current(|r| r.driver_type().is_polling()) {
+            socket.set_nonblocking(true)?;
+        }
+
         Ok(Self {
             inner: Socket::from_socket2(Socket2::from(socket))?,
         })

--- a/compio-net/src/unix.rs
+++ b/compio-net/src/unix.rs
@@ -19,6 +19,8 @@ use compio_io::{
     },
     util::Splittable,
 };
+#[cfg(unix)]
+use compio_runtime::Runtime;
 use compio_runtime::fd::PollFd;
 use futures_util::{Stream, StreamExt, stream::FusedStream};
 use socket2::{Domain, SockAddr, Socket as Socket2, Type};
@@ -87,6 +89,10 @@ impl UnixListener {
     #[cfg(unix)]
     /// Creates new UnixListener from a [`std::os::unix::net::UnixListener`].
     pub fn from_std(stream: std::os::unix::net::UnixListener) -> io::Result<Self> {
+        if Runtime::with_current(|r| r.driver_type().is_polling()) {
+            stream.set_nonblocking(true)?;
+        }
+
         Ok(Self {
             inner: Socket::from_socket2(Socket2::from(stream))?,
         })
@@ -225,6 +231,10 @@ impl UnixStream {
     /// Creates new UnixStream from a [`std::os::unix::net::UnixStream`].
     #[cfg(unix)]
     pub fn from_std(stream: std::os::unix::net::UnixStream) -> io::Result<Self> {
+        if Runtime::with_current(|r| r.driver_type().is_polling()) {
+            stream.set_nonblocking(true)?;
+        }
+
         Ok(Self {
             inner: Socket::from_socket2(Socket2::from(stream))?,
         })

--- a/compio-net/tests/runtime_wake.rs
+++ b/compio-net/tests/runtime_wake.rs
@@ -1,0 +1,47 @@
+use std::io::Write;
+
+use compio_io::AsyncRead;
+use compio_net::TcpStream;
+
+/// This is a regression test for a `compio_runtime::spawn_blocking` hang that
+/// was observed in compio v0.19.1, compio-net v0.12.1 when a polling driver
+/// ("compio-driver/polling") was in use.
+#[compio_macros::test]
+async fn runtime_tcp_stream_blocking_read() {
+    // 1. Construct a client/server pair of `compio_net::TcpStream`s, the server
+    //    stream via `::from_std`.
+    //
+    // NB. Don't explicitly set it non-blocking.
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+    let addr = listener.local_addr().unwrap();
+    let connector = std::thread::spawn(move || std::net::TcpStream::connect(addr).unwrap());
+    let mut client = connector.join().unwrap();
+    let (server, _) = listener.accept().unwrap();
+    let mut stream = TcpStream::from_std(server).unwrap();
+
+    // 2. Write a message into the client pipe.
+    client.write_all(b"PIPELINED-FIRST-FRAME").unwrap();
+    client.flush().unwrap();
+
+    // 3. Read the whole message out of the server's stream.
+    let bytes_read = stream.read(Vec::with_capacity(64)).await.0.unwrap();
+    assert_eq!(bytes_read, 21);
+
+    // 4. Spawn a runtime thread to attempt a second read from the (now empty)
+    //    server stream.
+    let reader =
+        compio_runtime::spawn(async move { stream.read(Vec::with_capacity(64)).await.0.unwrap() });
+
+    // 5. Spawn a second, noop runtime thread -- it just sleeps and yields.
+    //
+    // This is where the hang occurs when it presents. The above `stream.read`
+    // blocks on the empty stream, blocking the whole runtime thread.
+    compio_runtime::spawn_blocking(|| {
+        std::thread::sleep(std::time::Duration::from_millis(100));
+    })
+    .await
+    .unwrap();
+
+    drop(reader);
+    drop(client);
+}


### PR DESCRIPTION
This PR adds a regression test to demonstrate a runtime-thread hang, and proposes a solution to the problem. The fix is only one line, but the ramifications should be considered before accepting this change.

The hang can be observed when,
1. Compio is using the polling driver,
2. A socket (that has not been configured with `set_nonblocking(true)`) is moved into compio via e.g. `TcpListener::from_std`,
3. A `compio_runtime::spawn(..)` task invokes a potentially-blocking (e.g. `TcpStream::read`) method on the runtime thread,
4. A second `compio_runtime::spawn[_blocking](..)` task is enqueued while the potentially blocking method is blocking.

I'm not entirely confident in the fix, as (among other reasons) it could be argued that the core issue in the above steps is that the socket was moved into compio without first being configured to be non-blocking. I'm not sure that argument holds water, but there may be technical reasons for it to be the case that I'm not familiar with.

I think it's important to note that the hang is a change in behavior between compio-net v0.11.0 and v0.12.1. The [runtime_hang/backported_repro](https://github.com/ludumipsum/compio/tree/runtime_hang/backported_repro) branch backports the [runtime_wake.rs](https://github.com/ludumipsum/compio/blob/runtime_hang/backported_repro/compio-net/tests/runtime_wake.rs) test onto v0.11.0 and this hang does not occur on that branch as it does on the [runtime_hang/repro](https://github.com/ludumipsum/compio/tree/runtime_hang/repro) branch (which includes the unit test but not the fix based on v0.12.1).