### PR TITLE
docs: make third-party docs no-inline

### DIFF
--- a/compio-buf/src/lib.rs
+++ b/compio-buf/src/lib.rs
@@ -19,14 +19,19 @@
 )]
 
 #[cfg(feature = "arrayvec")]
+#[doc(no_inline)]
 pub use arrayvec;
 #[cfg(feature = "bumpalo")]
+#[doc(no_inline)]
 pub use bumpalo;
 #[cfg(feature = "bytes")]
+#[doc(no_inline)]
 pub use bytes;
 #[cfg(feature = "memmap2")]
+#[doc(no_inline)]
 pub use memmap2;
 #[cfg(feature = "smallvec")]
+#[doc(no_inline)]
 pub use smallvec;
 
 mod io;

--- a/compio-tls/src/lib.rs
+++ b/compio-tls/src/lib.rs
@@ -13,10 +13,13 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
 #[cfg(feature = "py-dynamic-openssl")]
+#[doc(no_inline)]
 pub use compio_py_dynamic_openssl as py_dynamic_openssl;
 #[cfg(feature = "native-tls")]
+#[doc(no_inline)]
 pub use native_tls;
 #[cfg(feature = "rustls")]
+#[doc(no_inline)]
 pub use rustls;
 
 mod adapter;

--- a/compio/src/lib.rs
+++ b/compio/src/lib.rs
@@ -31,14 +31,19 @@
 )]
 
 #[doc(no_inline)]
+#[doc(no_inline)]
 pub use buf::BufResult;
 #[cfg(feature = "arrayvec")]
+#[doc(no_inline)]
 pub use buf::arrayvec;
 #[cfg(feature = "bumpalo")]
+#[doc(no_inline)]
 pub use buf::bumpalo;
 #[cfg(feature = "bytes")]
+#[doc(no_inline)]
 pub use buf::bytes;
 #[cfg(feature = "smallvec")]
+#[doc(no_inline)]
 pub use buf::smallvec;
 #[cfg(feature = "compat")]
 pub use compio_compat as compat;
@@ -78,8 +83,10 @@ pub use compio_ws as ws;
 #[doc(inline)]
 pub use runtime::time;
 #[cfg(feature = "native-tls")]
+#[doc(no_inline)]
 pub use tls::native_tls;
 #[cfg(feature = "rustls")]
+#[doc(no_inline)]
 pub use tls::rustls;
 #[doc(inline)]
 pub use {compio_buf as buf, compio_driver as driver};


### PR DESCRIPTION
`bumpalo` and `smallvec` re-exports `alloc`, making `cargo doc` reports ICE. So I made every third party deps `doc(no_inline)` and now `cargo` should be happy.

Related: https://github.com/rust-lang/rust/issues/158769