### PR TITLE
docs(contributing): mention flake.nix for development dependencies

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,6 +23,7 @@ We adhere to [Rust Code of Conduct](https://www.rust-lang.org/policies/code-of-c
 ### Develop Guide
 
 - Use nightly toolchain to develop and run `rustup update` regularly. Compio does use nightly features, behind feature gate; so, when testing with `--all-features` flag, only nightly toolchain would work.
+- Building with `--all-features` may require system-level dependencies beyond the Rust toolchain. All dependencies are defined in the `devShell` specified in the repository's `flake.nix`, allowing you to set up the environment using `nix develop`.
 
 ### Style Guide
 


### PR DESCRIPTION
Running `cargo test --all-features` requires system-level dependencies; any missing dependencies will cause an error (in my environment, this failed due to missing lpython3.12, requiring me to install it first).
All these dependencies are defined in the `devShell` section of `flake.nix`, so Nix provides a solution here.
However, since CONTRIBUTING.md doesn't mention Nix at all, I'll add a note about it.
