### PR TITLE
feat(runtime): improve cancellation for multishot streams

### DIFF
--- a/compio-net/Cargo.toml
+++ b/compio-net/Cargo.toml
@@ -47,6 +47,7 @@ libc = { workspace = true }
 # Shared dev dependencies for all platforms
 [dev-dependencies]
 compio-macros = { workspace = true }
+compio-runtime = { workspace = true, features = ["time"] }
 tempfile = { workspace = true }
 
 [features]

--- a/compio-net/tests/incoming.rs
+++ b/compio-net/tests/incoming.rs
@@ -1,6 +1,9 @@
-use compio_io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
+use std::time::Duration;
+
+use compio_buf::BufResult;
+use compio_io::{AsyncRead, AsyncReadExt, AsyncReadMulti as _, AsyncWrite, AsyncWriteExt};
 use compio_net::{TcpListener, TcpStream, UnixListener, UnixStream};
-use compio_runtime::ResumeUnwind;
+use compio_runtime::{CancelToken, ResumeUnwind, StreamExt as _, time::timeout};
 use futures_util::StreamExt;
 
 #[compio_macros::test]
@@ -68,4 +71,38 @@ async fn incoming_unix() {
     }
 
     task.await.resume_unwind();
+}
+
+#[compio_macros::test]
+async fn incoming_tcp_multi_cancel() {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+
+    let addr = listener.local_addr().unwrap();
+
+    compio_runtime::spawn(async move {
+        let mut tx = TcpStream::connect(addr).await.unwrap();
+
+        let mut v = vec![0xAA, 128];
+        loop {
+            let BufResult(res, buf) = tx.write(v).await;
+            res.unwrap();
+            v = buf;
+        }
+    })
+    .detach();
+
+    let (mut rx, _) = listener.accept().await.unwrap();
+
+    let ct = CancelToken::new();
+    let mut s = rx.read_multi(0).with_cancel(ct.clone());
+
+    assert!(s.next().await.is_some_and(|r| r.is_ok()));
+
+    ct.cancel();
+
+    timeout(Duration::from_millis(200), async move {
+        while let Some(Ok(_)) = s.next().await {}
+    })
+    .await
+    .unwrap();
 }

--- a/compio-runtime/src/future/combinator/cancel.rs
+++ b/compio-runtime/src/future/combinator/cancel.rs
@@ -3,7 +3,7 @@ use std::{
     task::{Context, Poll},
 };
 
-use futures_util::FutureExt;
+use futures_util::{FutureExt, Stream, StreamExt};
 use pin_project_lite::pin_project;
 use synchrony::unsync::event::EventListener;
 
@@ -123,5 +123,38 @@ where
         }
 
         this.future.poll_unpin(cx).map(Ok)
+    }
+}
+
+impl<F: ?Sized> Stream for WithCancel<F>
+where
+    F: Stream,
+{
+    type Item = F::Item;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let this = self.project();
+
+        with_ext(cx.waker(), |waker, ext: &Ext| {
+            let ext = ext.with_cancel(this.cancel);
+            ExtWaker::new(waker, &ext).poll_next(this.future)
+        })
+    }
+}
+
+impl<F: ?Sized> Stream for WithCancelFailFast<F>
+where
+    F: Stream,
+{
+    type Item = Result<F::Item, Cancelled>;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let mut this = self.project();
+
+        if this.listen.poll_unpin(cx).is_ready() {
+            return Poll::Ready(Some(Err(Cancelled)));
+        }
+
+        this.future.poll_next_unpin(cx).map(|item| item.map(Ok))
     }
 }

--- a/compio-runtime/src/future/combinator/mod.rs
+++ b/compio-runtime/src/future/combinator/mod.rs
@@ -7,6 +7,7 @@ use std::borrow::Cow;
 
 pub use cancel::*;
 use compio_driver::Extra;
+use futures_util::Stream;
 pub use personality::*;
 
 use crate::CancelToken;
@@ -109,3 +110,57 @@ pub trait FutureExt {
 }
 
 impl<F: Future + ?Sized> FutureExt for F {}
+
+/// Extension trait for streams.
+///
+/// # Implementation
+///
+/// Extra data are passed down to runtime when the combinators are polled using
+/// a custom [`Waker`], and those data are single-threaded. This means
+/// - when [`Waker`]s are sent to other threads, the data will be lost.
+/// - when using a "sub-executor" like `FuturesUnordered`, which also creates
+///   its own waker, the data will be lost.
+///
+/// So try to keep the path from the wrapped stream to runtime clean, something
+/// like this will generally work:
+///
+/// ```rust,ignore
+/// use std::vec::Vec;
+///
+/// use compio::runtime::{StreamExt, CancelToken};
+/// use compio::net::TcpStream;
+///
+/// let input = TcpStream::connect("127.0.0.1:8000").await.unwrap();
+/// let cancel = CancelToken::new();
+/// let mut input_stream = input.read_multi(0).with_cancel(cancel.clone());
+/// while let Some(buf) = input_stream.next().await {
+///     let _ = buf.unwrap();
+/// }
+/// ```
+///
+/// [`Waker`]: std::task::Waker
+pub trait StreamExt {
+    /// Sets the personality for this stream.
+    ///
+    /// This only takes effect on io-uring drivers and will be ignored on other
+    /// ones.
+    fn with_personality(self, personality: u16) -> WithPersonality<Self>
+    where
+        Self: Sized,
+    {
+        WithPersonality::new(self, personality)
+    }
+
+    /// Sets the cancel token for this stream.
+    ///
+    /// If multiple [`CancelToken`]s are set, the innermost one (the one being
+    /// polled last) will take precedence.
+    fn with_cancel(self, token: CancelToken) -> WithCancel<Self>
+    where
+        Self: Sized,
+    {
+        WithCancel::new(self, token)
+    }
+}
+
+impl<F: Stream + ?Sized> StreamExt for F {}

--- a/compio-runtime/src/future/combinator/personality.rs
+++ b/compio-runtime/src/future/combinator/personality.rs
@@ -3,6 +3,7 @@ use std::{
     task::{Context, Poll},
 };
 
+use futures_util::Stream;
 use pin_project_lite::pin_project;
 
 use crate::{
@@ -38,6 +39,19 @@ impl<F: Future + ?Sized> Future for WithPersonality<F> {
         with_ext(cx.waker(), |waker, ext: &Ext| {
             let ext = ext.with_personality(*this.personality);
             ExtWaker::new(waker, &ext).poll(this.future)
+        })
+    }
+}
+
+impl<F: Stream + ?Sized> Stream for WithPersonality<F> {
+    type Item = F::Item;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let this = self.project();
+
+        with_ext(cx.waker(), |waker, ext: &Ext| {
+            let ext = ext.with_personality(*this.personality);
+            ExtWaker::new(waker, &ext).poll_next(this.future)
         })
     }
 }

--- a/compio-runtime/src/future/stream.rs
+++ b/compio-runtime/src/future/stream.rs
@@ -14,7 +14,7 @@ use compio_driver::{
 use futures_util::{Stream, StreamExt, stream::FusedStream};
 
 use crate::{
-    ContextExt,
+    CancelToken, ContextExt,
     future::{poll_multishot, poll_task_with_extra, submit_raw},
 };
 
@@ -363,6 +363,9 @@ impl<
                     Some(Err(e)) => break Poll::Ready(Some(Err(e))),
                     None => self.op = None,
                 },
+                None if cx.get_cancel().is_some_and(CancelToken::is_cancelled) => {
+                    break Poll::Ready(None);
+                }
                 None => match (self.create_op)() {
                     Ok(op) => self.op = Some(op),
                     Err(e) => break Poll::Ready(Some(Err(e))),

--- a/compio-runtime/src/waker/ext.rs
+++ b/compio-runtime/src/waker/ext.rs
@@ -8,6 +8,7 @@ use std::{
 };
 
 use compio_send_wrapper::SendWrapper;
+use futures_util::Stream;
 
 use crate::Ext;
 
@@ -77,6 +78,10 @@ impl<'a, 'b> ExtWaker<'a, 'b> {
 
     pub fn poll<F: Future + ?Sized>(&self, fut: Pin<&mut F>) -> Poll<F::Output> {
         self.with(|waker| fut.poll(&mut Context::from_waker(waker)))
+    }
+
+    pub fn poll_next<F: Stream + ?Sized>(&self, fut: Pin<&mut F>) -> Poll<Option<F::Item>> {
+        self.with(|waker| fut.poll_next(&mut Context::from_waker(waker)))
     }
 
     fn with<F, R>(&self, f: F) -> R


### PR DESCRIPTION
- Extend future combinators (`WithCancel` and `WithPersonality`) to also wrap streams
- Ensure `SubmitMultiStream` respects cancellation (gates `create_op` behind `cx.get_cancel().is_some_and(CancelToken::is_cancelled)`)