### PR TITLE
fix: semicolon_in_expressions_from_macros

### DIFF
--- a/compio-driver/build.rs
+++ b/compio-driver/build.rs
@@ -1,3 +1,5 @@
+#![allow(semicolon_in_expressions_from_macros)]
+
 use cfg_aliases::cfg_aliases;
 
 fn main() {

--- a/compio-fs/build.rs
+++ b/compio-fs/build.rs
@@ -1,3 +1,5 @@
+#![allow(semicolon_in_expressions_from_macros)]
+
 use cfg_aliases::cfg_aliases;
 
 fn main() {

--- a/compio-quic/build.rs
+++ b/compio-quic/build.rs
@@ -1,3 +1,5 @@
+#![allow(semicolon_in_expressions_from_macros)]
+
 use cfg_aliases::cfg_aliases;
 
 fn main() {

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1776169885,
-        "narHash": "sha256-l/iNYDZ4bGOAFQY2q8y5OAfBBtrDAaPuRQqWaFHVRXM=",
+        "lastModified": 1784007870,
+        "narHash": "sha256-djcLt/JJphyNt4eDY9XTly+/WbCK5lqWq9lSgCmJkkQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4bd9165a9165d7b5e33ae57f3eecbcb28fb231c9",
+        "rev": "18b9261cb3294b6d2a06d03f96872827b8fe2698",
         "type": "github"
       },
       "original": {
@@ -48,11 +48,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776395632,
-        "narHash": "sha256-Mi1uF5f2FsdBIvy+v7MtsqxD3Xjhd0ARJdwoqqqPtJo=",
+        "lastModified": 1784178955,
+        "narHash": "sha256-YtXHVFBzzqSidcEhPhfTcF2yzzu0p0yA7x07LOR+LaY=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "8087ff1f47fff983a1fba70fa88b759f2fd8ae97",
+        "rev": "1785b85aeccca381caf8777133410f577b8f2f59",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Since https://github.com/rust-lang/rust/pull/159222, `semicolon_in_expressions_from_macros` is no longer suppressed and has became a hard error. `cfg_aliases` generates code that hits the lint. There's an [upstream issue](https://github.com/katharostech/cfg_aliases/issues/16) on the matter but we don't know when that will be fixed. This PR suppress the error on our end for now.
