### PR TITLE
docs(runtime): document Linux io_uring tuning

### DIFF
--- a/compio-runtime/README.md
+++ b/compio-runtime/README.md
@@ -37,6 +37,40 @@ runtime.block_on(async {
 });
 ```
 
+### Linux io_uring tuning
+
+`Runtime` is thread-local and cannot be sent between threads. Create a runtime
+inside each worker thread when using Compio's thread-per-core model. For
+dispatching work across runtime threads, use the
+[`compio-dispatcher`](https://crates.io/crates/compio-dispatcher) crate.
+
+On Linux, applications that enable Compio's `io-uring` driver can opt in to
+kernel features that reduce task-work overhead. These settings are
+workload-dependent, so benchmark them in the deployment environment rather
+than treating them as universal defaults:
+
+```rust
+use compio::driver::ProactorBuilder;
+use compio::runtime::RuntimeBuilder;
+
+let mut proactor = ProactorBuilder::new();
+proactor
+    // Available on Linux 6.0 and later.
+    .single_issuer(true)
+    // Available on Linux 5.19 and later.
+    .coop_taskrun(true)
+    .taskrun_flag(true);
+
+let runtime = RuntimeBuilder::new()
+    .with_proactor(proactor)
+    .build()
+    .unwrap();
+```
+
+These options are effective only with the `io-uring` feature. `taskrun_flag`
+should be used with `coop_taskrun`; `defer_taskrun` is a separate Linux 6.1+
+option that requires `single_issuer`.
+
 ## Configuration
 
 The runtime can be configured using the `RuntimeBuilder`:

--- a/compio-runtime/README.md
+++ b/compio-runtime/README.md
@@ -37,40 +37,6 @@ runtime.block_on(async {
 });
 ```
 
-### Linux io_uring tuning
-
-`Runtime` is thread-local and cannot be sent between threads. Create a runtime
-inside each worker thread when using Compio's thread-per-core model. For
-dispatching work across runtime threads, use the
-[`compio-dispatcher`](https://crates.io/crates/compio-dispatcher) crate.
-
-On Linux, applications that enable Compio's `io-uring` driver can opt in to
-kernel features that reduce task-work overhead. These settings are
-workload-dependent, so benchmark them in the deployment environment rather
-than treating them as universal defaults:
-
-```rust
-use compio::driver::ProactorBuilder;
-use compio::runtime::RuntimeBuilder;
-
-let mut proactor = ProactorBuilder::new();
-proactor
-    // Available on Linux 6.0 and later.
-    .single_issuer(true)
-    // Available on Linux 5.19 and later.
-    .coop_taskrun(true)
-    .taskrun_flag(true);
-
-let runtime = RuntimeBuilder::new()
-    .with_proactor(proactor)
-    .build()
-    .unwrap();
-```
-
-These options are effective only with the `io-uring` feature. `taskrun_flag`
-should be used with `coop_taskrun`; `defer_taskrun` is a separate Linux 6.1+
-option that requires `single_issuer`.
-
 ## Configuration
 
 The runtime can be configured using the `RuntimeBuilder`:

--- a/compio/src/lib.rs
+++ b/compio/src/lib.rs
@@ -18,6 +18,40 @@
 //! println!("{}", buffer);
 //! # })
 //! ```
+//!
+//! ## Linux `io_uring` tuning
+//!
+//! [`runtime::Runtime`] is thread-local and cannot be sent between threads. Create a
+//! runtime inside each worker thread when using Compio's thread-per-core model. For
+//! dispatching work across runtime threads, use the
+//! [`dispatcher`](https://docs.rs/compio-dispatcher) crate.
+//!
+//! On Linux, applications that enable Compio's `io-uring` driver can opt in to kernel
+//! features that reduce task-work overhead. These settings are workload-dependent, so
+//! benchmark them in the deployment environment rather than treating them as universal
+//! defaults:
+//!
+//! ```rust
+//! use compio::driver::ProactorBuilder;
+//! use compio::runtime::RuntimeBuilder;
+//!
+//! let mut proactor = ProactorBuilder::new();
+//! proactor
+//!     // Available on Linux 6.0 and later.
+//!     .single_issuer(true)
+//!     // Available on Linux 5.19 and later.
+//!     .coop_taskrun(true)
+//!     .taskrun_flag(true);
+//!
+//! let runtime = RuntimeBuilder::new()
+//!     .with_proactor(proactor)
+//!     .build()
+//!     .unwrap();
+//! ```
+//!
+//! These options are effective only with the `io-uring` feature. `taskrun_flag` should
+//! be used with `coop_taskrun`; `defer_taskrun` is a separate Linux 6.1+ option that
+//! requires `single_issuer`.
 
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![allow(unused_features)]


### PR DESCRIPTION
## Summary

- document Compio's thread-local runtime model and point multithreaded users to `compio-dispatcher`
- add a narrowly scoped Linux `io_uring` tuning example for the builder options discussed in #553's linked performance conversation
- state the kernel/version and option-dependency constraints from the public builder API, without making workload-independent performance claims

This contributes one documented slice of #553; it does not close the broader documentation issue.

## Validation

- `git diff --check`
- checked the corresponding `Runtime` and `ProactorBuilder` API documentation in the current source tree
- Cargo is not installed in the local environment, so `cargo fmt --check` and doctests were not run; the PR remains draft pending those checks

Prepared with AI assistance. The stated constraints are source-backed; no local Rust toolchain validation is claimed.