### PR TITLE
fix(compio-fs): populate ctime correctly

### DIFF
--- a/compio-driver/build.rs
+++ b/compio-driver/build.rs
@@ -18,6 +18,12 @@ fn main() {
         gnulinux: { all(target_os = "linux", target_env = "gnu") },
         freebsd: { target_os = "freebsd" },
         solarish: { any(target_os = "illumos", target_os = "solaris") },
+        // Platforms whose `struct stat` carries the birth time in `st_birthtime`.
+        noctime: { any(
+            target_os = "freebsd",
+            target_os = "openbsd",
+            target_vendor = "apple"
+        ) },
 
         // Driver
         polling: { all(unix, any(not(target_os = "linux"), feature = "polling")) },

--- a/compio-driver/build.rs
+++ b/compio-driver/build.rs
@@ -19,7 +19,7 @@ fn main() {
         freebsd: { target_os = "freebsd" },
         solarish: { any(target_os = "illumos", target_os = "solaris") },
         // Platforms whose `struct stat` carries the birth time in `st_birthtime`.
-        noctime: { any(
+        st_birthtime: { any(
             target_os = "freebsd",
             target_os = "openbsd",
             target_vendor = "apple"

--- a/compio-driver/src/sys/op/fs/iour.rs
+++ b/compio-driver/src/sys/op/fs/iour.rs
@@ -95,10 +95,10 @@ unsafe impl<S: AsFd> OpCode for FileStat<S> {
 }
 
 impl<S> IntoInner for FileStat<S> {
-    type Inner = Stat;
+    type Inner = FileAttr;
 
     fn into_inner(self) -> Self::Inner {
-        statx_to_stat(self.stat)
+        statx_to_attr(self.stat)
     }
 }
 
@@ -149,10 +149,10 @@ unsafe impl<S: AsFd> OpCode for PathStat<S> {
 }
 
 impl<S: AsFd> IntoInner for PathStat<S> {
-    type Inner = Stat;
+    type Inner = FileAttr;
 
     fn into_inner(self) -> Self::Inner {
-        statx_to_stat(self.stat)
+        statx_to_attr(self.stat)
     }
 }
 

--- a/compio-driver/src/sys/op/fs/poll.rs
+++ b/compio-driver/src/sys/op/fs/poll.rs
@@ -5,14 +5,14 @@ use crate::{Decision, PollOpCode as OpCode, sys::op::*};
 /// Get metadata of an opened file.
 pub struct FileStat<S> {
     pub(crate) fd: S,
-    pub(crate) stat: Stat,
+    pub(crate) stat: FileAttr,
 }
 
 /// Get metadata from path.
 pub struct PathStat<S: AsFd> {
     pub(crate) dirfd: S,
     pub(crate) path: CString,
-    pub(crate) stat: Stat,
+    pub(crate) stat: FileAttr,
     pub(crate) follow_symlink: bool,
 }
 
@@ -153,7 +153,7 @@ impl<S> FileStat<S> {
 }
 
 impl<S> IntoInner for FileStat<S> {
-    type Inner = Stat;
+    type Inner = FileAttr;
 
     fn into_inner(self) -> Self::Inner {
         self.stat
@@ -187,7 +187,7 @@ impl<S: AsFd> PathStat<S> {
 }
 
 impl<S: AsFd> IntoInner for PathStat<S> {
-    type Inner = Stat;
+    type Inner = FileAttr;
 
     fn into_inner(self) -> Self::Inner {
         self.stat

--- a/compio-driver/src/sys/op/fs/stub.rs
+++ b/compio-driver/src/sys/op/fs/stub.rs
@@ -60,7 +60,7 @@ impl<S: AsFd> OpCode for FileStat<S> {
 }
 
 impl<S> IntoInner for FileStat<S> {
-    type Inner = Stat;
+    type Inner = FileAttr;
 
     fn into_inner(self) -> Self::Inner {
         stub_unimpl()
@@ -90,7 +90,7 @@ impl<S: AsFd> OpCode for PathStat<S> {
 }
 
 impl<S: AsFd> IntoInner for PathStat<S> {
-    type Inner = Stat;
+    type Inner = FileAttr;
 
     fn into_inner(self) -> Self::Inner {
         stub_unimpl()

--- a/compio-driver/src/sys/op/mod.rs
+++ b/compio-driver/src/sys/op/mod.rs
@@ -14,7 +14,7 @@ cfg_select! {
     unix => {
         mod_use![unix];
 
-        pub use crate::sys::pal::{CurrentDir, Interest};
+        pub use crate::sys::pal::{CurrentDir, FileAttr, Interest};
         pub use rustix::fs::{Mode, OFlags, Stat};
     }
     _ => {}

--- a/compio-driver/src/sys/pal/unix/stat/linux.rs
+++ b/compio-driver/src/sys/pal/unix/stat/linux.rs
@@ -17,8 +17,27 @@ pub fn statx<Fd: AsFd>(dirfd: Fd, path: &CStr, follow_symlink: bool) -> io::Resu
 }
 
 #[allow(dead_code)]
-pub fn stat<Fd: AsFd>(dirfd: Fd, path: &CStr, follow_symlink: bool) -> io::Result<Stat> {
-    statx(dirfd, path, follow_symlink).map(statx_to_stat)
+pub fn stat<Fd: AsFd>(dirfd: Fd, path: &CStr, follow_symlink: bool) -> io::Result<FileAttr> {
+    statx(dirfd, path, follow_symlink).map(statx_to_attr)
+}
+
+/// Convert a [`Statx`] into a [`FileAttr`], carrying the birth time separately
+/// from the [`Stat`] (which on Linux has no birth-time field).
+pub fn statx_to_attr(statx: Statx) -> FileAttr {
+    FileAttr {
+        stat: statx_to_stat(statx),
+        created: statx_created(&statx),
+    }
+}
+
+/// Extract the birth (creation) time from a [`Statx`], if the kernel/filesystem
+/// reported it.
+fn statx_created(statx: &Statx) -> Option<(i64, i64)> {
+    if statx.stx_mask & StatxFlags::BTIME.bits() != 0 {
+        Some((statx.stx_btime.tv_sec as _, statx.stx_btime.tv_nsec as _))
+    } else {
+        None
+    }
 }
 
 pub const fn statx_to_stat(statx: Statx) -> Stat {
@@ -37,7 +56,9 @@ pub const fn statx_to_stat(statx: Statx) -> Stat {
     stat.st_atime_nsec = statx.stx_atime.tv_nsec as _;
     stat.st_mtime = statx.stx_mtime.tv_sec as _;
     stat.st_mtime_nsec = statx.stx_mtime.tv_nsec as _;
-    stat.st_ctime = statx.stx_btime.tv_sec as _;
-    stat.st_ctime_nsec = statx.stx_btime.tv_nsec as _;
+    // `st_ctime` is the inode change time, not the birth time. The birth time
+    // is carried separately in `FileAttr::created`.
+    stat.st_ctime = statx.stx_ctime.tv_sec as _;
+    stat.st_ctime_nsec = statx.stx_ctime.tv_nsec as _;
     stat
 }

--- a/compio-driver/src/sys/pal/unix/stat/mod.rs
+++ b/compio-driver/src/sys/pal/unix/stat/mod.rs
@@ -26,12 +26,12 @@ impl FileAttr {
     }
 }
 
-#[cfg(noctime)]
+#[cfg(st_birthtime)]
 fn stat_created(stat: &Stat) -> Option<(i64, i64)> {
     Some((stat.st_birthtime as _, stat.st_birthtime_nsec as _))
 }
 
-#[cfg(not(noctime))]
+#[cfg(not(st_birthtime))]
 fn stat_created(_stat: &Stat) -> Option<(i64, i64)> {
     // On Linux `struct stat` has no birth time; it is obtained from `statx`.
     None

--- a/compio-driver/src/sys/pal/unix/stat/mod.rs
+++ b/compio-driver/src/sys/pal/unix/stat/mod.rs
@@ -1,23 +1,61 @@
 use super::*;
 
+/// File metadata returned by the stat operations.
+///
+/// It bundles the raw platform [`Stat`] together with the file creation (birth)
+/// time. On Linux the birth time is not part of `struct stat`; it comes from
+/// `statx` instead, so it has to be carried separately. On the BSDs and Apple
+/// platforms it is extracted from the `st_birthtime` field of [`Stat`].
+#[derive(Clone, Copy)]
+pub struct FileAttr {
+    /// The raw `stat` result.
+    pub stat: Stat,
+    /// Creation (birth) time as `(seconds, nanoseconds)` since the Unix epoch,
+    /// or [`None`] when the platform/filesystem does not report it.
+    pub created: Option<(i64, i64)>,
+}
+
+impl FileAttr {
+    /// Build from a plain [`Stat`], extracting the birth time from the
+    /// `st_birthtime` field when the platform stores it there.
+    pub fn from_stat(stat: Stat) -> Self {
+        Self {
+            created: stat_created(&stat),
+            stat,
+        }
+    }
+}
+
+#[cfg(noctime)]
+fn stat_created(stat: &Stat) -> Option<(i64, i64)> {
+    Some((stat.st_birthtime as _, stat.st_birthtime_nsec as _))
+}
+
+#[cfg(not(noctime))]
+fn stat_created(_stat: &Stat) -> Option<(i64, i64)> {
+    // On Linux `struct stat` has no birth time; it is obtained from `statx`.
+    None
+}
+
 cfg_select! {
      linux_all => {
         mod_use![linux];
     }
     _ => {
-        pub fn stat<Fd: AsFd>(dirfd: Fd, path: &CStr, follow_symlink: bool) -> io::Result<Stat> {
+        pub fn stat<Fd: AsFd>(dirfd: Fd, path: &CStr, follow_symlink: bool) -> io::Result<FileAttr> {
             use rustix::fs::{fstat, statat};
 
-            if path.is_empty() {
-                Ok(fstat(dirfd)?)
+            let stat = if path.is_empty() {
+                fstat(dirfd)?
             } else {
                 let flags = if follow_symlink {
                     AtFlags::empty()
                 } else {
                     AtFlags::SYMLINK_NOFOLLOW
                 };
-                Ok(statat(dirfd, path, flags)?)
-            }
+                statat(dirfd, path, flags)?
+            };
+            Ok(FileAttr::from_stat(stat))
         }
     }
 }

--- a/compio-fs/src/file.rs
+++ b/compio-fs/src/file.rs
@@ -144,7 +144,7 @@ impl File {
     pub async fn metadata(&self) -> io::Result<Metadata> {
         let op = FileStat::new(self.to_shared_fd());
         let BufResult(res, op) = compio_runtime::submit(op).await;
-        res.map(|_| Metadata::from_stat(op.into_inner()))
+        res.map(|_| Metadata::from_attr(op.into_inner()))
     }
 
     /// Changes the permissions on the underlying file.

--- a/compio-fs/src/metadata/mod.rs
+++ b/compio-fs/src/metadata/mod.rs
@@ -9,7 +9,7 @@ mod sys;
 use std::{io, path::Path, time::SystemTime};
 
 #[cfg(unix)]
-use compio_driver::op::Stat;
+use compio_driver::op::{FileAttr, Stat};
 
 /// Given a path, query the file system to get information about a file,
 /// directory, etc.
@@ -96,12 +96,15 @@ impl Metadata {
         self.0.accessed()
     }
 
-    /// Returns the creation time listed in this metadata.
+    /// Returns the creation (birth) time listed in this metadata.
     ///
     /// ## Platform specific
     /// * Windows: The returned value corresponds to the `ftCreationTime` field.
-    /// * Unix: The returned value corresponds to `st_ctime` or `st_birthtime`
-    ///   of
+    /// * Linux: The returned value corresponds to the `stx_btime` field of
+    ///   `statx`. Returns an error if the filesystem does not report a birth
+    ///   time.
+    /// * Other Unix (BSD/Apple): The returned value corresponds to the
+    ///   `st_birthtime` field of
     #[cfg_attr(all(unix, not(gnulinux)), doc = "[`libc::stat`](struct@libc::stat).")]
     #[cfg_attr(gnulinux, doc = "[`libc::stat64`](struct@libc::stat64).")]
     #[cfg_attr(
@@ -171,6 +174,11 @@ impl Metadata {
     #[cfg_attr(gnulinux, doc = "[`libc::stat64`](struct@libc::stat64).")]
     pub fn from_stat(stat: Stat) -> Self {
         Self(sys::Metadata::from_stat(stat))
+    }
+
+    /// Create from [`FileAttr`].
+    pub(crate) fn from_attr(attr: FileAttr) -> Self {
+        Self(sys::Metadata::from_attr(attr))
     }
 }
 

--- a/compio-fs/src/metadata/unix.rs
+++ b/compio-fs/src/metadata/unix.rs
@@ -13,7 +13,7 @@ use std::{
 use compio_buf::{BufResult, IntoInner};
 #[cfg(dirfd)]
 use compio_driver::ToSharedFd;
-use compio_driver::op::{CurrentDir, PathStat, Stat};
+use compio_driver::op::{CurrentDir, FileAttr, PathStat, Stat};
 use compio_runtime::ResumeUnwind;
 use rustix::fs::FileType as FileTypeInner;
 
@@ -27,7 +27,7 @@ async fn metadata_impl(
     let path = path_string(path)?;
     let op = PathStat::new(dir, path, follow_symlink);
     let BufResult(res, op) = compio_runtime::submit(op).await;
-    res.map(|_| Metadata::from_stat(op.into_inner()))
+    res.map(|_| Metadata::from_attr(op.into_inner()))
 }
 
 pub async fn metadata(path: impl AsRef<Path>) -> io::Result<Metadata> {
@@ -60,16 +60,25 @@ pub async fn set_permissions(path: impl AsRef<Path>, perm: Permissions) -> io::R
 }
 
 #[derive(Clone)]
-pub struct Metadata(pub(crate) Stat);
+pub struct Metadata(pub(crate) FileAttr);
 
 impl Metadata {
     /// Create from [`Stat`].
+    ///
+    /// The birth (creation) time is only recovered from platforms that store it
+    /// in `struct stat` (BSD/Apple); on Linux it is unavailable through a plain
+    /// [`Stat`] and [`created`](Self::created) will return an error.
     pub fn from_stat(stat: Stat) -> Self {
-        Self(stat)
+        Self(FileAttr::from_stat(stat))
+    }
+
+    /// Create from [`FileAttr`].
+    pub(crate) fn from_attr(attr: FileAttr) -> Self {
+        Self(attr)
     }
 
     pub fn file_type(&self) -> FileType {
-        FileType(FileTypeInner::from_raw_mode(self.0.st_mode as _))
+        FileType(FileTypeInner::from_raw_mode(self.0.stat.st_mode as _))
     }
 
     pub fn is_dir(&self) -> bool {
@@ -86,104 +95,101 @@ impl Metadata {
 
     #[allow(clippy::len_without_is_empty)]
     pub fn len(&self) -> u64 {
-        self.0.st_size as _
+        self.0.stat.st_size as _
     }
 
     pub fn permissions(&self) -> Permissions {
-        Permissions::from_mode(self.0.st_mode as _)
+        Permissions::from_mode(self.0.stat.st_mode as _)
     }
 
     pub fn modified(&self) -> io::Result<SystemTime> {
         Ok(SystemTime::UNIX_EPOCH
-            + Duration::from_secs(self.0.st_mtime as _)
-            + Duration::from_nanos(self.0.st_mtime_nsec as _))
+            + Duration::from_secs(self.0.stat.st_mtime as _)
+            + Duration::from_nanos(self.0.stat.st_mtime_nsec as _))
     }
 
     pub fn accessed(&self) -> io::Result<SystemTime> {
         Ok(SystemTime::UNIX_EPOCH
-            + Duration::from_secs(self.0.st_atime as _)
-            + Duration::from_nanos(self.0.st_atime_nsec as _))
+            + Duration::from_secs(self.0.stat.st_atime as _)
+            + Duration::from_nanos(self.0.stat.st_atime_nsec as _))
     }
 
-    #[cfg(not(noctime))]
     pub fn created(&self) -> io::Result<SystemTime> {
-        // We've assigned btime field to ctime.
-        Ok(SystemTime::UNIX_EPOCH
-            + Duration::from_secs(self.0.st_ctime as _)
-            + Duration::from_nanos(self.0.st_ctime_nsec as _))
-    }
-
-    #[cfg(noctime)]
-    pub fn created(&self) -> io::Result<SystemTime> {
-        Ok(SystemTime::UNIX_EPOCH
-            + Duration::from_secs(self.0.st_birthtime as _)
-            + Duration::from_nanos(self.0.st_birthtime_nsec as _))
+        match self.0.created {
+            Some((secs, nsecs)) => Ok(SystemTime::UNIX_EPOCH
+                + Duration::from_secs(secs as _)
+                + Duration::from_nanos(nsecs as _)),
+            None => Err(io::Error::new(
+                io::ErrorKind::Unsupported,
+                "creation time is not available for the filesystem",
+            )),
+        }
     }
 }
 
 impl MetadataExt for Metadata {
     fn dev(&self) -> u64 {
-        self.0.st_dev as _
+        self.0.stat.st_dev as _
     }
 
     fn ino(&self) -> u64 {
-        self.0.st_ino as _
+        self.0.stat.st_ino as _
     }
 
     fn mode(&self) -> u32 {
-        self.0.st_mode as _
+        self.0.stat.st_mode as _
     }
 
     fn nlink(&self) -> u64 {
-        self.0.st_nlink as _
+        self.0.stat.st_nlink as _
     }
 
     fn uid(&self) -> u32 {
-        self.0.st_uid as _
+        self.0.stat.st_uid as _
     }
 
     fn gid(&self) -> u32 {
-        self.0.st_gid as _
+        self.0.stat.st_gid as _
     }
 
     fn rdev(&self) -> u64 {
-        self.0.st_rdev as _
+        self.0.stat.st_rdev as _
     }
 
     fn size(&self) -> u64 {
-        self.0.st_size as _
+        self.0.stat.st_size as _
     }
 
     fn atime(&self) -> i64 {
-        self.0.st_atime as _
+        self.0.stat.st_atime as _
     }
 
     fn atime_nsec(&self) -> i64 {
-        self.0.st_atime_nsec as _
+        self.0.stat.st_atime_nsec as _
     }
 
     fn mtime(&self) -> i64 {
-        self.0.st_mtime as _
+        self.0.stat.st_mtime as _
     }
 
     fn mtime_nsec(&self) -> i64 {
-        self.0.st_mtime_nsec as _
+        self.0.stat.st_mtime_nsec as _
     }
 
     fn ctime(&self) -> i64 {
-        self.0.st_ctime as _
+        self.0.stat.st_ctime as _
     }
 
     fn ctime_nsec(&self) -> i64 {
-        self.0.st_ctime_nsec as _
+        self.0.stat.st_ctime_nsec as _
     }
 
     fn blksize(&self) -> u64 {
-        self.0.st_blksize as _
+        self.0.stat.st_blksize as _
     }
 
     fn blocks(&self) -> u64 {
-        self.0.st_blocks as _
+        self.0.stat.st_blocks as _
     }
 }
 

--- a/compio-fs/tests/file.rs
+++ b/compio-fs/tests/file.rs
@@ -42,6 +42,20 @@ async fn metadata() {
 
     let std_meta = std::fs::metadata("Cargo.toml").unwrap();
     assert_eq!(size, std_meta.len());
+
+    // `created()` must report the birth time and `ctime()` the inode change
+    // time, matching std's semantics.
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::MetadataExt;
+
+        assert_eq!(std_meta.ctime(), MetadataExt::ctime(&meta));
+        assert_eq!(std_meta.ctime_nsec(), MetadataExt::ctime_nsec(&meta));
+
+        if let Ok(std_created) = std_meta.created() {
+            assert_eq!(std_created, meta.created().unwrap());
+        }
+    }
 }
 
 #[compio_macros::test]

--- a/compio-fs/tests/file.rs
+++ b/compio-fs/tests/file.rs
@@ -49,8 +49,8 @@ async fn metadata() {
     {
         use std::os::unix::fs::MetadataExt;
 
-        assert_eq!(std_meta.ctime(), MetadataExt::ctime(&meta));
-        assert_eq!(std_meta.ctime_nsec(), MetadataExt::ctime_nsec(&meta));
+        assert_eq!(std_meta.ctime(), meta.ctime());
+        assert_eq!(std_meta.ctime_nsec(), meta.ctime_nsec());
 
         if let Ok(std_created) = std_meta.created() {
             assert_eq!(std_created, meta.created().unwrap());


### PR DESCRIPTION
In Linux, `stx_ctime` means the last time the file inode is changed (Change Time), and is not the time the file is created, which will be `stx_btime`. compio has been populating a `rustix::fs::Stat::st_ctime` from linux's `stx_btime` is incorrect. The first commit of this PR contains a regression test for this.

I fixed this by creating our own `FileAttr` type, which is a rustix Stat plus a separate `created` field. On linux it is populated from the statx result, and on platforms where the `struct stat` already carries btime in `st_birthtime` it is sourced from the stat result. 