### PR TITLE
style(driver,iour): rewrap a doc comment past the comment width

### DIFF
--- a/compio-driver/src/sys/driver/iour/mod.rs
+++ b/compio-driver/src/sys/driver/iour/mod.rs
@@ -237,8 +237,8 @@ impl Driver {
 
     /// Submit the pending SQEs and wait on completions in a single `enter`
     /// carrying `IORING_ENTER_NO_IOWAIT` so the wait is not charged as iowait
-    /// (see `DriverFlags::NO_IOWAIT`). The crate's `submit_*` helpers cannot add
-    /// custom `EnterFlags`, so this drops to the raw `enter` with
+    /// (see `DriverFlags::NO_IOWAIT`). The crate's `submit_*` helpers cannot
+    /// add custom `EnterFlags`, so this drops to the raw `enter` with
     /// `to_submit = sq_len()` instead of the combined `submit_and_wait`.
     fn submit_and_wait_no_iowait(
         &mut self,


### PR DESCRIPTION
`cargo fmt --all -- --check` has been failing on master since #957 — the line is 81 columns and `comment_width` is 80. Comment only.