### PR TITLE
feat: instrument the runtime for tokio-console (overview)

### DIFF
--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -54,6 +54,13 @@ jobs:
             no_default_features: true
           - os: 'ubuntu-22.04'
             features: 'native-tls,ring,py-dynamic-openssl'
+            # `console` is deliberately not part of `all`, so it needs a setup of
+            # its own to be built and tested at all.
+          - os: 'ubuntu-22.04'
+            features: 'console'
+          - os: 'windows-latest'
+            target: 'x86_64-pc-windows-msvc'
+            features: 'console'
           - os: 'ubuntu-22.04'
             target: 'x86_64-unknown-linux-musl'
             features: 'native-tls-vendored,ring,sync,polling'

--- a/.github/workflows/ci_test_executor.yml
+++ b/.github/workflows/ci_test_executor.yml
@@ -61,6 +61,12 @@ jobs:
             -p compio-executor \
             --test executor
 
+          cargo miri test \
+            -p compio-executor \
+            --features console \
+            --test executor \
+            --test console
+
           RUSTFLAGS="--cfg loom" \
           LOOM_LOCATION=1 \
           LOOM_LOG=info,compio_executor=trace \

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,7 @@ bytes = "1.7.1"
 bytemuck = "1.25.0"
 cfg_aliases = "0.2.2"
 compio-send-wrapper = "0.7.1"
+console-subscriber = "0.5.0"
 criterion = "0.8.0"
 crossbeam-queue = "0.3.8"
 flume = { version = "0.12.0", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,6 +72,7 @@ slab = "0.4.9"
 socket2 = "0.6.0"
 tempfile = "3.8.1"
 tokio = "1.33.0"
+tracing = { version = "0.1.41", default-features = false, features = ["std"] }
 tracing-subscriber = "0.3.18"
 webpki-roots = "1.0.0"
 widestring = "1.0.2"

--- a/README.md
+++ b/README.md
@@ -43,6 +43,43 @@ async fn main() {
 
 It's also possible to use the low-level driver (the proactor, without async executor) manually. See [`driver` example](./compio/examples/driver.rs).
 
+## Observability
+
+The `console` feature makes the runtime emit the [`tracing`] spans and events that [`tokio-console`] consumes, so compio applications can be inspected with it:
+
+```bash
+cargo add compio --features console
+```
+
+```toml
+# .cargo/config.toml
+#
+# `console-subscriber` refuses to run unless the runtime is known to be
+# instrumented; this is the escape hatch it provides for runtimes other than
+# tokio.
+[build]
+rustflags = ["--cfg", "console_without_tokio_unstable"]
+```
+
+```rust
+compio::console_subscriber::init();
+compio::runtime::Runtime::new().unwrap().block_on(async {
+    // ...
+});
+```
+
+Then run `tokio-console` to watch tasks, poll times and waker activity. The [`console` module docs](https://docs.rs/compio-runtime/latest/compio_runtime/console/) describe what is reported and what is not.
+
+The [`console` example](./compio/examples/console.rs) runs an echo server on a dispatcher, so that the console shows the tasks of a thread-per-core application spread over its worker threads, next to tasks that are wrong in the ways it warns about. It passes the cfg on the command line instead:
+
+```bash
+RUSTFLAGS="--cfg console_without_tokio_unstable" \
+    cargo run --example console --features console,time,net,dispatcher,sync
+```
+
+[`tracing`]: https://docs.rs/tracing
+[`tokio-console`]: https://github.com/tokio-rs/console
+
 ## Why the name?
 
 The name comes from "completion-based IO", and follows the non-existent convention that an async runtime should be named with a suffix "io".

--- a/compio-dispatcher/Cargo.toml
+++ b/compio-dispatcher/Cargo.toml
@@ -30,6 +30,10 @@ compio-signal = { workspace = true }
 
 futures-util = { workspace = true }
 
+[features]
+# Instrumentation for `tokio-console`. See `compio_runtime::console`.
+console = ["compio-runtime/console"]
+
 [[test]]
 name = "listener"
 required-features = ["compio-driver/sync"]

--- a/compio-dispatcher/src/lib.rs
+++ b/compio-dispatcher/src/lib.rs
@@ -183,9 +183,10 @@ impl Dispatcher {
     {
         let (concrete, rx) = Concrete::new(f);
 
+        let meta = SpawnMeta::capture().named("dispatch");
         match self.sender.send(Spawning {
             task: Box::new(concrete),
-            meta: SpawnMeta::capture(),
+            meta,
         }) {
             Ok(_) => Ok(rx),
             Err(err) => {

--- a/compio-dispatcher/src/lib.rs
+++ b/compio-dispatcher/src/lib.rs
@@ -20,14 +20,19 @@ use std::{
 };
 
 use compio_driver::{AsyncifyPool, DispatchError, Dispatchable, ProactorBuilder};
-use compio_runtime::{JoinHandle as CompioJoinHandle, Runtime};
+use compio_runtime::{JoinHandle as CompioJoinHandle, Runtime, SpawnMeta};
 use flume::{Sender, unbounded};
 use futures_channel::oneshot;
 
-type Spawning = Box<dyn Spawnable + Send>;
+/// A closure to spawn, and the [`SpawnMeta`] of the `dispatch` call it came
+/// from.
+struct Spawning {
+    task: Box<dyn Spawnable + Send>,
+    meta: SpawnMeta,
+}
 
 trait Spawnable {
-    fn spawn(self: Box<Self>, handle: &Runtime) -> CompioJoinHandle<()>;
+    fn spawn(self: Box<Self>, handle: &Runtime, meta: SpawnMeta) -> CompioJoinHandle<()>;
 }
 
 /// Concrete type for the closure we're sending to worker threads
@@ -49,12 +54,15 @@ where
     Fut: Future<Output = R>,
     R: Send + 'static,
 {
-    fn spawn(self: Box<Self>, handle: &Runtime) -> CompioJoinHandle<()> {
+    fn spawn(self: Box<Self>, handle: &Runtime, meta: SpawnMeta) -> CompioJoinHandle<()> {
         let Concrete { callback, func } = *self;
-        handle.spawn(async move {
-            let res = func().await;
-            callback.send(res).ok();
-        })
+        handle.spawn_at(
+            async move {
+                let res = func().await;
+                callback.send(res).ok();
+            },
+            meta,
+        )
     }
 }
 
@@ -123,8 +131,10 @@ impl Dispatcher {
                             .build()
                             .expect("cannot create compio runtime")
                             .block_on(async move {
-                                while let Ok(f) = receiver.recv_async().await {
-                                    let task = Runtime::with_current(|rt| f.spawn(rt));
+                                while let Ok(Spawning { task: f, meta }) =
+                                    receiver.recv_async().await
+                                {
+                                    let task = Runtime::with_current(|rt| f.spawn(rt, meta));
                                     if concurrent {
                                         task.detach()
                                     } else {
@@ -164,6 +174,7 @@ impl Dispatcher {
     ///
     /// If all threads have panicked, this method will return an error with the
     /// sent closure.
+    #[track_caller]
     pub fn dispatch<Fn, Fut, R>(&self, f: Fn) -> Result<oneshot::Receiver<R>, DispatchError<Fn>>
     where
         Fn: (FnOnce() -> Fut) + Send + 'static,
@@ -172,12 +183,15 @@ impl Dispatcher {
     {
         let (concrete, rx) = Concrete::new(f);
 
-        match self.sender.send(Box::new(concrete)) {
+        match self.sender.send(Spawning {
+            task: Box::new(concrete),
+            meta: SpawnMeta::capture(),
+        }) {
             Ok(_) => Ok(rx),
             Err(err) => {
                 // SAFETY: We know the dispatchable we sent has type `Concrete<Fn, R>`
                 let recovered =
-                    unsafe { Box::from_raw(Box::into_raw(err.0) as *mut Concrete<Fn, R>) };
+                    unsafe { Box::from_raw(Box::into_raw(err.0.task) as *mut Concrete<Fn, R>) };
                 Err(DispatchError(recovered.func))
             }
         }

--- a/compio-dispatcher/src/lib.rs
+++ b/compio-dispatcher/src/lib.rs
@@ -88,6 +88,7 @@ pub struct Dispatcher {
 
 impl Dispatcher {
     /// Create the dispatcher with specified number of threads.
+    #[track_caller]
     pub(crate) fn new_impl(builder: DispatcherBuilder) -> io::Result<Self> {
         let DispatcherBuilder {
             nthreads,
@@ -100,6 +101,9 @@ impl Dispatcher {
         proactor_builder.force_reuse_thread_pool();
         let pool = proactor_builder.create_or_get_thread_pool();
         let (sender, receiver) = unbounded::<Spawning>();
+        // Captured out here, since `#[track_caller]` does not reach into the
+        // closures the threads run, and every worker belongs to this call.
+        let meta = SpawnMeta::capture().named("dispatcher::worker");
 
         let threads = (0..nthreads)
             .map({
@@ -130,18 +134,21 @@ impl Dispatcher {
                             .thread_affinity(cpus)
                             .build()
                             .expect("cannot create compio runtime")
-                            .block_on(async move {
-                                while let Ok(Spawning { task: f, meta }) =
-                                    receiver.recv_async().await
-                                {
-                                    let task = Runtime::with_current(|rt| f.spawn(rt, meta));
-                                    if concurrent {
-                                        task.detach()
-                                    } else {
-                                        task.await.ok();
+                            .block_on_at(
+                                async move {
+                                    while let Ok(Spawning { task: f, meta }) =
+                                        receiver.recv_async().await
+                                    {
+                                        let task = Runtime::with_current(|rt| f.spawn(rt, meta));
+                                        if concurrent {
+                                            task.detach()
+                                        } else {
+                                            task.await.ok();
+                                        }
                                     }
-                                }
-                            });
+                                },
+                                meta,
+                            );
                     })
                 }
             })
@@ -155,6 +162,7 @@ impl Dispatcher {
     }
 
     /// Create the dispatcher with default config.
+    #[track_caller]
     pub fn new() -> io::Result<Self> {
         Self::builder().build()
     }
@@ -316,6 +324,7 @@ impl DispatcherBuilder {
     }
 
     /// Build the [`Dispatcher`].
+    #[track_caller]
     pub fn build(self) -> io::Result<Dispatcher> {
         Dispatcher::new_impl(self)
     }

--- a/compio-executor/Cargo.toml
+++ b/compio-executor/Cargo.toml
@@ -28,6 +28,7 @@ loom = { version = "0.7", features = ["checkpoint"] }
 
 [dev-dependencies]
 criterion = { workspace = true }
+tracing = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
 
 [target.'cfg(unix)'.dev-dependencies]

--- a/compio-executor/Cargo.toml
+++ b/compio-executor/Cargo.toml
@@ -20,6 +20,9 @@ compio-send-wrapper = { workspace = true }
 crossbeam-queue = { workspace = true }
 slotmap = { workspace = true }
 
+# Console
+tracing = { workspace = true, optional = true }
+
 [target.'cfg(loom)'.dependencies]
 loom = { version = "0.7", features = ["checkpoint"] }
 
@@ -32,6 +35,9 @@ nix = { workspace = true, features = ["resource", "signal"] }
 
 [features]
 enable_log = ["compio-log/enable_log"]
+
+# Instrumentation for `tokio-console`. See the `console` module.
+console = ["dep:tracing"]
 
 [[bench]]
 name = "schedule"

--- a/compio-executor/src/console.rs
+++ b/compio-executor/src/console.rs
@@ -56,11 +56,16 @@
 //! * A blocking task has no waker operations, since it is a closure rather than
 //!   a future. The console knows this from its `kind` and does not report a
 //!   lost waker for it.
+//! * A task spawned by an `async fn` is attributed to that function rather than
+//!   to its caller, since [`#[track_caller]`][async-track-caller] is a no-op on
+//!   `async fn`s and [`SpawnMeta`] therefore cannot be forwarded through them.
+//!   The ones compio spawns itself are named to make up for it.
 //! * The resources tab stays empty: timers and in-flight operations are not
 //!   instrumented yet.
 //!
 //! [`tokio-console`]: https://github.com/tokio-rs/console
 //! [`tracing`]: https://docs.rs/tracing
+//! [async-track-caller]: https://github.com/rust-lang/rust/issues/110011
 
 #[cfg(not(feature = "console"))]
 mod disabled;

--- a/compio-executor/src/console.rs
+++ b/compio-executor/src/console.rs
@@ -1,0 +1,68 @@
+//! [`tokio-console`] instrumentation.
+//!
+//! [`tokio-console`] collects its data through [`tracing`] spans and events
+//! that follow a fixed naming convention. It is *not* tied to tokio's internals
+//! in any way, so any executor emitting the same spans and events can be
+//! observed with it.
+//!
+//! Enable the `console` feature to make this executor emit them:
+//!
+//! * every task gets a `runtime.spawn` span, entered while the task is polled,
+//!   so that the console can compute poll counts, busy/idle/scheduled times and
+//!   the poll time histogram.
+//!
+//! When the feature is disabled, all of this compiles down to nothing: the
+//! types in this module become zero-sized and every method an empty inlined
+//! function.
+//!
+//! # Usage
+//!
+//! `console-subscriber` refuses to run unless it can prove that the runtime is
+//! instrumented, which for tokio means the `tokio_unstable` cfg. For other
+//! runtimes it provides the `console_without_tokio_unstable` escape hatch, so a
+//! binary observing compio needs:
+//!
+//! ```toml
+//! # .cargo/config.toml
+//! [build]
+//! rustflags = ["--cfg", "console_without_tokio_unstable"]
+//! ```
+//!
+//! Installing the subscriber is then all it takes. The `compio` crate
+//! re-exports `console-subscriber` for the purpose, so that its version cannot
+//! drift from the one this instrumentation was written against:
+//!
+//! ```ignore
+//! compio::console_subscriber::init();
+//! compio::runtime::Runtime::new().unwrap().block_on(async {
+//!     // ...
+//! });
+//! ```
+//!
+//! # Limitations
+//!
+//! * The console's data model has one runtime per process, while compio is
+//!   thread-per-core and has one executor per thread. The tasks of all of them
+//!   are listed together; the `thread` field tells them apart.
+//! * The blocking pool is part of the driver rather than the executor, so a
+//!   task spawned by `spawn_blocking` is reported as an ordinary task waiting
+//!   for an operation, and the time spent in the closure counts as idle.
+//! * The resources tab stays empty: timers and in-flight operations are not
+//!   instrumented yet.
+//!
+//! [`tokio-console`]: https://github.com/tokio-rs/console
+//! [`tracing`]: https://docs.rs/tracing
+
+#[cfg(not(feature = "console"))]
+mod disabled;
+#[cfg(feature = "console")]
+mod enabled;
+
+#[cfg(not(feature = "console"))]
+pub use disabled::SpawnMeta;
+#[cfg(not(feature = "console"))]
+pub(crate) use disabled::TaskSpan;
+#[cfg(feature = "console")]
+pub use enabled::SpawnMeta;
+#[cfg(feature = "console")]
+pub(crate) use enabled::TaskSpan;

--- a/compio-executor/src/console.rs
+++ b/compio-executor/src/console.rs
@@ -152,7 +152,7 @@ mod parity {
     fn the_wrappers_pass_their_argument_through() {
         assert_eq!(instrument_blocking(SpawnMeta::untracked(), || 1u8)(), 1);
 
-        let fut = instrument_block_on(std::future::ready(1u8));
+        let fut = instrument_block_on(SpawnMeta::untracked(), std::future::ready(1u8));
         let _: &dyn Future<Output = u8> = &fut;
     }
 }

--- a/compio-executor/src/console.rs
+++ b/compio-executor/src/console.rs
@@ -109,3 +109,50 @@ impl WakerOp {
         }
     }
 }
+/// Assertions that the two variants above present the same surface.
+///
+/// Only one of them is ever compiled, and the one compiled by default is the
+/// one nearly every build uses: a difference between the two shows up as a
+/// build failure for whoever turns the feature on, long after the code that
+/// assumed the other shape was written.
+///
+/// Coercing each item to a function pointer pins its whole signature, and
+/// naming [`EnterGuard`] with a lifetime pins the shape of the guard: the
+/// enabled one borrows the span, so a disabled one that owns itself, and would
+/// let code outlive the span it is timing, does not have a lifetime to name.
+#[cfg(test)]
+mod parity {
+    use std::{fmt::Debug, future::Future};
+
+    #[cfg(not(feature = "console"))]
+    use super::disabled::EnterGuard;
+    #[cfg(feature = "console")]
+    use super::enabled::EnterGuard;
+    use super::*;
+
+    const _: fn() -> SpawnMeta = SpawnMeta::capture;
+    const _: fn(SpawnMeta, &'static str) -> SpawnMeta = SpawnMeta::named;
+    const _: fn() -> SpawnMeta = SpawnMeta::untracked;
+
+    const _: fn(SpawnMeta) -> TaskSpan = TaskSpan::new::<()>;
+    const _: for<'a> fn(&'a TaskSpan) -> EnterGuard<'a> = TaskSpan::enter;
+    const _: fn(&TaskSpan, WakerOp) = TaskSpan::waker_op;
+
+    /// [`SpawnMeta`] is copied out of a spawn call rather than moved, and
+    /// reaches the dispatcher's threads through its channel.
+    const fn meta<T: Copy + Send + Sync + Unpin + Debug + 'static>() {}
+    const _: () = meta::<SpawnMeta>();
+
+    /// [`TaskSpan`] sits in the task header, which threads share.
+    const fn span<T: Send + Sync + Debug>() {}
+    const _: () = span::<TaskSpan>();
+
+    /// The wrappers return `impl Trait`, so pin them by use instead.
+    #[test]
+    fn the_wrappers_pass_their_argument_through() {
+        assert_eq!(instrument_blocking(SpawnMeta::untracked(), || 1u8)(), 1);
+
+        let fut = instrument_block_on(std::future::ready(1u8));
+        let _: &dyn Future<Output = u8> = &fut;
+    }
+}

--- a/compio-executor/src/console.rs
+++ b/compio-executor/src/console.rs
@@ -9,7 +9,9 @@
 //!
 //! * every task gets a `runtime.spawn` span, entered while the task is polled,
 //!   so that the console can compute poll counts, busy/idle/scheduled times and
-//!   the poll time histogram.
+//!   the poll time histogram;
+//! * every waker operation emits a `runtime::waker` event, so that the console
+//!   can compute waker counts and detect self-wakes and lost wakers.
 //!
 //! When the feature is disabled, all of this compiles down to nothing: the
 //! types in this module become zero-sized and every method an empty inlined
@@ -66,3 +68,32 @@ pub(crate) use disabled::TaskSpan;
 pub use enabled::SpawnMeta;
 #[cfg(feature = "console")]
 pub(crate) use enabled::TaskSpan;
+
+/// An operation on a task's waker, reported as a `runtime::waker` event.
+///
+/// Note that [`Waker::wake`](std::task::Waker::wake) does not call the `drop`
+/// implementation, so the console counts [`Self::Wake`] as both a wake and a
+/// drop. Emitting an additional [`Self::Drop`] for it would make the live waker
+/// count (clones - drops) go negative.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum WakerOp {
+    Clone,
+    Drop,
+    Wake,
+    WakeByRef,
+}
+
+impl WakerOp {
+    /// The `op` value of the event, as expected by the console.
+    ///
+    /// Only the enabled variant reports anything, so only it reads this.
+    #[cfg(feature = "console")]
+    pub(crate) const fn as_str(self) -> &'static str {
+        match self {
+            Self::Clone => "waker.clone",
+            Self::Drop => "waker.drop",
+            Self::Wake => "waker.wake",
+            Self::WakeByRef => "waker.wake_by_ref",
+        }
+    }
+}

--- a/compio-executor/src/console.rs
+++ b/compio-executor/src/console.rs
@@ -11,7 +11,10 @@
 //!   so that the console can compute poll counts, busy/idle/scheduled times and
 //!   the poll time histogram;
 //! * every waker operation emits a `runtime::waker` event, so that the console
-//!   can compute waker counts and detect self-wakes and lost wakers.
+//!   can compute waker counts and detect self-wakes and lost wakers;
+//! * a closure handed to the blocking pool gets such a span too, entered around
+//!   the closure instead of around a poll, so that the time spent in it is
+//!   reported as busy time rather than as idle time.
 //!
 //! When the feature is disabled, all of this compiles down to nothing: the
 //! types in this module become zero-sized and every method an empty inlined
@@ -46,13 +49,13 @@
 //! * The console's data model has one runtime per process, while compio is
 //!   thread-per-core and has one executor per thread. The tasks of all of them
 //!   are listed together; the `thread` field tells them apart.
-//! * The blocking pool is part of the driver rather than the executor, so a
-//!   task spawned by `spawn_blocking` is reported as an ordinary task waiting
-//!   for an operation, and the time spent in the closure counts as idle.
 //! * A `block_on` nested inside a task — a runtime built within another one —
 //!   reports the two as separate tasks, but both of their spans are entered on
 //!   the same stack. The console attributes the polls to the inner one for as
 //!   long as that is the case.
+//! * A blocking task has no waker operations, since it is a closure rather than
+//!   a future. The console knows this from its `kind` and does not report a
+//!   lost waker for it.
 //! * The resources tab stays empty: timers and in-flight operations are not
 //!   instrumented yet.
 //!
@@ -67,11 +70,11 @@ mod enabled;
 #[cfg(not(feature = "console"))]
 pub(crate) use disabled::TaskSpan;
 #[cfg(not(feature = "console"))]
-pub use disabled::{SpawnMeta, instrument_block_on};
+pub use disabled::{SpawnMeta, instrument_block_on, instrument_blocking};
 #[cfg(feature = "console")]
 pub(crate) use enabled::TaskSpan;
 #[cfg(feature = "console")]
-pub use enabled::{SpawnMeta, instrument_block_on};
+pub use enabled::{SpawnMeta, instrument_block_on, instrument_blocking};
 
 /// An operation on a task's waker, reported as a `runtime::waker` event.
 ///

--- a/compio-executor/src/console.rs
+++ b/compio-executor/src/console.rs
@@ -49,6 +49,10 @@
 //! * The blocking pool is part of the driver rather than the executor, so a
 //!   task spawned by `spawn_blocking` is reported as an ordinary task waiting
 //!   for an operation, and the time spent in the closure counts as idle.
+//! * A `block_on` nested inside a task — a runtime built within another one —
+//!   reports the two as separate tasks, but both of their spans are entered on
+//!   the same stack. The console attributes the polls to the inner one for as
+//!   long as that is the case.
 //! * The resources tab stays empty: timers and in-flight operations are not
 //!   instrumented yet.
 //!
@@ -61,13 +65,13 @@ mod disabled;
 mod enabled;
 
 #[cfg(not(feature = "console"))]
-pub use disabled::SpawnMeta;
-#[cfg(not(feature = "console"))]
 pub(crate) use disabled::TaskSpan;
-#[cfg(feature = "console")]
-pub use enabled::SpawnMeta;
+#[cfg(not(feature = "console"))]
+pub use disabled::{SpawnMeta, instrument_block_on};
 #[cfg(feature = "console")]
 pub(crate) use enabled::TaskSpan;
+#[cfg(feature = "console")]
+pub use enabled::{SpawnMeta, instrument_block_on};
 
 /// An operation on a task's waker, reported as a `runtime::waker` event.
 ///

--- a/compio-executor/src/console/disabled.rs
+++ b/compio-executor/src/console/disabled.rs
@@ -78,6 +78,6 @@ pub fn instrument_blocking<T, F: FnOnce() -> T>(_meta: SpawnMeta, f: F) -> impl 
 ///
 /// This is a no-op unless the `console` feature is enabled.
 #[inline(always)]
-pub fn instrument_block_on<F: Future>(fut: F) -> impl Future<Output = F::Output> {
+pub fn instrument_block_on<F: Future>(_meta: SpawnMeta, fut: F) -> impl Future<Output = F::Output> {
     fut
 }

--- a/compio-executor/src/console/disabled.rs
+++ b/compio-executor/src/console/disabled.rs
@@ -14,6 +14,12 @@ impl SpawnMeta {
     pub fn capture() -> Self {
         Self
     }
+
+    /// Do not report the task to the console at all.
+    #[inline(always)]
+    pub fn untracked() -> Self {
+        Self
+    }
 }
 
 /// The guard returned by [`TaskSpan::enter`].
@@ -50,6 +56,15 @@ impl TaskSpan {
 
     #[inline(always)]
     pub(crate) fn waker_op(&self, _op: super::WakerOp) {}
+}
+
+/// Instrument a closure about to be handed to the blocking pool, so that it
+/// shows up as a blocking task in the console.
+///
+/// This is a no-op unless the `console` feature is enabled.
+#[inline(always)]
+pub fn instrument_blocking<T, F: FnOnce() -> T>(_meta: SpawnMeta, f: F) -> impl FnOnce() -> T {
+    f
 }
 
 /// Instrument a future blocked on by the runtime, so that it shows up as a

--- a/compio-executor/src/console/disabled.rs
+++ b/compio-executor/src/console/disabled.rs
@@ -51,3 +51,12 @@ impl TaskSpan {
     #[inline(always)]
     pub(crate) fn waker_op(&self, _op: super::WakerOp) {}
 }
+
+/// Instrument a future blocked on by the runtime, so that it shows up as a
+/// task in the console.
+///
+/// This is a no-op unless the `console` feature is enabled.
+#[inline(always)]
+pub fn instrument_block_on<F: Future>(fut: F) -> impl Future<Output = F::Output> {
+    fut
+}

--- a/compio-executor/src/console/disabled.rs
+++ b/compio-executor/src/console/disabled.rs
@@ -47,4 +47,7 @@ impl TaskSpan {
     pub(crate) fn enter(&self) -> EnterGuard<'_> {
         Entered(PhantomData)
     }
+
+    #[inline(always)]
+    pub(crate) fn waker_op(&self, _op: super::WakerOp) {}
 }

--- a/compio-executor/src/console/disabled.rs
+++ b/compio-executor/src/console/disabled.rs
@@ -15,6 +15,12 @@ impl SpawnMeta {
         Self
     }
 
+    /// Name the task, which the console displays in a column of its own.
+    #[inline(always)]
+    pub fn named(self, _name: &'static str) -> Self {
+        self
+    }
+
     /// Do not report the task to the console at all.
     #[inline(always)]
     pub fn untracked() -> Self {

--- a/compio-executor/src/console/disabled.rs
+++ b/compio-executor/src/console/disabled.rs
@@ -1,0 +1,50 @@
+//! No-op stand-ins used when the `console` feature is disabled.
+
+use std::marker::PhantomData;
+
+/// Metadata of a spawned task, reported to the console.
+///
+/// Zero-sized and inert unless the `console` feature is enabled.
+#[derive(Debug, Clone, Copy)]
+pub struct SpawnMeta;
+
+impl SpawnMeta {
+    /// Capture the location of the caller.
+    #[inline(always)]
+    pub fn capture() -> Self {
+        Self
+    }
+}
+
+/// The guard returned by [`TaskSpan::enter`].
+///
+/// The enabled variant measures the busy time of a task as the time its guard
+/// is alive, so dropping it right away is a bug that this makes visible in both
+/// configurations. It borrows the span for the same reason: the enabled guard
+/// does, and code that compiles without the feature has to compile with it.
+#[must_use = "the task span is exited as soon as this is dropped"]
+pub(crate) struct Entered<'a>(PhantomData<&'a TaskSpan>);
+
+/// The guard [`TaskSpan::enter`] returns, named the same in both variants so
+/// that the parity assertions can reach it.
+pub(crate) type EnterGuard<'a> = Entered<'a>;
+
+/// The `runtime.spawn` span of a task.
+#[derive(Debug)]
+pub(crate) struct TaskSpan;
+
+impl TaskSpan {
+    #[inline(always)]
+    #[expect(
+        clippy::extra_unused_type_parameters,
+        reason = "mirrors the enabled variant, which records the future's size"
+    )]
+    pub(crate) fn new<F>(_meta: SpawnMeta) -> Self {
+        Self
+    }
+
+    #[inline(always)]
+    pub(crate) fn enter(&self) -> EnterGuard<'_> {
+        Entered(PhantomData)
+    }
+}

--- a/compio-executor/src/console/enabled.rs
+++ b/compio-executor/src/console/enabled.rs
@@ -1,0 +1,108 @@
+//! The actual [`tokio-console`] instrumentation.
+//!
+//! [`tokio-console`]: https://github.com/tokio-rs/console
+
+use std::{
+    mem,
+    panic::Location,
+    sync::atomic::{AtomicU64, Ordering},
+};
+
+use tracing::Span;
+
+/// Target of the task spans. The console accepts any target for spans named
+/// `runtime.spawn`, but the target is displayed, so make it a useful one.
+const TARGET: &str = "compio::task";
+
+/// Id displayed by the console in its `ID` column.
+///
+/// This is deliberately *not* the executor's [`TaskId`], which is a slot index
+/// and thus both reused and duplicated across the executors of a
+/// thread-per-core application.
+///
+/// [`TaskId`]: crate::queue::TaskId
+fn next_task_id() -> u64 {
+    static NEXT: AtomicU64 = AtomicU64::new(1);
+
+    NEXT.fetch_add(1, Ordering::Relaxed)
+}
+
+std::thread_local! {
+    /// Label of the current thread, to tell the tasks of the executors of a
+    /// thread-per-core application apart.
+    static THREAD: String = {
+        let thread = std::thread::current();
+        match thread.name() {
+            Some(name) => name.to_owned(),
+            None => format!("{:?}", thread.id()),
+        }
+    };
+}
+
+fn spawn_span(kind: &'static str, size: usize, loc: &'static Location<'static>) -> Span {
+    fn build(
+        kind: &'static str,
+        size: usize,
+        loc: &'static Location<'static>,
+        thread: &str,
+    ) -> Span {
+        tracing::trace_span!(
+            target: TARGET,
+            // The console attributes polls of a task to the innermost task span
+            // that is entered, so task spans must never be nested.
+            parent: None,
+            "runtime.spawn",
+            kind = kind,
+            task.id = next_task_id(),
+            size.bytes = size,
+            thread = thread,
+            loc.file = loc.file(),
+            loc.line = loc.line(),
+            loc.col = loc.column(),
+        )
+    }
+
+    // The label is gone once the thread tears its locals down, which a task
+    // spawned from another destructor still runs after. Report it unlabelled
+    // rather than panicking on the way out.
+    THREAD
+        .try_with(|thread| build(kind, size, loc, thread.as_str()))
+        .unwrap_or_else(|_| build(kind, size, loc, ""))
+}
+
+/// Metadata of a spawned task, reported to the console.
+///
+/// The disabled variant of this is zero-sized, so nothing here may be
+/// load-bearing outside of the console.
+#[derive(Debug, Clone, Copy)]
+pub struct SpawnMeta(&'static Location<'static>);
+
+impl SpawnMeta {
+    /// Capture the location of the caller.
+    #[inline]
+    #[track_caller]
+    pub fn capture() -> Self {
+        Self(Location::caller())
+    }
+}
+
+/// The guard [`TaskSpan::enter`] returns, named the same in both variants so
+/// that the parity assertions can reach it.
+pub(crate) type EnterGuard<'a> = tracing::span::Entered<'a>;
+
+/// The `runtime.spawn` span of a task.
+#[derive(Debug)]
+pub(crate) struct TaskSpan(Span);
+
+impl TaskSpan {
+    pub(crate) fn new<F>(meta: SpawnMeta) -> Self {
+        Self(spawn_span("task", mem::size_of::<F>(), meta.0))
+    }
+
+    /// Enter the task span. The console measures the time the span is entered
+    /// as the busy time of the task, and counts one poll per entry.
+    #[inline]
+    pub(crate) fn enter(&self) -> EnterGuard<'_> {
+        self.0.enter()
+    }
+}

--- a/compio-executor/src/console/enabled.rs
+++ b/compio-executor/src/console/enabled.rs
@@ -5,7 +5,12 @@
 use std::{
     mem,
     panic::Location,
-    sync::atomic::{AtomicU64, Ordering},
+    pin::Pin,
+    sync::{
+        Arc,
+        atomic::{AtomicU64, Ordering},
+    },
+    task::{Context, Poll, RawWaker, RawWakerVTable, Waker},
 };
 
 use tracing::Span;
@@ -120,5 +125,126 @@ impl TaskSpan {
         if let Some(id) = self.0.id() {
             waker_op(id.into_u64(), op);
         }
+    }
+}
+
+/// A [`Waker`] that reports its operations to the console, on behalf of a task
+/// that is not owned by the executor.
+struct ShimWaker {
+    inner: Waker,
+    id: u64,
+}
+
+impl ShimWaker {
+    const VTABLE: &'static RawWakerVTable = &RawWakerVTable::new(
+        Self::clone_waker,
+        Self::wake,
+        Self::wake_by_ref,
+        Self::drop_waker,
+    );
+
+    fn waker(inner: Waker, id: u64) -> Waker {
+        let this = Arc::new(Self { inner, id });
+        // The shim is a live waker of the task, and dropping it reports a
+        // `waker.drop`, so report the matching `waker.clone` here.
+        this.report(WakerOp::Clone);
+        let raw = RawWaker::new(Arc::into_raw(this).cast(), Self::VTABLE);
+        // SAFETY: the vtable operates on `Arc<ShimWaker>` pointers, which is
+        // what we just leaked.
+        unsafe { Waker::from_raw(raw) }
+    }
+
+    /// # Safety
+    ///
+    /// `ptr` must come from [`Arc::into_raw`] of a live `Arc<ShimWaker>`.
+    unsafe fn borrow(ptr: *const ()) -> &'static Self {
+        unsafe { &*ptr.cast::<Self>() }
+    }
+
+    /// # Safety
+    ///
+    /// `ptr` must come from [`Arc::into_raw`] of a live `Arc<ShimWaker>`, and
+    /// the caller must give up its ownership of it.
+    unsafe fn own(ptr: *const ()) -> Arc<Self> {
+        unsafe { Arc::from_raw(ptr.cast::<Self>()) }
+    }
+
+    unsafe fn clone_waker(ptr: *const ()) -> RawWaker {
+        unsafe { Self::borrow(ptr) }.report(WakerOp::Clone);
+        unsafe { Arc::increment_strong_count(ptr.cast::<Self>()) };
+        RawWaker::new(ptr, Self::VTABLE)
+    }
+
+    unsafe fn wake(ptr: *const ()) {
+        let this = unsafe { Self::own(ptr) };
+        this.report(WakerOp::Wake);
+        this.inner.wake_by_ref();
+    }
+
+    unsafe fn wake_by_ref(ptr: *const ()) {
+        let this = unsafe { Self::borrow(ptr) };
+        this.report(WakerOp::WakeByRef);
+        this.inner.wake_by_ref();
+    }
+
+    unsafe fn drop_waker(ptr: *const ()) {
+        let this = unsafe { Self::own(ptr) };
+        this.report(WakerOp::Drop);
+    }
+
+    #[inline]
+    fn report(&self, op: WakerOp) {
+        waker_op(self.id, op);
+    }
+}
+
+/// A future instrumented as a `block_on` task, returned by
+/// [`instrument_block_on`].
+struct BlockOn<F> {
+    span: Span,
+    id: Option<u64>,
+    /// The waker given to us by the runtime and the shim wrapping it, cached to
+    /// avoid rebuilding the shim on every poll.
+    waker: Option<(Waker, Waker)>,
+    fut: F,
+}
+
+impl<F: Future> Future for BlockOn<F> {
+    type Output = F::Output;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        // SAFETY: we never move out of `fut`, and all other fields are `Unpin`.
+        let this = unsafe { self.get_unchecked_mut() };
+        let fut = unsafe { Pin::new_unchecked(&mut this.fut) };
+
+        let _entered = this.span.enter();
+
+        let Some(id) = this.id else {
+            return fut.poll(cx);
+        };
+
+        if !matches!(&this.waker, Some((given, _)) if given.will_wake(cx.waker())) {
+            let given = cx.waker().clone();
+            let shim = ShimWaker::waker(given.clone(), id);
+            this.waker = Some((given, shim));
+        }
+
+        let shim = &this.waker.as_ref().expect("waker was just set").1;
+        fut.poll(&mut Context::from_waker(shim))
+    }
+}
+
+/// Instrument a future blocked on by the runtime, so that it shows up as a
+/// task in the console.
+#[track_caller]
+pub fn instrument_block_on<F: Future>(fut: F) -> impl Future<Output = F::Output> {
+    let span = spawn_span("block_on", mem::size_of::<F>(), Location::caller());
+    let id = span.id().map(|id| id.into_u64());
+
+    BlockOn {
+        span,
+        id,
+        waker: None,
+        fut,
     }
 }

--- a/compio-executor/src/console/enabled.rs
+++ b/compio-executor/src/console/enabled.rs
@@ -70,8 +70,19 @@ std::thread_local! {
     };
 }
 
-fn spawn_span(kind: TaskKind, size: usize, loc: &'static Location<'static>) -> Span {
-    fn build(kind: TaskKind, size: usize, loc: &'static Location<'static>, thread: &str) -> Span {
+fn spawn_span(
+    kind: TaskKind,
+    size: usize,
+    loc: &'static Location<'static>,
+    name: Option<&'static str>,
+) -> Span {
+    fn build(
+        kind: TaskKind,
+        size: usize,
+        loc: &'static Location<'static>,
+        name: Option<&'static str>,
+        thread: &str,
+    ) -> Span {
         tracing::trace_span!(
             target: TARGET,
             // The console attributes polls of a task to the innermost task span
@@ -80,6 +91,9 @@ fn spawn_span(kind: TaskKind, size: usize, loc: &'static Location<'static>) -> S
             "runtime.spawn",
             kind = kind.as_str(),
             task.id = next_task_id(),
+            // The console gives this field a column of its own, and leaves it
+            // empty for the tasks that do not have it.
+            task.name = name,
             size.bytes = size,
             thread = thread,
             loc.file = loc.file(),
@@ -92,8 +106,8 @@ fn spawn_span(kind: TaskKind, size: usize, loc: &'static Location<'static>) -> S
     // spawned from another destructor still runs after. Report it unlabelled
     // rather than panicking on the way out.
     THREAD
-        .try_with(|thread| build(kind, size, loc, thread.as_str()))
-        .unwrap_or_else(|_| build(kind, size, loc, ""))
+        .try_with(|thread| build(kind, size, loc, name, thread.as_str()))
+        .unwrap_or_else(|_| build(kind, size, loc, name, ""))
 }
 
 fn waker_op(id: u64, op: WakerOp) {
@@ -113,6 +127,7 @@ pub struct SpawnMeta(Option<Reported>);
 #[derive(Debug, Clone, Copy)]
 struct Reported {
     loc: &'static Location<'static>,
+    name: Option<&'static str>,
 }
 
 impl SpawnMeta {
@@ -122,6 +137,19 @@ impl SpawnMeta {
     pub fn capture() -> Self {
         Self(Some(Reported {
             loc: Location::caller(),
+            name: None,
+        }))
+    }
+
+    /// Name the task, which the console displays in a column of its own.
+    ///
+    /// This is worth doing for the tasks a user did not spawn themselves, since
+    /// the location of those points into compio rather than into their code.
+    #[inline]
+    pub fn named(self, name: &'static str) -> Self {
+        Self(self.0.map(|it| Reported {
+            name: Some(name),
+            ..it
         }))
     }
 
@@ -142,7 +170,7 @@ impl SpawnMeta {
     /// nothing downstream has to know about the difference.
     fn span(self, kind: TaskKind, size: usize) -> Span {
         match self.0 {
-            Some(it) => spawn_span(kind, size, it.loc),
+            Some(it) => spawn_span(kind, size, it.loc, it.name),
             None => Span::none(),
         }
     }

--- a/compio-executor/src/console/enabled.rs
+++ b/compio-executor/src/console/enabled.rs
@@ -21,6 +21,30 @@ use super::WakerOp;
 /// `runtime.spawn`, but the target is displayed, so make it a useful one.
 const TARGET: &str = "compio::task";
 
+/// What a task span reports the task as being.
+///
+/// The console considers a task whose kind is not [`Self::Task`] to not be
+/// driven by a future, and skips the lints that only make sense for one: the
+/// self-wake ratio, the lost waker, the never-yielded and the large future
+/// ones.
+#[derive(Debug, Clone, Copy)]
+enum TaskKind {
+    Task,
+    Blocking,
+    BlockOn,
+}
+
+impl TaskKind {
+    /// The `kind` value of the span, as expected by the console.
+    const fn as_str(self) -> &'static str {
+        match self {
+            Self::Task => "task",
+            Self::Blocking => "blocking",
+            Self::BlockOn => "block_on",
+        }
+    }
+}
+
 /// Id displayed by the console in its `ID` column.
 ///
 /// This is deliberately *not* the executor's [`TaskId`], which is a slot index
@@ -46,20 +70,15 @@ std::thread_local! {
     };
 }
 
-fn spawn_span(kind: &'static str, size: usize, loc: &'static Location<'static>) -> Span {
-    fn build(
-        kind: &'static str,
-        size: usize,
-        loc: &'static Location<'static>,
-        thread: &str,
-    ) -> Span {
+fn spawn_span(kind: TaskKind, size: usize, loc: &'static Location<'static>) -> Span {
+    fn build(kind: TaskKind, size: usize, loc: &'static Location<'static>, thread: &str) -> Span {
         tracing::trace_span!(
             target: TARGET,
             // The console attributes polls of a task to the innermost task span
             // that is entered, so task spans must never be nested.
             parent: None,
             "runtime.spawn",
-            kind = kind,
+            kind = kind.as_str(),
             task.id = next_task_id(),
             size.bytes = size,
             thread = thread,
@@ -85,17 +104,47 @@ fn waker_op(id: u64, op: WakerOp) {
 
 /// Metadata of a spawned task, reported to the console.
 ///
-/// The disabled variant of this is zero-sized, so nothing here may be
-/// load-bearing outside of the console.
+/// `None` for a task that is not reported at all. The disabled variant of this
+/// is zero-sized, so nothing here may be load-bearing outside of the console.
 #[derive(Debug, Clone, Copy)]
-pub struct SpawnMeta(&'static Location<'static>);
+pub struct SpawnMeta(Option<Reported>);
+
+/// What is reported about a task, for the tasks that are reported at all.
+#[derive(Debug, Clone, Copy)]
+struct Reported {
+    loc: &'static Location<'static>,
+}
 
 impl SpawnMeta {
     /// Capture the location of the caller.
     #[inline]
     #[track_caller]
     pub fn capture() -> Self {
-        Self(Location::caller())
+        Self(Some(Reported {
+            loc: Location::caller(),
+        }))
+    }
+
+    /// Do not report the task to the console at all.
+    ///
+    /// This is for tasks that only wrap work reported by something else, like
+    /// the future waiting for a blocking closure: reporting both would count
+    /// the same work twice, and hide the interesting one behind a wrapper that
+    /// is idle the whole time.
+    #[inline]
+    pub fn untracked() -> Self {
+        Self(None)
+    }
+
+    /// The span of the task, or a disabled span if it is not to be reported.
+    ///
+    /// Entering a disabled span and asking for its id are both no-ops, so
+    /// nothing downstream has to know about the difference.
+    fn span(self, kind: TaskKind, size: usize) -> Span {
+        match self.0 {
+            Some(it) => spawn_span(kind, size, it.loc),
+            None => Span::none(),
+        }
     }
 }
 
@@ -109,7 +158,7 @@ pub(crate) struct TaskSpan(Span);
 
 impl TaskSpan {
     pub(crate) fn new<F>(meta: SpawnMeta) -> Self {
-        Self(spawn_span("task", mem::size_of::<F>(), meta.0))
+        Self(meta.span(TaskKind::Task, mem::size_of::<F>()))
     }
 
     /// Enter the task span. The console measures the time the span is entered
@@ -234,11 +283,27 @@ impl<F: Future> Future for BlockOn<F> {
     }
 }
 
+/// Instrument a closure about to be handed to the blocking pool, so that it
+/// shows up as a blocking task in the console.
+///
+/// The span is created here rather than on the pool thread, so that the task
+/// shows up as soon as it is queued and the wait for a worker is reported as
+/// idle time. It is entered around the closure itself, so that the time spent
+/// in it is reported as busy time.
+pub fn instrument_blocking<T, F: FnOnce() -> T>(meta: SpawnMeta, f: F) -> impl FnOnce() -> T {
+    let span = meta.span(TaskKind::Blocking, mem::size_of::<F>());
+
+    move || {
+        let _entered = span.enter();
+        f()
+    }
+}
+
 /// Instrument a future blocked on by the runtime, so that it shows up as a
 /// task in the console.
 #[track_caller]
 pub fn instrument_block_on<F: Future>(fut: F) -> impl Future<Output = F::Output> {
-    let span = spawn_span("block_on", mem::size_of::<F>(), Location::caller());
+    let span = SpawnMeta::capture().span(TaskKind::BlockOn, mem::size_of::<F>());
     let id = span.id().map(|id| id.into_u64());
 
     BlockOn {

--- a/compio-executor/src/console/enabled.rs
+++ b/compio-executor/src/console/enabled.rs
@@ -10,6 +10,8 @@ use std::{
 
 use tracing::Span;
 
+use super::WakerOp;
+
 /// Target of the task spans. The console accepts any target for spans named
 /// `runtime.spawn`, but the target is displayed, so make it a useful one.
 const TARGET: &str = "compio::task";
@@ -70,6 +72,12 @@ fn spawn_span(kind: &'static str, size: usize, loc: &'static Location<'static>) 
         .unwrap_or_else(|_| build(kind, size, loc, ""))
 }
 
+fn waker_op(id: u64, op: WakerOp) {
+    // `task.id` of a waker event is the *span* id of the task, which is how the
+    // console looks the task up.
+    tracing::trace!(target: "runtime::waker", op = op.as_str(), task.id = id);
+}
+
 /// Metadata of a spawned task, reported to the console.
 ///
 /// The disabled variant of this is zero-sized, so nothing here may be
@@ -104,5 +112,13 @@ impl TaskSpan {
     #[inline]
     pub(crate) fn enter(&self) -> EnterGuard<'_> {
         self.0.enter()
+    }
+
+    /// Record a waker operation on this task.
+    #[inline]
+    pub(crate) fn waker_op(&self, op: WakerOp) {
+        if let Some(id) = self.0.id() {
+            waker_op(id.into_u64(), op);
+        }
     }
 }

--- a/compio-executor/src/console/enabled.rs
+++ b/compio-executor/src/console/enabled.rs
@@ -329,9 +329,8 @@ pub fn instrument_blocking<T, F: FnOnce() -> T>(meta: SpawnMeta, f: F) -> impl F
 
 /// Instrument a future blocked on by the runtime, so that it shows up as a
 /// task in the console.
-#[track_caller]
-pub fn instrument_block_on<F: Future>(fut: F) -> impl Future<Output = F::Output> {
-    let span = SpawnMeta::capture().span(TaskKind::BlockOn, mem::size_of::<F>());
+pub fn instrument_block_on<F: Future>(meta: SpawnMeta, fut: F) -> impl Future<Output = F::Output> {
+    let span = meta.span(TaskKind::BlockOn, mem::size_of::<F>());
     let id = span.id().map(|id| id.into_u64());
 
     BlockOn {

--- a/compio-executor/src/lib.rs
+++ b/compio-executor/src/lib.rs
@@ -15,6 +15,7 @@ use std::{any::Any, fmt::Debug, ptr::NonNull, task::Waker};
 
 use crate::queue::{TaskId, TaskQueue};
 
+pub mod console;
 mod join_handle;
 mod queue;
 mod task;
@@ -23,6 +24,7 @@ mod waker;
 
 use compio_log::{instrument, trace};
 use compio_send_wrapper::SendWrapper;
+pub use console::SpawnMeta;
 use crossbeam_queue::ArrayQueue;
 pub use join_handle::{JoinError, JoinHandle, ResumeUnwind};
 use util::panic_guard;
@@ -178,12 +180,25 @@ impl Executor {
     }
 
     /// Spawn a future onto the executor.
+    #[track_caller]
     pub fn spawn<F: Future + 'static>(&self, fut: F) -> JoinHandle<F::Output> {
+        self.spawn_at(fut, SpawnMeta::capture())
+    }
+
+    /// Spawn a future onto the executor, attributing it to `meta`.
+    ///
+    /// This is only useful for wrappers around [`spawn`] that want
+    /// [`tokio-console`] to blame their own caller instead of themselves;
+    /// [`SpawnMeta`] is a zero-sized no-op without the `console` feature.
+    ///
+    /// [`spawn`]: Self::spawn
+    /// [`tokio-console`]: crate::console
+    pub fn spawn_at<F: Future + 'static>(&self, fut: F, meta: SpawnMeta) -> JoinHandle<F::Output> {
         let shared = self.shared();
         let tracker = shared.queue.tracker();
         // SAFETY: Executor cannot be sent to ther thread
         let queue = unsafe { shared.queue.get_unchecked() };
-        let task = queue.insert(self.ptr, tracker, fut);
+        let task = queue.insert(self.ptr, tracker, fut, meta);
 
         JoinHandle::new(task)
     }

--- a/compio-executor/src/queue.rs
+++ b/compio-executor/src/queue.rs
@@ -3,7 +3,7 @@ use std::{fmt::Debug, ptr::NonNull};
 use compio_send_wrapper::SendWrapper;
 use slotmap::new_key_type;
 
-use crate::{Shared, task::Task, util::assert_not_impl};
+use crate::{Shared, console::SpawnMeta, task::Task, util::assert_not_impl};
 
 new_key_type! { pub struct TaskId; }
 
@@ -136,12 +136,13 @@ impl TaskQueue {
         shared: NonNull<Shared>,
         tracker: SendWrapper<()>,
         future: F,
+        meta: SpawnMeta,
     ) -> Task {
         unsafe {
             self.with_inner(|inner| {
                 let mut ret = None;
                 let key = inner.map.insert_with_key(|key| {
-                    let [ptr, r] = Task::new::<F, 2>(key, shared, tracker, future);
+                    let [ptr, r] = Task::new::<F, 2>(key, shared, tracker, future, meta);
                     ret = Some(r);
                     Item {
                         prev: None,

--- a/compio-executor/src/task/mod.rs
+++ b/compio-executor/src/task/mod.rs
@@ -14,6 +14,7 @@ use compio_send_wrapper::SendWrapper;
 
 use crate::{
     AtomicPtr, PanicResult, Shared, UnsafeCell,
+    console::{SpawnMeta, TaskSpan},
     queue::TaskId,
     task::{
         local::Local,
@@ -60,6 +61,8 @@ struct Header {
     tracker: ManuallyDrop<SendWrapper<()>>,
     shared: AtomicPtr<Shared>,
     waker: UnsafeCell<MaybeUninit<Waker>>,
+    /// Zero-sized unless the `console` feature is enabled.
+    span: TaskSpan,
 }
 
 union FutureState<F: Future> {
@@ -154,6 +157,11 @@ impl<F: Future + 'static> TaskAlloc<F> {
     }
 
     unsafe fn dealloc(header: NonNull<Header>) {
+        // Unlike `drop_future`, this runs during a panic as well: the header
+        // holds the task's span, and leaking it would leave the task running in
+        // the console forever. The subscriber is then reentered while
+        // unwinding, so a panic inside it aborts rather than unwinds.
+        //
         // SAFETY: The caller guarantees that the pointer is valid and properly aligned
         // for `TaskAlloc<F>`, and that no other reference to the allocation
         // exists.
@@ -167,6 +175,7 @@ impl Task {
         shared: NonNull<Shared>,
         tracker: SendWrapper<()>,
         future: F,
+        meta: SpawnMeta,
     ) -> [Task; N] {
         let alloc = Box::new(TaskAlloc {
             header: Header {
@@ -176,6 +185,7 @@ impl Task {
                 tracker: ManuallyDrop::new(tracker),
                 shared: AtomicPtr::new(shared.as_ptr()),
                 waker: UnsafeCell::new(MaybeUninit::uninit()),
+                span: TaskSpan::new::<F>(meta),
             },
             future: UnsafeCell::new(FutureState {
                 future: ManuallyDrop::new(future),
@@ -238,6 +248,10 @@ impl Task {
             debug!(?state, "Cancelled");
             return Poll::Ready(());
         }
+
+        // The console counts one poll of the task per entry of its span, and
+        // measures the time it stays entered as the busy time of the task.
+        let _entered = header.span.enter();
 
         self.with_waker(|waker| {
             let ctx = &mut Context::from_waker(waker);
@@ -385,8 +399,10 @@ impl Drop for Task {
         // The future/result and waker types are unwind-unsafe (ManuallyDrop in
         // union, MaybeUninit). Dropping them during an existing panic could
         // trigger a second panic, which would be UB. Skip content drops but
-        // still deallocate the memory since dealloc does not run destructors
-        // on the inner types.
+        // still deallocate the memory, since dealloc does not run destructors
+        // on the inner types. (It does run the one of the task span of the
+        // `console` feature, which is wanted: the console would otherwise show
+        // the task as running forever.)
         if ::std::thread::panicking() {
             unsafe { (header.vtable.dealloc)(self.0) }
             return;
@@ -440,9 +456,14 @@ mod test {
         }
     }
 
-    /// All dropping is handled manually by [`Executor`]. The memory is
+    /// All dropping is handled manually by [`Executor`], and the memory is
     /// deallocated by [`Task`].
     ///
+    /// The `console` feature is the one exception: it puts a `tracing` span in
+    /// the header, which is dropped along with the allocation by
+    /// [`TaskAlloc::dealloc`]. Asserting the difference rather than skipping
+    /// the assertion keeps it meaningful in both configurations.
+    ///
     /// [`Executor`]: crate::Executor
-    const _: () = assert!(!needs_drop::<TaskAlloc<NeedsDrop>>());
+    const _: () = assert!(needs_drop::<TaskAlloc<NeedsDrop>>() == cfg!(feature = "console"));
 }

--- a/compio-executor/src/task/mod.rs
+++ b/compio-executor/src/task/mod.rs
@@ -14,7 +14,7 @@ use compio_send_wrapper::SendWrapper;
 
 use crate::{
     AtomicPtr, PanicResult, Shared, UnsafeCell,
-    console::{SpawnMeta, TaskSpan},
+    console::{SpawnMeta, TaskSpan, WakerOp},
     queue::TaskId,
     task::{
         local::Local,
@@ -209,6 +209,20 @@ impl Task {
 
     pub unsafe fn increment_count(ptr: *const ()) {
         unsafe { &*(ptr as *const Header) }.state.inc();
+    }
+
+    /// Record a waker operation of this task for [`tokio-console`].
+    ///
+    /// This is a no-op unless the `console` feature is enabled.
+    ///
+    /// # Safety
+    ///
+    /// `ptr` must point to a live task allocation.
+    ///
+    /// [`tokio-console`]: crate::console
+    #[inline(always)]
+    pub(crate) unsafe fn record_waker_op(ptr: *const (), op: WakerOp) {
+        unsafe { &*(ptr as *const Header) }.span.waker_op(op);
     }
 
     pub fn schedule(&self) {

--- a/compio-executor/src/waker.rs
+++ b/compio-executor/src/waker.rs
@@ -3,7 +3,7 @@ use std::{
     task::{RawWaker, RawWakerVTable, Waker},
 };
 
-use crate::task::Task;
+use crate::{console::WakerOp, task::Task};
 
 impl Task {
     const VTABLE: &'static RawWakerVTable = {
@@ -17,19 +17,23 @@ impl Task {
 
     #[inline(always)]
     unsafe fn clone_waker(ptr: *const ()) -> RawWaker {
+        unsafe { Task::record_waker_op(ptr, WakerOp::Clone) };
         unsafe { Task::increment_count(ptr) };
         RawWaker::new(ptr, Self::VTABLE)
     }
 
     unsafe fn wake(ptr: *const ()) {
+        unsafe { Task::record_waker_op(ptr, WakerOp::Wake) };
         unsafe { Task::from_raw(ptr) }.schedule();
     }
 
     unsafe fn wake_by_ref(ptr: *const ()) {
+        unsafe { Task::record_waker_op(ptr, WakerOp::WakeByRef) };
         ManuallyDrop::new(unsafe { Task::from_raw(ptr) }).schedule();
     }
 
     unsafe fn drop_waker(ptr: *const ()) {
+        unsafe { Task::record_waker_op(ptr, WakerOp::Drop) };
         drop(unsafe { Task::from_raw(ptr) });
     }
 

--- a/compio-executor/tests/console.rs
+++ b/compio-executor/tests/console.rs
@@ -209,8 +209,9 @@ fn untyped(field: &Field, value: &dyn std::fmt::Debug) -> ! {
     );
 }
 
+#[track_caller]
 fn block_on<F: Future>(exe: &Executor, fut: F) -> F::Output {
-    let fut = console::instrument_block_on(fut);
+    let fut = console::instrument_block_on(SpawnMeta::capture(), fut);
     let cx = &mut Context::from_waker(Waker::noop());
     let mut fut = pin!(fut);
     loop {

--- a/compio-executor/tests/console.rs
+++ b/compio-executor/tests/console.rs
@@ -1,0 +1,336 @@
+//! Assert that the executor emits what [`tokio-console`] expects.
+//!
+//! [`tokio-console`]: https://github.com/tokio-rs/console
+#![cfg(feature = "console")]
+
+use std::{
+    collections::{HashMap, HashSet},
+    future::Future,
+    pin::pin,
+    sync::{Arc, Mutex},
+    task::{Context, Poll, Waker},
+};
+
+use compio_executor::Executor;
+use tracing::{
+    Event, Metadata, Subscriber,
+    field::{Field, Visit},
+    span::{Attributes, Id, Record},
+};
+
+/// Everything we care about a `runtime.spawn` span.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+struct Task {
+    kind: String,
+    id: u64,
+    size: u64,
+    /// Label telling the executors of a thread-per-core application apart,
+    /// which the console displays among the fields of the task.
+    thread: String,
+    file: String,
+    line: u64,
+    /// Number of times the span was entered, which the console reports as the
+    /// number of polls of the task.
+    polls: usize,
+    exits: usize,
+    closed: bool,
+    /// `op` values of the `runtime::waker` events of this task, in order.
+    waker_ops: Vec<String>,
+}
+
+impl Task {
+    fn wakes(&self) -> usize {
+        self.count("waker.wake") + self.count("waker.wake_by_ref")
+    }
+
+    fn count(&self, op: &str) -> usize {
+        self.waker_ops.iter().filter(|it| *it == op).count()
+    }
+
+    /// The console derives the number of live wakers of a task this way, and
+    /// warns about tasks that have lost all of them.
+    fn live_wakers(&self) -> isize {
+        // `Waker::wake` consumes the waker without dropping it.
+        let created = self.count("waker.clone") as isize;
+        let destroyed = (self.count("waker.drop") + self.count("waker.wake")) as isize;
+        created - destroyed
+    }
+}
+
+/// A subscriber recording the same things `console-subscriber` would.
+#[derive(Debug, Default, Clone)]
+struct Recorder(Arc<Mutex<HashMap<u64, Task>>>);
+
+impl Recorder {
+    fn install(&self) -> tracing::subscriber::DefaultGuard {
+        tracing::subscriber::set_default(self.clone())
+    }
+
+    /// The recorded tasks, in the order they were spawned.
+    fn tasks(&self) -> Vec<Task> {
+        let tasks = self.0.lock().unwrap();
+        let mut tasks: Vec<_> = tasks.iter().collect();
+        tasks.sort_unstable_by_key(|(span, _)| **span);
+        tasks.into_iter().map(|(_, task)| task.clone()).collect()
+    }
+
+    /// The only recorded spawned task, ignoring the `block_on` one.
+    fn spawned(&self) -> Task {
+        let mut tasks = self.tasks();
+        tasks.retain(|task| task.kind == "task");
+        assert_eq!(tasks.len(), 1);
+        tasks.into_iter().next().unwrap()
+    }
+
+    fn with(&self, id: &Id, f: impl FnOnce(&mut Task)) {
+        if let Some(task) = self.0.lock().unwrap().get_mut(&id.into_u64()) {
+            f(task);
+        }
+    }
+}
+
+impl Subscriber for Recorder {
+    /// `console-subscriber` recognizes a task by this span name and a waker
+    /// operation by this event target, whatever their other metadata, and
+    /// ignores everything else. Filtering the same way keeps this recorder from
+    /// tripping over the unrelated spans and events of the `enable_log`
+    /// feature.
+    fn enabled(&self, meta: &Metadata<'_>) -> bool {
+        meta.name() == "runtime.spawn" || meta.target() == "runtime::waker"
+    }
+
+    fn new_span(&self, attrs: &Attributes<'_>) -> Id {
+        assert!(
+            attrs.parent().is_none() && attrs.is_root(),
+            "task spans must not be nested, or the console attributes the polls of a task to its \
+             parent"
+        );
+
+        let mut task = Task::default();
+        attrs.record(&mut TaskVisitor(&mut task));
+
+        // The id is only unique among live spans, which is enough here since
+        // the recorder never forgets a task. Hold the lock across the whole
+        // read-modify-write, or two threads pick the same id.
+        let mut tasks = self.0.lock().unwrap();
+        let id = Id::from_u64(tasks.len() as u64 + 1);
+        tasks.insert(id.into_u64(), task);
+        id
+    }
+
+    fn record(&self, _span: &Id, _values: &Record<'_>) {}
+
+    fn record_follows_from(&self, _span: &Id, _follows: &Id) {}
+
+    fn event(&self, event: &Event<'_>) {
+        let mut op = WakerVisitor::default();
+        event.record(&mut op);
+        let (id, op) = (op.id.expect("task.id"), op.op.expect("op"));
+        self.with(&Id::from_u64(id), |task| task.waker_ops.push(op));
+    }
+
+    fn enter(&self, span: &Id) {
+        self.with(span, |task| task.polls += 1);
+    }
+
+    fn exit(&self, span: &Id) {
+        self.with(span, |task| task.exits += 1);
+    }
+
+    fn try_close(&self, span: Id) -> bool {
+        self.with(&span, |task| task.closed = true);
+        true
+    }
+}
+
+struct TaskVisitor<'a>(&'a mut Task);
+
+impl Visit for TaskVisitor<'_> {
+    fn record_u64(&mut self, field: &Field, value: u64) {
+        match field.name() {
+            "task.id" => self.0.id = value,
+            "size.bytes" => self.0.size = value,
+            "loc.line" => self.0.line = value,
+            _ => {}
+        }
+    }
+
+    fn record_str(&mut self, field: &Field, value: &str) {
+        match field.name() {
+            "kind" => self.0.kind = value.to_owned(),
+            "thread" => self.0.thread = value.to_owned(),
+            "loc.file" => self.0.file = value.to_owned(),
+            _ => {}
+        }
+    }
+
+    fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
+        untyped(field, value);
+    }
+}
+
+#[derive(Default)]
+struct WakerVisitor {
+    op: Option<String>,
+    id: Option<u64>,
+}
+
+impl Visit for WakerVisitor {
+    fn record_u64(&mut self, field: &Field, value: u64) {
+        if field.name() == "task.id" {
+            self.id = Some(value);
+        }
+    }
+
+    fn record_str(&mut self, field: &Field, value: &str) {
+        if field.name() == "op" {
+            self.op = Some(value.to_owned());
+        }
+    }
+
+    fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
+        untyped(field, value);
+    }
+}
+
+/// Reject a field recorded without a type of its own.
+///
+/// `console-subscriber` keeps a field recorded that way as an opaque string, so
+/// a field it is supposed to interpret must be recorded with its own type
+/// instead. An `Option` that is `None` records nothing at all, rather than a
+/// `None` for the console to display.
+fn untyped(field: &Field, value: &dyn std::fmt::Debug) -> ! {
+    panic!(
+        "`{}` is recorded as `{value:?}` rather than with a type of its own",
+        field.name()
+    );
+}
+
+fn block_on<F: Future>(exe: &Executor, fut: F) -> F::Output {
+    let fut = compio_executor::console::instrument_block_on(fut);
+    let cx = &mut Context::from_waker(Waker::noop());
+    let mut fut = pin!(fut);
+    loop {
+        if let Poll::Ready(res) = fut.as_mut().poll(cx) {
+            return res;
+        }
+        exe.tick();
+    }
+}
+
+async fn yield_now() {
+    let mut yielded = false;
+    std::future::poll_fn(move |cx| {
+        if yielded {
+            return Poll::Ready(());
+        }
+        yielded = true;
+        cx.waker().wake_by_ref();
+        Poll::Pending
+    })
+    .await
+}
+
+#[test]
+fn spawned_task_is_reported() {
+    let recorder = Recorder::default();
+    let _guard = recorder.install();
+    let exe = Executor::new();
+
+    let line = line!() + 1;
+    let handle = exe.spawn(async {
+        yield_now().await;
+        yield_now().await;
+    });
+    block_on(&exe, handle).unwrap();
+
+    let task = recorder.spawned();
+    assert_eq!(task.file, file!());
+    assert_eq!(task.line, line as u64, "the caller of spawn is reported");
+    assert_ne!(task.size, 0);
+    assert!(!task.thread.is_empty(), "the thread is labelled");
+
+    // Initial poll plus one per yield.
+    assert_eq!(task.polls, 3);
+    assert_eq!(task.exits, task.polls);
+    assert!(task.closed);
+
+    assert_eq!(task.wakes(), 2, "one wake per yield");
+    assert_eq!(
+        task.live_wakers(),
+        0,
+        "wakers must balance out, or the console reports a lost waker: {:?}",
+        task.waker_ops
+    );
+}
+
+#[test]
+fn blocked_on_future_is_reported_as_a_task() {
+    let recorder = Recorder::default();
+    let _guard = recorder.install();
+    let exe = Executor::new();
+
+    block_on(&exe, async {
+        exe.spawn(yield_now()).await.unwrap();
+    });
+
+    let tasks = recorder.tasks();
+    assert_eq!(tasks.len(), 2);
+    assert_eq!(tasks[0].kind, "block_on");
+    assert_eq!(tasks[0].file, file!());
+    assert_eq!(tasks[1].kind, "task");
+    assert!(tasks[0].polls >= 2 && tasks[1].polls >= 2);
+    assert_eq!(tasks[0].live_wakers(), 0);
+    assert_eq!(tasks[1].live_wakers(), 0);
+}
+
+#[test]
+fn task_ids_are_unique_across_executors() {
+    const EXECUTORS: usize = 4;
+
+    let recorder = Recorder::default();
+    // One executor per thread, as a thread-per-core application has.
+    let threads: Vec<_> = (0..EXECUTORS)
+        .map(|it| {
+            let recorder = recorder.clone();
+            std::thread::Builder::new()
+                .name(format!("executor-{it}"))
+                .spawn(move || {
+                    // The subscriber is thread-local, so each thread installs
+                    // the shared recorder for itself.
+                    let _guard = recorder.install();
+                    let exe = Executor::new();
+                    block_on(&exe, exe.spawn(std::future::ready(()))).unwrap();
+                })
+                .expect("spawn a thread")
+        })
+        .collect();
+    for thread in threads {
+        thread.join().expect("the thread shouldn't panic");
+    }
+
+    let tasks = recorder.tasks();
+    let ids: HashSet<_> = tasks.iter().map(|it| it.id).collect();
+    assert_eq!(ids.len(), tasks.len(), "{tasks:?}");
+    // The console displays this to tell the executors apart.
+    let labels: HashSet<_> = tasks.iter().map(|it| it.thread.as_str()).collect();
+    assert_eq!(labels.len(), EXECUTORS, "{labels:?}");
+}
+
+#[test]
+fn dropped_task_closes_its_span() {
+    let recorder = Recorder::default();
+    let _guard = recorder.install();
+    let exe = Executor::new();
+
+    let handle = exe.spawn(std::future::pending::<()>());
+    exe.tick();
+    drop(handle);
+    // Let the executor reclaim the cancelled task.
+    exe.tick();
+    exe.tick();
+
+    let task = recorder.spawned();
+    assert_eq!(task.polls, 1);
+    assert!(task.closed, "the console would show it as running forever");
+}

--- a/compio-executor/tests/console.rs
+++ b/compio-executor/tests/console.rs
@@ -11,7 +11,7 @@ use std::{
     task::{Context, Poll, Waker},
 };
 
-use compio_executor::Executor;
+use compio_executor::{Executor, SpawnMeta, console};
 use tracing::{
     Event, Metadata, Subscriber,
     field::{Field, Visit},
@@ -207,7 +207,7 @@ fn untyped(field: &Field, value: &dyn std::fmt::Debug) -> ! {
 }
 
 fn block_on<F: Future>(exe: &Executor, fut: F) -> F::Output {
-    let fut = compio_executor::console::instrument_block_on(fut);
+    let fut = console::instrument_block_on(fut);
     let cx = &mut Context::from_waker(Waker::noop());
     let mut fut = pin!(fut);
     loop {
@@ -282,6 +282,49 @@ fn blocked_on_future_is_reported_as_a_task() {
     assert!(tasks[0].polls >= 2 && tasks[1].polls >= 2);
     assert_eq!(tasks[0].live_wakers(), 0);
     assert_eq!(tasks[1].live_wakers(), 0);
+}
+
+#[test]
+fn blocking_closure_is_reported_as_a_blocking_task() {
+    let recorder = Recorder::default();
+    let _guard = recorder.install();
+
+    let line = line!() + 1;
+    let f = console::instrument_blocking(SpawnMeta::capture(), {
+        let recorder = recorder.clone();
+        // The console counts one poll per entry of the span and measures the
+        // busy time of the task as the time it stays entered, so the closure
+        // must run while it is.
+        move || recorder.tasks()[0].polls
+    });
+
+    let task = &recorder.tasks()[0];
+    assert_eq!(
+        task.kind, "blocking",
+        "the console skips its future lints for this kind"
+    );
+    assert_eq!(task.file, file!());
+    assert_eq!(task.line, line as u64, "the caller is reported");
+    assert_eq!(task.polls, 0, "the task shows up as soon as it is queued");
+
+    assert_eq!(f(), 1, "the closure runs while the span is entered");
+    let task = &recorder.tasks()[0];
+    assert_eq!(task.exits, 1, "and the span is left afterwards");
+    assert!(task.waker_ops.is_empty(), "a closure has no waker");
+}
+
+#[test]
+fn untracked_task_is_not_reported() {
+    let recorder = Recorder::default();
+    let _guard = recorder.install();
+    let exe = Executor::new();
+
+    let handle = exe.spawn_at(yield_now(), SpawnMeta::untracked());
+    block_on(&exe, handle).unwrap();
+
+    let tasks = recorder.tasks();
+    assert_eq!(tasks.len(), 1, "only the `block_on` task: {tasks:?}");
+    assert_eq!(tasks[0].kind, "block_on");
 }
 
 #[test]

--- a/compio-executor/tests/console.rs
+++ b/compio-executor/tests/console.rs
@@ -23,6 +23,8 @@ use tracing::{
 struct Task {
     kind: String,
     id: u64,
+    /// The console displays this in a column of its own, when present.
+    name: Option<String>,
     size: u64,
     /// Label telling the executors of a thread-per-core application apart,
     /// which the console displays among the fields of the task.
@@ -158,6 +160,7 @@ impl Visit for TaskVisitor<'_> {
     fn record_str(&mut self, field: &Field, value: &str) {
         match field.name() {
             "kind" => self.0.kind = value.to_owned(),
+            "task.name" => self.0.name = Some(value.to_owned()),
             "thread" => self.0.thread = value.to_owned(),
             "loc.file" => self.0.file = value.to_owned(),
             _ => {}
@@ -311,6 +314,33 @@ fn blocking_closure_is_reported_as_a_blocking_task() {
     let task = &recorder.tasks()[0];
     assert_eq!(task.exits, 1, "and the span is left afterwards");
     assert!(task.waker_ops.is_empty(), "a closure has no waker");
+}
+
+#[test]
+fn task_can_be_named() {
+    let recorder = Recorder::default();
+    let _guard = recorder.install();
+    let exe = Executor::new();
+
+    let handle = exe.spawn_at(yield_now(), SpawnMeta::capture().named("named"));
+    block_on(&exe, handle).unwrap();
+
+    assert_eq!(recorder.spawned().name.as_deref(), Some("named"));
+}
+
+#[test]
+fn unnamed_task_has_no_name() {
+    let recorder = Recorder::default();
+    let _guard = recorder.install();
+    let exe = Executor::new();
+
+    block_on(&exe, exe.spawn(yield_now())).unwrap();
+
+    assert_eq!(
+        recorder.spawned().name,
+        None,
+        "the console leaves the column empty rather than showing a placeholder"
+    );
 }
 
 #[test]

--- a/compio-fs/src/lib.rs
+++ b/compio-fs/src/lib.rs
@@ -63,6 +63,23 @@ pub(crate) fn path_string(path: impl AsRef<std::path::Path>) -> io::Result<std::
 use compio_buf::{BufResult, IntoInner};
 use compio_driver::{SharedFd, op::AsyncifyFd};
 
+/// Run `f` on the blocking pool, reporting it to the console under `name`.
+///
+/// The tasks compio spawns itself are named, since their location points into
+/// compio rather than into the code that asked for the work.
+#[allow(dead_code)] // Only some platforms have blocking fallbacks.
+pub(crate) async fn spawn_blocking_named<T: Send + 'static>(
+    name: &'static str,
+    f: impl (FnOnce() -> T) + Send + 'static,
+) -> T {
+    use compio_runtime::{ResumeUnwind, SpawnMeta};
+
+    compio_runtime::spawn_blocking_at(f, SpawnMeta::capture().named(name))
+        .await
+        .resume_unwind()
+        .expect("shouldn't be cancelled")
+}
+
 pub(crate) async fn spawn_blocking_with<T, R, F>(fd: SharedFd<T>, f: F) -> io::Result<R>
 where
     T: Sync + 'static,

--- a/compio-fs/src/metadata/unix.rs
+++ b/compio-fs/src/metadata/unix.rs
@@ -14,7 +14,6 @@ use compio_buf::{BufResult, IntoInner};
 #[cfg(dirfd)]
 use compio_driver::ToSharedFd;
 use compio_driver::op::{CurrentDir, FileAttr, PathStat, Stat};
-use compio_runtime::ResumeUnwind;
 use rustix::fs::FileType as FileTypeInner;
 
 use crate::path_string;
@@ -53,10 +52,10 @@ pub async fn symlink_metadata_at(
 
 pub async fn set_permissions(path: impl AsRef<Path>, perm: Permissions) -> io::Result<()> {
     let path = path.as_ref().to_path_buf();
-    compio_runtime::spawn_blocking(move || std::fs::set_permissions(path, perm))
-        .await
-        .resume_unwind()
-        .expect("shouldn't be cancelled")
+    crate::spawn_blocking_named("fs::set_permissions", move || {
+        std::fs::set_permissions(path, perm)
+    })
+    .await
 }
 
 #[derive(Clone)]

--- a/compio-fs/src/metadata/windows.rs
+++ b/compio-fs/src/metadata/windows.rs
@@ -2,27 +2,25 @@ use std::{io, os::windows::fs::MetadataExt, path::Path, time::SystemTime};
 
 #[cfg(dirfd)]
 use compio_driver::ToSharedFd;
-use compio_runtime::ResumeUnwind;
 
 #[cfg(dirfd)]
 use crate::File;
+use crate::spawn_blocking_named;
 
 pub async fn metadata(path: impl AsRef<Path>) -> io::Result<Metadata> {
     let path = path.as_ref().to_path_buf();
-    compio_runtime::spawn_blocking(move || std::fs::metadata(path))
+    spawn_blocking_named("fs::metadata", move || std::fs::metadata(path))
         .await
-        .resume_unwind()
-        .expect("shouldn't be cancelled")
         .map(Metadata::from)
 }
 
 pub async fn symlink_metadata(path: impl AsRef<Path>) -> io::Result<Metadata> {
     let path = path.as_ref().to_path_buf();
-    compio_runtime::spawn_blocking(move || std::fs::symlink_metadata(path))
-        .await
-        .resume_unwind()
-        .expect("shouldn't be cancelled")
-        .map(Metadata::from)
+    spawn_blocking_named("fs::symlink_metadata", move || {
+        std::fs::symlink_metadata(path)
+    })
+    .await
+    .map(Metadata::from)
 }
 
 #[cfg(dirfd)]
@@ -59,7 +57,7 @@ pub async fn symlink_metadata_at(dir: &File, path: impl AsRef<Path>) -> io::Resu
 
 pub async fn set_permissions(path: impl AsRef<Path>, perm: Permissions) -> io::Result<()> {
     let path = path.as_ref().to_path_buf();
-    compio_runtime::spawn_blocking(move || {
+    spawn_blocking_named("fs::set_permissions", move || {
         // Reduce syscalls at best effort.
         if let Some(p) = perm.original {
             std::fs::set_permissions(&path, p)
@@ -70,8 +68,6 @@ pub async fn set_permissions(path: impl AsRef<Path>, perm: Permissions) -> io::R
         }
     })
     .await
-    .resume_unwind()
-    .expect("shouldn't be cancelled")
 }
 
 #[derive(Clone)]

--- a/compio-fs/src/open_options/windows.rs
+++ b/compio-fs/src/open_options/windows.rs
@@ -2,12 +2,11 @@ use std::{io, os::windows::fs::OpenOptionsExt, path::Path};
 
 #[cfg(dirfd)]
 use compio_driver::ToSharedFd;
-use compio_runtime::ResumeUnwind;
 use windows_sys::Win32::Storage::FileSystem::{
     FILE_FLAG_OVERLAPPED, FILE_SHARE_DELETE, FILE_SHARE_READ, FILE_SHARE_WRITE,
 };
 
-use crate::File;
+use crate::{File, spawn_blocking_named};
 
 #[derive(Clone, Debug)]
 pub struct OpenOptions {
@@ -82,10 +81,7 @@ impl OpenOptions {
     pub async fn open(&self, p: impl AsRef<Path>) -> io::Result<File> {
         let opt = std::fs::OpenOptions::from(self);
         let p = p.as_ref().to_path_buf();
-        let file = compio_runtime::spawn_blocking(move || opt.open(p))
-            .await
-            .resume_unwind()
-            .expect("shouldn't be cancelled")?;
+        let file = spawn_blocking_named("fs::open", move || opt.open(p)).await?;
         File::from_std(file)
     }
 

--- a/compio-fs/src/utils/windows.rs
+++ b/compio-fs/src/utils/windows.rs
@@ -2,61 +2,49 @@ use std::{io, path::Path};
 
 #[cfg(dirfd)]
 use compio_driver::ToSharedFd;
-use compio_runtime::ResumeUnwind;
 
 #[cfg(dirfd)]
 use crate::File;
+use crate::spawn_blocking_named;
 
 pub async fn remove_file(path: impl AsRef<Path>) -> io::Result<()> {
     let path = path.as_ref().to_path_buf();
-    compio_runtime::spawn_blocking(move || std::fs::remove_file(path))
-        .await
-        .resume_unwind()
-        .expect("shouldn't be cancelled")
+    spawn_blocking_named("fs::remove_file", move || std::fs::remove_file(path)).await
 }
 
 pub async fn remove_dir(path: impl AsRef<Path>) -> io::Result<()> {
     let path = path.as_ref().to_path_buf();
-    compio_runtime::spawn_blocking(move || std::fs::remove_dir(path))
-        .await
-        .resume_unwind()
-        .expect("shouldn't be cancelled")
+    spawn_blocking_named("fs::remove_dir", move || std::fs::remove_dir(path)).await
 }
 
 pub async fn rename(from: impl AsRef<Path>, to: impl AsRef<Path>) -> io::Result<()> {
     let from = from.as_ref().to_path_buf();
     let to = to.as_ref().to_path_buf();
-    compio_runtime::spawn_blocking(move || std::fs::rename(from, to))
-        .await
-        .resume_unwind()
-        .expect("shouldn't be cancelled")
+    spawn_blocking_named("fs::rename", move || std::fs::rename(from, to)).await
 }
 
 pub async fn symlink_file(original: impl AsRef<Path>, link: impl AsRef<Path>) -> io::Result<()> {
     let original = original.as_ref().to_path_buf();
     let link = link.as_ref().to_path_buf();
-    compio_runtime::spawn_blocking(move || std::os::windows::fs::symlink_file(original, link))
-        .await
-        .resume_unwind()
-        .expect("shouldn't be cancelled")
+    spawn_blocking_named("fs::symlink_file", move || {
+        std::os::windows::fs::symlink_file(original, link)
+    })
+    .await
 }
 
 pub async fn symlink_dir(original: impl AsRef<Path>, link: impl AsRef<Path>) -> io::Result<()> {
     let original = original.as_ref().to_path_buf();
     let link = link.as_ref().to_path_buf();
-    compio_runtime::spawn_blocking(move || std::os::windows::fs::symlink_dir(original, link))
-        .await
-        .resume_unwind()
-        .expect("shouldn't be cancelled")
+    spawn_blocking_named("fs::symlink_dir", move || {
+        std::os::windows::fs::symlink_dir(original, link)
+    })
+    .await
 }
 
 pub async fn hard_link(original: impl AsRef<Path>, link: impl AsRef<Path>) -> io::Result<()> {
     let original = original.as_ref().to_path_buf();
     let link = link.as_ref().to_path_buf();
-    compio_runtime::spawn_blocking(move || std::fs::hard_link(original, link))
-        .await
-        .resume_unwind()
-        .expect("shouldn't be cancelled")
+    spawn_blocking_named("fs::hard_link", move || std::fs::hard_link(original, link)).await
 }
 
 pub struct DirBuilder;
@@ -68,10 +56,7 @@ impl DirBuilder {
 
     pub async fn create(&self, path: &Path) -> io::Result<()> {
         let path = path.to_path_buf();
-        compio_runtime::spawn_blocking(move || std::fs::create_dir(path))
-            .await
-            .resume_unwind()
-            .expect("shouldn't be cancelled")
+        spawn_blocking_named("fs::create_dir", move || std::fs::create_dir(path)).await
     }
 
     #[cfg(dirfd)]

--- a/compio-net/src/resolve/unix.rs
+++ b/compio-net/src/resolve/unix.rs
@@ -3,14 +3,17 @@ use std::{
     net::{SocketAddr, ToSocketAddrs},
 };
 
-use compio_runtime::ResumeUnwind;
+use compio_runtime::{ResumeUnwind, SpawnMeta};
 
 pub async fn resolve_sock_addrs(
     host: &str,
     port: u16,
 ) -> io::Result<std::vec::IntoIter<SocketAddr>> {
     let host = host.to_string();
-    compio_runtime::spawn_blocking(move || (host, port).to_socket_addrs())
+    // Name the task: its location points here rather than into the code that
+    // asked for the address, since this is an `async fn`.
+    let meta = SpawnMeta::capture().named("resolve");
+    compio_runtime::spawn_blocking_at(move || (host, port).to_socket_addrs(), meta)
         .await
         .resume_unwind()
         .expect("shouldn't be cancelled")

--- a/compio-process/src/unix.rs
+++ b/compio-process/src/unix.rs
@@ -6,12 +6,15 @@ use compio_driver::{
     op::{BufResultExt, Read, ReadManaged, Write},
 };
 use compio_io::{AsyncRead, AsyncReadManaged, AsyncWrite};
-use compio_runtime::{ResumeUnwind, Runtime};
+use compio_runtime::{ResumeUnwind, Runtime, SpawnMeta};
 
 use crate::{ChildStderr, ChildStdin, ChildStdout};
 
 pub async fn child_wait(mut child: process::Child) -> io::Result<process::ExitStatus> {
-    compio_runtime::spawn_blocking(move || child.wait())
+    // Name the task: its location points here rather than into the code that
+    // waited for the child, since this is an `async fn`.
+    let meta = SpawnMeta::capture().named("process::wait");
+    compio_runtime::spawn_blocking_at(move || child.wait(), meta)
         .await
         .resume_unwind()
         .expect("shouldn't be cancelled")

--- a/compio-quic/src/connection.rs
+++ b/compio-quic/src/connection.rs
@@ -393,6 +393,7 @@ pub struct Connecting(Shared<ConnectionInner>);
 impl Connecting {
     conn_fn!();
 
+    #[track_caller]
     pub(crate) fn new(
         handle: ConnectionHandle,
         conn: quinn_proto::Connection,
@@ -405,6 +406,9 @@ impl Connecting {
         ));
         // Name the task: the caller of this is compio rather than user code, so
         // its location alone does not say what the task is.
+        // Unlike the endpoint's worker, this one can be attributed to the user:
+        // every path here is a plain `fn`, so the caller reaches us and the
+        // console tells a connection they made apart from one they accepted.
         let meta = SpawnMeta::capture().named("quic::connection");
         let worker = compio_runtime::spawn_at(
             {

--- a/compio-quic/src/connection.rs
+++ b/compio-quic/src/connection.rs
@@ -9,7 +9,7 @@ use std::{
 
 use compio_buf::bytes::Bytes;
 use compio_log::Instrument;
-use compio_runtime::JoinHandle;
+use compio_runtime::{JoinHandle, SpawnMeta};
 use flume::{Receiver, Sender};
 use futures_util::{
     FutureExt, StreamExt,
@@ -403,10 +403,16 @@ impl Connecting {
         let inner = Shared::new(ConnectionInner::new(
             handle, conn, socket, events_tx, events_rx,
         ));
-        let worker = compio_runtime::spawn({
-            let inner = inner.clone();
-            async move { inner.run().await }.in_current_span()
-        });
+        // Name the task: the caller of this is compio rather than user code, so
+        // its location alone does not say what the task is.
+        let meta = SpawnMeta::capture().named("quic::connection");
+        let worker = compio_runtime::spawn_at(
+            {
+                let inner = inner.clone();
+                async move { inner.run().await }.in_current_span()
+            },
+            meta,
+        );
         inner.state().worker = Some(worker);
         Self(inner)
     }

--- a/compio-quic/src/endpoint.rs
+++ b/compio-quic/src/endpoint.rs
@@ -18,7 +18,7 @@ use compio_log::{Instrument, error};
 #[cfg(rustls)]
 use compio_net::ToSocketAddrsAsync;
 use compio_net::UdpSocket;
-use compio_runtime::JoinHandle;
+use compio_runtime::{JoinHandle, SpawnMeta};
 use flume::{Receiver, Sender, unbounded};
 use futures_util::{FutureExt, StreamExt, future, select, task::AtomicWaker};
 use quinn_proto::{
@@ -229,9 +229,15 @@ impl EndpointInner {
 
     fn respond(&self, buf: Vec<u8>, transmit: Transmit) {
         let socket = self.socket.clone();
-        compio_runtime::spawn(async move {
-            socket.send(buf, &transmit).await;
-        })
+        // Name the task: the caller of this is compio rather than user code, so
+        // its location alone does not say what the task is.
+        let meta = SpawnMeta::capture().named("quic::respond");
+        compio_runtime::spawn_at(
+            async move {
+                socket.send(buf, &transmit).await;
+            },
+            meta,
+        )
         .detach();
     }
 
@@ -430,15 +436,20 @@ impl Endpoint {
             config,
             server_config,
         )?));
-        let worker = compio_runtime::spawn({
-            let inner = inner.clone();
-            async move {
-                if let Err(e) = inner.run().await {
-                    error!("I/O error: {:?}", e);
+        // See the note in `respond` on why this task is named.
+        let meta = SpawnMeta::capture().named("quic::endpoint");
+        let worker = compio_runtime::spawn_at(
+            {
+                let inner = inner.clone();
+                async move {
+                    if let Err(e) = inner.run().await {
+                        error!("I/O error: {:?}", e);
+                    }
                 }
-            }
-            .in_current_span()
-        });
+                .in_current_span()
+            },
+            meta,
+        );
         inner.state.lock().worker = Some(worker);
         Ok(Self {
             inner,

--- a/compio-quic/src/endpoint.rs
+++ b/compio-quic/src/endpoint.rs
@@ -125,6 +125,7 @@ impl EndpointState {
         }
     }
 
+    #[track_caller]
     fn new_connection(
         &mut self,
         handle: ConnectionHandle,
@@ -194,6 +195,7 @@ impl EndpointInner {
         })
     }
 
+    #[track_caller]
     fn connect(
         &self,
         remote: SocketAddr,
@@ -241,6 +243,7 @@ impl EndpointInner {
         .detach();
     }
 
+    #[track_caller]
     pub(crate) fn accept(
         &self,
         incoming: quinn_proto::Incoming,
@@ -436,7 +439,9 @@ impl Endpoint {
             config,
             server_config,
         )?));
-        // See the note in `respond` on why this task is named.
+        // See the note in `respond` on why this task is named. The location
+        // cannot be the user's: `client`, `server` and `bind` all reach us from
+        // an `async fn`, which `#[track_caller]` does not propagate through.
         let meta = SpawnMeta::capture().named("quic::endpoint");
         let worker = compio_runtime::spawn_at(
             {
@@ -498,6 +503,7 @@ impl Endpoint {
     }
 
     /// Connect to a remote endpoint.
+    #[track_caller]
     pub fn connect(
         &self,
         remote: SocketAddr,

--- a/compio-quic/src/incoming.rs
+++ b/compio-quic/src/incoming.rs
@@ -29,6 +29,7 @@ impl Incoming {
 
     /// Attempt to accept this incoming connection (an error may still
     /// occur).
+    #[track_caller]
     pub fn accept(mut self) -> Result<Connecting, ConnectionError> {
         let inner = self.0.take().unwrap();
         Ok(inner.endpoint.accept(inner.incoming, None)?)

--- a/compio-runtime/Cargo.toml
+++ b/compio-runtime/Cargo.toml
@@ -53,6 +53,8 @@ synchrony = { workspace = true, features = ["async_flag"] }
 [features]
 time = []
 async-fd = ["dep:compio-io"]
+# Instrumentation for `tokio-console`. See the `console` module.
+console = ["compio-executor/console"]
 
 current_thread_id = []
 sanitize = []

--- a/compio-runtime/src/lib.rs
+++ b/compio-runtime/src/lib.rs
@@ -242,6 +242,9 @@ impl Runtime {
     ) -> JoinHandle<T> {
         use futures_util::FutureExt;
 
+        // The closure is what the console reports as the blocking task, so the
+        // future waiting for it below is not reported at all.
+        let f = console::instrument_blocking(meta, f);
         let op = Asyncify::new(move || {
             // TODO: Refactor blocking pool and handle panic within worker and propagate it
             // back
@@ -249,7 +252,7 @@ impl Runtime {
             BufResult(Ok(0), res)
         });
         let submit = self.submit(op);
-        self.spawn_at(submit.map(|res| res.1.into_inner()), meta)
+        self.spawn_at(submit.map(|res| res.1.into_inner()), SpawnMeta::untracked())
     }
 
     /// Attach a raw file descriptor/handle/socket to the runtime.

--- a/compio-runtime/src/lib.rs
+++ b/compio-runtime/src/lib.rs
@@ -171,7 +171,16 @@ impl Runtime {
     /// Block on the future till it completes.
     #[track_caller]
     pub fn block_on<F: Future>(&self, future: F) -> F::Output {
-        let future = console::instrument_block_on(SpawnMeta::capture(), future);
+        self.block_on_at(future, SpawnMeta::capture())
+    }
+
+    /// Block on the future till it completes, attributing the task it shows up
+    /// as in the console to the given [`SpawnMeta`].
+    ///
+    /// This is for the runtimes compio blocks on itself, whose location points
+    /// into compio rather than into the code of whoever set them running.
+    pub fn block_on_at<F: Future>(&self, future: F, meta: SpawnMeta) -> F::Output {
+        let future = console::instrument_block_on(meta, future);
         self.enter(|| {
             let waker = self.waker();
             let mut context = Context::from_waker(&waker);

--- a/compio-runtime/src/lib.rs
+++ b/compio-runtime/src/lib.rs
@@ -47,7 +47,7 @@ use compio_buf::{BufResult, IntoInner};
 use compio_driver::{AsRawFd, DriverType, OpCode, Proactor, ProactorBuilder, RawFd, op::Asyncify};
 pub use compio_driver::{BufferPool, ErrorExt};
 use compio_executor::{Executor, ExecutorConfig};
-pub use compio_executor::{JoinHandle, ResumeUnwind};
+pub use compio_executor::{JoinHandle, ResumeUnwind, SpawnMeta, console};
 use compio_log::{debug, instrument};
 
 use crate::affinity::bind_to_cpu_set;
@@ -169,7 +169,9 @@ impl Runtime {
     }
 
     /// Block on the future till it completes.
+    #[track_caller]
     pub fn block_on<F: Future>(&self, future: F) -> F::Output {
+        let future = console::instrument_block_on(SpawnMeta::capture(), future);
         self.enter(|| {
             let waker = self.waker();
             let mut context = Context::from_waker(&waker);
@@ -193,16 +195,50 @@ impl Runtime {
     ///
     /// Spawning a task enables the task to execute concurrently to other tasks.
     /// There is no guarantee that a spawned task will execute to completion.
+    #[track_caller]
     pub fn spawn<F: Future + 'static>(&self, future: F) -> JoinHandle<F::Output> {
-        self.executor.spawn(future)
+        self.spawn_at(future, SpawnMeta::capture())
+    }
+
+    /// Spawns a new asynchronous task, attributing it to `meta` instead of to
+    /// the caller.
+    ///
+    /// This is what wrappers around [`spawn`] want, so that [`tokio-console`]
+    /// blames their own caller instead of themselves. [`SpawnMeta`] is only
+    /// interesting to it, and is a zero-sized no-op without the `console`
+    /// feature.
+    ///
+    /// [`spawn`]: Self::spawn
+    /// [`tokio-console`]: crate::console
+    pub fn spawn_at<F: Future + 'static>(
+        &self,
+        future: F,
+        meta: SpawnMeta,
+    ) -> JoinHandle<F::Output> {
+        self.executor.spawn_at(future, meta)
     }
 
     /// Spawns a blocking task in a new thread, and wait for it.
     ///
     /// The task will not be cancelled even if the future is dropped.
+    #[track_caller]
     pub fn spawn_blocking<T: Send + 'static>(
         &self,
         f: impl (FnOnce() -> T) + Send + 'static,
+    ) -> JoinHandle<T> {
+        self.spawn_blocking_at(f, SpawnMeta::capture())
+    }
+
+    /// Spawns a blocking task in a new thread, attributing it to `meta` instead
+    /// of to the caller.
+    ///
+    /// See [`spawn_at`] for what `meta` is good for.
+    ///
+    /// [`spawn_at`]: Self::spawn_at
+    pub fn spawn_blocking_at<T: Send + 'static>(
+        &self,
+        f: impl (FnOnce() -> T) + Send + 'static,
+        meta: SpawnMeta,
     ) -> JoinHandle<T> {
         use futures_util::FutureExt;
 
@@ -213,7 +249,7 @@ impl Runtime {
             BufResult(Ok(0), res)
         });
         let submit = self.submit(op);
-        self.spawn(submit.map(|res| res.1.into_inner()))
+        self.spawn_at(submit.map(|res| res.1.into_inner()), meta)
     }
 
     /// Attach a raw file descriptor/handle/socket to the runtime.
@@ -494,8 +530,25 @@ impl RuntimeBuilder {
 ///
 /// This method doesn't create runtime. It tries to obtain the current runtime
 /// by [`Runtime::with_current`].
+#[track_caller]
 pub fn spawn<F: Future + 'static>(future: F) -> JoinHandle<F::Output> {
-    Runtime::with_current(|r| r.spawn(future))
+    // Capture outside of the closure: `#[track_caller]` does not reach into it,
+    // so inlining this would attribute every task to the line above.
+    let meta = SpawnMeta::capture();
+    spawn_at(future, meta)
+}
+
+/// Spawns a new asynchronous task, attributing it to `meta` instead of to the
+/// caller.
+///
+/// See [`Runtime::spawn_at`] for what `meta` is good for.
+///
+/// ## Panics
+///
+/// This method doesn't create runtime. It tries to obtain the current runtime
+/// by [`Runtime::with_current`].
+pub fn spawn_at<F: Future + 'static>(future: F, meta: SpawnMeta) -> JoinHandle<F::Output> {
+    Runtime::with_current(|r| r.spawn_at(future, meta))
 }
 
 /// Spawns a blocking task in a new thread, and wait for it.
@@ -506,10 +559,29 @@ pub fn spawn<F: Future + 'static>(future: F) -> JoinHandle<F::Output> {
 ///
 /// This method doesn't create runtime. It tries to obtain the current runtime
 /// by [`Runtime::with_current`].
+#[track_caller]
 pub fn spawn_blocking<T: Send + 'static>(
     f: impl (FnOnce() -> T) + Send + 'static,
 ) -> JoinHandle<T> {
-    Runtime::with_current(|r| r.spawn_blocking(f))
+    // See the note in `spawn` on why this is not inlined below.
+    let meta = SpawnMeta::capture();
+    spawn_blocking_at(f, meta)
+}
+
+/// Spawns a blocking task in a new thread, attributing it to `meta` instead of
+/// to the caller.
+///
+/// See [`Runtime::spawn_at`] for what `meta` is good for.
+///
+/// ## Panics
+///
+/// This method doesn't create runtime. It tries to obtain the current runtime
+/// by [`Runtime::with_current`].
+pub fn spawn_blocking_at<T: Send + 'static>(
+    f: impl (FnOnce() -> T) + Send + 'static,
+    meta: SpawnMeta,
+) -> JoinHandle<T> {
+    Runtime::with_current(|r| r.spawn_blocking_at(f, meta))
 }
 
 /// Submit an operation to the current runtime, and return a future for it.

--- a/compio/Cargo.toml
+++ b/compio/Cargo.toml
@@ -256,6 +256,10 @@ required-features = ["time", "signal", "macros"]
 name = "dispatcher"
 required-features = ["macros", "dispatcher", "sync", "net"]
 
+[[example]]
+name = "console"
+required-features = ["console", "time", "net", "dispatcher", "sync"]
+
 [[bench]]
 name = "fs"
 harness = false

--- a/compio/Cargo.toml
+++ b/compio/Cargo.toml
@@ -191,7 +191,12 @@ compat-all = ["compat-tokio", "compat-futures"]
 enable_log = ["compio-log/enable_log"]
 
 # Instrumentation for `tokio-console`. See `compio::runtime::console`.
-console = ["dep:console-subscriber", "compio-runtime/console", "runtime"]
+console = [
+    "dep:console-subscriber",
+    "compio-runtime/console",
+    "compio-dispatcher?/console",
+    "runtime",
+]
 
 # Nightly features
 allocator_api = ["compio-buf/allocator_api", "compio-io?/allocator_api"]

--- a/compio/Cargo.toml
+++ b/compio/Cargo.toml
@@ -37,6 +37,9 @@ compio-quic = { workspace = true, optional = true }
 compio-ws = { workspace = true, optional = true }
 compio-compat = { workspace = true, optional = true }
 
+# Console
+console-subscriber = { workspace = true, optional = true }
+
 # Shared dev dependencies for all platforms
 [dev-dependencies]
 compio-buf = { workspace = true, features = ["bumpalo"] }
@@ -186,6 +189,9 @@ compat-all = ["compat-tokio", "compat-futures"]
 
 # Logging
 enable_log = ["compio-log/enable_log"]
+
+# Instrumentation for `tokio-console`. See `compio::runtime::console`.
+console = ["dep:console-subscriber", "compio-runtime/console", "runtime"]
 
 # Nightly features
 allocator_api = ["compio-buf/allocator_api", "compio-io?/allocator_api"]

--- a/compio/examples/console.rs
+++ b/compio/examples/console.rs
@@ -1,0 +1,213 @@
+//! Observe a compio application with [`tokio-console`].
+//!
+//! This runs a small echo server on a [`Dispatcher`], so that the console shows
+//! the tasks of a thread-per-core application spread over its worker threads,
+//! next to a handful of tasks that are wrong on purpose, so that it shows the
+//! warnings it can raise about them.
+//!
+//! Run it with the cfg that lets `console-subscriber` instrument a runtime
+//! other than tokio:
+//!
+//! ```sh
+//! RUSTFLAGS="--cfg console_without_tokio_unstable" \
+//!     cargo run --example console --features console,time,net,dispatcher,sync
+//! ```
+//!
+//! Then, in another terminal:
+//!
+//! ```sh
+//! tokio-console
+//! ```
+//!
+//! The task list has a column for the thread a task belongs to, and one for its
+//! name, which is worth setting for the tasks a user did not spawn themselves,
+//! since the location of those points into compio rather than into their code.
+//! Press `w` to sort by warnings, or `t` to look at a single task.
+//!
+//! [`tokio-console`]: https://github.com/tokio-rs/console
+
+use std::{
+    future::poll_fn, hint::black_box, num::NonZeroUsize, task::Poll, thread, time::Duration,
+};
+
+use compio::{
+    BufResult,
+    dispatcher::Dispatcher,
+    io::{AsyncRead, AsyncWriteExt},
+    net::{TcpListener, TcpStream},
+    runtime::{Runtime, SpawnMeta, spawn_at, spawn_blocking_at},
+    time::sleep,
+};
+
+/// Worker threads of the dispatcher, each with an executor of its own.
+const WORKERS: usize = 4;
+
+fn main() {
+    // Install the subscriber before starting any runtime, so that the futures
+    // passed to `block_on` show up as tasks as well.
+    compio::console_subscriber::init();
+
+    // The tasks that misbehave get threads of their own, both to keep them from
+    // disturbing the server and to fill in the thread column. The one that
+    // never yields needs one to itself: it never lets its executor run anything
+    // else, which is the point of the warning about it.
+    let lints = spawn_runtime("compio-lints", lints);
+    let hog = spawn_runtime("compio-hog", never_yields);
+
+    Runtime::new().unwrap().block_on(server());
+
+    lints.join().unwrap();
+    hog.join().unwrap();
+}
+
+/// Run a runtime of its own on a named thread. The console reads the name to
+/// tell the executors of a thread-per-core application apart.
+///
+/// The meta is captured out here rather than in the closure the thread runs,
+/// since `#[track_caller]` does not reach into a closure. Without it both of
+/// these report the `block_on` below as their location, and only the thread
+/// column tells them apart.
+#[track_caller]
+fn spawn_runtime<F: Future<Output = ()> + 'static>(
+    name: &'static str,
+    f: fn() -> F,
+) -> thread::JoinHandle<()> {
+    let meta = SpawnMeta::capture();
+    thread::Builder::new()
+        .name(name.to_owned())
+        .spawn(move || Runtime::new().unwrap().block_on_at(f(), meta))
+        .unwrap()
+}
+
+/// Spawn a named task on the current runtime.
+///
+/// Naming is what [`SpawnMeta`] is for. Without one, the console falls back to
+/// the location of the spawn, which this also records.
+///
+/// A wrapper around a spawn wants `#[track_caller]`, or the location it records
+/// is the one inside the wrapper, and every task spawned through it reports the
+/// same line.
+#[track_caller]
+fn spawn(name: &'static str, f: impl Future<Output = ()> + 'static) {
+    spawn_at(f, SpawnMeta::capture().named(name)).detach();
+}
+
+/// An echo server whose connections are handled by the dispatcher's workers,
+/// driven by clients of our own so that there is always something to look at.
+async fn server() {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    let dispatcher = Dispatcher::builder()
+        .worker_threads(NonZeroUsize::new(WORKERS).unwrap())
+        // Named for the same reason the threads above are.
+        .thread_names(|i| format!("compio-worker-{i}"))
+        .build()
+        .unwrap();
+
+    spawn("load-generator", async move {
+        loop {
+            let mut client = TcpStream::connect(&addr).await.unwrap();
+            client.write_all("hello from compio").await.unwrap();
+            sleep(Duration::from_millis(50)).await;
+        }
+    });
+
+    // A task on the blocking pool, which the console reports as busy while the
+    // closure runs rather than as idle, and as a `blocking` task rather than as
+    // one driven by a future.
+    spawn("blocking-pool", async {
+        loop {
+            spawn_blocking_at(
+                || thread::sleep(Duration::from_millis(200)),
+                SpawnMeta::capture().named("blocking-pool-work"),
+            )
+            .await
+            .unwrap();
+            sleep(Duration::from_millis(300)).await;
+        }
+    });
+
+    // A task that is idle almost all of the time, for contrast: the console
+    // shows where a task's time actually goes.
+    spawn("idle-timer", async {
+        loop {
+            sleep(Duration::from_millis(500)).await;
+        }
+    });
+
+    println!("run `tokio-console` to watch this process");
+
+    loop {
+        let (mut stream, _) = listener.accept().await.unwrap();
+        // Every dispatched closure becomes a task named `dispatch` on whichever
+        // worker picks it up. Dropping the receiver only discards the reply,
+        // the worker still runs the closure.
+        drop(
+            dispatcher
+                .dispatch(move || async move {
+                    let BufResult(read, buf) = stream.read(Vec::with_capacity(32)).await;
+                    read.unwrap();
+                    stream.write_all(buf).await.unwrap();
+                })
+                .unwrap(),
+        );
+    }
+}
+
+/// The tasks that the console warns about, other than the one that never
+/// yields, which needs a thread to itself.
+async fn lints() {
+    // Woken by itself three times for every time the timer wakes it, which is
+    // over the console's default threshold of half of the wakeups.
+    spawn("self-waker", async {
+        loop {
+            for _ in 0..3 {
+                let mut woken = false;
+                poll_fn(|cx| {
+                    if woken {
+                        return Poll::Ready(());
+                    }
+                    woken = true;
+                    cx.waker().wake_by_ref();
+                    Poll::Pending
+                })
+                .await;
+            }
+            sleep(Duration::from_millis(100)).await;
+        }
+    });
+
+    // Pending without ever holding on to the waker, so nothing can ever wake it
+    // again. The console counts the live wakers of a task and warns when a task
+    // that has not finished has none left.
+    spawn("lost-waker", poll_fn(|_| Poll::Pending));
+
+    // A future large enough that the console suggests boxing it: it is measured
+    // at the spawn, and this one holds its buffer across an await.
+    spawn("large-future", async {
+        loop {
+            let buf = [0u8; 8192];
+            sleep(Duration::from_millis(400)).await;
+            black_box(&buf);
+        }
+    });
+
+    std::future::pending().await
+}
+
+/// A task that takes its executor and never gives it back. The console warns
+/// about tasks that have been in their first poll for over a second.
+async fn never_yields() {
+    spawn("never-yields", async {
+        loop {
+            // Blocking work that never reaches an await point, so the executor
+            // cannot take the thread back and the task stays in its very first
+            // poll. Sleeping rather than spinning keeps the example from
+            // pinning a core for as long as it runs.
+            thread::sleep(Duration::from_millis(500));
+        }
+    });
+
+    std::future::pending().await
+}

--- a/compio/src/lib.rs
+++ b/compio/src/lib.rs
@@ -18,6 +18,20 @@
 //! println!("{}", buffer);
 //! # })
 //! ```
+//!
+//! ## Observability
+//! The `console` feature instruments the runtime for [`tokio-console`] and
+//! re-exports [`console_subscriber`], so that an application observing compio
+//! does not have to keep a version of it in step with this one.
+//!
+//! See [`runtime::console`] for the setup it takes, and for what is reported
+//! and what is not.
+//!
+//! [`tokio-console`]: https://github.com/tokio-rs/console
+//! [`console_subscriber`]: https://docs.rs/console-subscriber
+// The module is only there with the `runtime` feature, so the link is spelled
+// out rather than resolved, like the two above.
+//! [`runtime::console`]: https://docs.rs/compio-runtime/latest/compio_runtime/console/
 
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![allow(unused_features)]

--- a/compio/src/lib.rs
+++ b/compio/src/lib.rs
@@ -74,6 +74,8 @@ pub use compio_tls as tls;
 #[cfg(feature = "ws")]
 #[doc(inline)]
 pub use compio_ws as ws;
+#[cfg(feature = "console")]
+pub use console_subscriber;
 #[cfg(feature = "time")]
 #[doc(inline)]
 pub use runtime::time;


### PR DESCRIPTION
Closes nothing; opening this to see whether it's a direction the project wants before going further (see [Follow-ups](#follow-ups)).

## What

Adds a `console` feature that makes compio observable with [tokio-console](https://github.com/tokio-rs/console):

```toml
# Cargo.toml
compio = { version = "*", features = ["console"] }
```

```toml
# .cargo/config.toml
[build]
rustflags = ["--cfg", "console_without_tokio_unstable"]
```

```rust
compio::console_subscriber::init();
compio::runtime::Runtime::new().unwrap().block_on(async { /* ... */ });
```

That's it — no wrapper types, no replacing `spawn` calls. `console-subscriber` is an optional dependency of `compio` and re-exported, so there is nothing else to add or version-match.

## Why this works at all

`console-subscriber` is a plain `tracing_subscriber::Layer`. It does not call a single tokio API to collect its data; it recognizes spans named `runtime.spawn` and events targeting `runtime::waker`. Any executor emitting those can be observed with it. The one tokio-specific bit is an assertion that the runtime is instrumented, for which it explicitly provides the `console_without_tokio_unstable` escape hatch for other runtimes ([console-subscriber/src/lib.rs](https://github.com/tokio-rs/console/blob/main/console-subscriber/src/lib.rs)).

Its gRPC server runs on its own thread with its own current-thread tokio runtime, so it does not touch the compio event loop.

## What it looks like

Running `compio/examples/console.rs`:

```
 ⚠ 1 tasks have woken themselves over 50% of the time
╭Tasks (6)  ▶ Running (1)  ⏸ Idle (3)───────────────────────────────────────────────────────────────────────────
│Warn ID State Name Total▿ Busy  Sched Idle  Polls   Kind     Location                        Fields
│      1 ⏸            6s   101ms 6s    68ms  888326  block_on compio/examples/console.rs:28:29 size.bytes=16  thread=main
│      2 ⏸            6s    12µs 67µs  6s    11      task     compio/examples/console.rs:33:5  size.bytes=120 thread=main
│⚠ 1   3 ⏫           6s   181ms 6s    33µs  888595  task     compio/examples/console.rs:41:5  size.bytes=1   thread=main
│      4 ▶            6s     5s  41µs  540ms 55      task     compio/examples/console.rs:53:5  size.bytes=120 thread=main
│      5 ⏸            6s   443µs 369µs 6s    216     task     compio/examples/console.rs:62:5  size.bytes=256 thread=main
│      6 ⏹            5s    74µs 3µs   5s    2       task     compio/examples/console.rs:76:5  size.bytes=24  thread=main
```

And a task detail view:

```
Target: compio::task            Location: compio/examples/console.rs:33:5
Total  42.00s   Busy 71.94µs (0.00%)   Scheduled 551.59µs (0.00%)   Idle 42.00s (100.00%)
Current wakers: 1   Clones: 77   Drops: 76   Woken: 76 times   Last woken: 190.35ms ago
Poll Times   p10 611ns  p50 971ns   p90 1.26µs  p99 1.77µs   (+ histogram)
Sched Times  p10 3.79µs p50 7.36µs  p90 10.94µs p99 12.61µs  (+ histogram)
```

Verified against real `tokio-console` 0.1.14 / `console-subscriber` 0.5.0 on Linux io_uring: task list, task details with both histograms, waker counts, the self-wake lint and the lost-waker lint all behave correctly.

Since compio is thread-per-core and the console's data model has one runtime per process, the tasks of all executors are listed together, with a `thread` field to tell them apart:

```
│ 1 ⏸ ... block_on ...:8:62  thread=worker-0
│ 2 ⏸ ... block_on ...:8:62  thread=worker-2
│ 3 ⏸ ... task     ...:9:25  thread=worker-0
│ 4 ⏸ ... task     ...:9:25  thread=worker-2
│ 5 ⏸ ... block_on ...:8:62  thread=worker-1
│ 6 ⏸ ... task     ...:9:25  thread=worker-1
```

## How

All of the instrumentation is in the new `compio-executor/src/console/` module, with an `enabled` and a `disabled` variant:

- `Header` gains a `span: TaskSpan` field. Without the feature `TaskSpan` is zero-sized, so the header layout does not change.
- `Task::run` enters the span around the poll: one entry per poll gives the console exactly the poll count and busy time.
- The four `RawWakerVTable` functions in `waker.rs` emit the `runtime::waker` events directly. Doing it inside the executor rather than through a wrapping waker means **no extra allocation and no extra indirection** on the wake path.
- `Executor::spawn` / `Runtime::spawn` / `Runtime::spawn_blocking` / `compio_runtime::spawn` / `spawn_blocking` become `#[track_caller]` so the console reports the real call site. Because `#[track_caller]` only propagates through annotated frames, each of these also gets an `*_at` counterpart taking a `SpawnMeta`, which is a zero-sized no-op without the feature. `Runtime::spawn_at` / `spawn_blocking_at` are public so wrappers can forward their own caller, which `compio-dispatcher` does. `SpawnMeta` also carries an optional `task.name`, which the console gives a column of its own; the address resolver and the dispatcher set it, since their locations point into compio rather than into user code.
- `Runtime::block_on` wraps its future so it shows up as a `block_on` task, like tokio does.
- `spawn_blocking` instruments the closure rather than the future waiting for it, so the time spent in the closure is reported as busy and the wait for a worker as idle. Its `kind` is `blocking`, which is how the console knows to skip the four lints that only make sense for a future (self-wake, lost waker, never-yielded, large future) — the wrapper future trips several of them otherwise. That wrapper is now left unreported, since it stands for work already accounted for.

## Cost

`cargo bench -p compio-executor --bench schedule -- local_wake/10000`, feature off vs. on: within noise (±2%, both directions across runs).

200 tasks × 501 polls, every poll self-waking (adversarial for this instrumentation):

| | ns/poll |
| --- | --- |
| feature off | 16 |
| feature on, no subscriber installed | 18 |
| feature on, `console_subscriber::init()` | ~320 |

So it is free when off, ~2ns/poll when compiled in but unobserved (one no-op `Span::enter`), and the usual tokio-console order of magnitude when actually observed — dominated by `tracing-subscriber` registry dispatch, same as on tokio. Real workloads poll far less pathologically.

Dependency-wise `console-subscriber` pulls in tokio + tonic + hyper + prost, which is why the feature is off by default and not part of `all`.

## Tests

`compio-executor/tests/console.rs` implements a minimal `Subscriber` recording the same things `console-subscriber` does, and asserts the contract rather than the implementation:

- a spawned task gets a span with the expected kind/size/location, entered once per poll and closed at the end;
- task spans are never nested (otherwise the console attributes a child's polls to its parent — [console#440](https://github.com/tokio-rs/console/issues/440));
- waker clones and drops balance out, so the console never reports a live task as having lost its waker;
- the `block_on` future is reported as a task;
- a blocking closure is reported as a blocking task, busy while it runs;
- a task can be named, and an unnamed one reports no name at all;
- an untracked task is not reported;
- task ids stay unique across executors, i.e. across threads;
- a cancelled task closes its span, so it does not linger as "running" forever.

The executor's miri job also runs the existing `executor` test suite with the feature on, since it changes the task allocation.

Checked locally: `cargo clippy --all-features --all-targets -- -Dwarnings`, `cargo doc --workspace --all-features`, `cargo check --features all,nightly,ring,sync --no-default-features` (stub driver), `cargo test -p compio --features all,console`, `cargo miri test -p compio-executor --features console --test executor --test console`, and the loom suite with the feature on.

## Follow-ups

Deliberately left out to keep this reviewable; happy to do them in separate PRs if this lands:

- **Resources tab.** Instrumenting timers as `runtime.resource` and in-flight operations as `runtime.resource.async_op` would let the console show which io_uring/IOCP operation is pending on which task — something tokio-console cannot show for tokio. I prototyped it and it works, but per-operation spans are expensive and numerous enough that they want their own feature, plus a decision on where to draw the line (the `OpCode` level, or the `compio-fs`/`compio-net` level).
- **Attribution through `async fn`s.** The internal wrappers in `compio-net`, `compio-fs`, `compio-process` and `compio-quic` are `async fn`s, and `#[track_caller]` is a no-op on those ([rust#110011](https://github.com/rust-lang/rust/issues/110011)), so they cannot forward a caller location and the tasks they spawn are attributed to them. The ones compio spawns itself are named to make up for it, but fixing it properly means rewriting them as `fn -> impl Future`.

These are all documented as limitations in the `console` module docs.



