### PR TITLE
feat(executor): instrument tasks for tokio-console

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,6 +72,7 @@ slab = "0.4.9"
 socket2 = "0.6.0"
 tempfile = "3.8.1"
 tokio = "1.33.0"
+tracing = { version = "0.1.41", default-features = false, features = ["std"] }
 tracing-subscriber = "0.3.18"
 webpki-roots = "1.0.0"
 widestring = "1.0.2"

--- a/compio-executor/Cargo.toml
+++ b/compio-executor/Cargo.toml
@@ -28,6 +28,7 @@ loom = { version = "0.7", features = ["checkpoint"] }
 
 [dev-dependencies]
 criterion = { workspace = true }
+tracing = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
 
 [target.'cfg(unix)'.dev-dependencies]

--- a/compio-executor/Cargo.toml
+++ b/compio-executor/Cargo.toml
@@ -20,6 +20,9 @@ compio-send-wrapper = { workspace = true }
 crossbeam-queue = { workspace = true }
 slotmap = { workspace = true }
 
+# Console
+tracing = { workspace = true, optional = true }
+
 [target.'cfg(loom)'.dependencies]
 loom = { version = "0.7", features = ["checkpoint"] }
 
@@ -32,6 +35,9 @@ nix = { workspace = true, features = ["resource", "signal"] }
 
 [features]
 enable_log = ["compio-log/enable_log"]
+
+# Instrumentation for `tokio-console`. See the `console` module.
+console = ["dep:tracing"]
 
 [[bench]]
 name = "schedule"

--- a/compio-executor/src/console.rs
+++ b/compio-executor/src/console.rs
@@ -91,7 +91,7 @@ cfg_select! {
 }
 
 pub(crate) use imp::TaskSpan;
-pub use imp::{SpawnMeta, instrument_block_on, instrument_blocking};
+pub use imp::{SpawnMeta, instrument_block_on, instrument_blocking, instrument_execute};
 
 /// An operation on a task's waker, reported as a `runtime::waker` event.
 ///
@@ -161,6 +161,9 @@ mod parity {
         assert_eq!(instrument_blocking(SpawnMeta::untracked(), || 1u8)(), 1);
 
         let fut = instrument_block_on(SpawnMeta::untracked(), std::future::ready(1u8));
+        let _: &dyn Future<Output = u8> = &fut;
+
+        let fut = instrument_execute(SpawnMeta::untracked(), std::future::ready(1u8));
         let _: &dyn Future<Output = u8> = &fut;
     }
 }

--- a/compio-executor/src/console.rs
+++ b/compio-executor/src/console.rs
@@ -55,6 +55,10 @@
 //! * The blocking pool is part of the driver rather than the executor, so a
 //!   task spawned by `spawn_blocking` is reported as an ordinary task waiting
 //!   for an operation, and the time spent in the closure counts as idle.
+//! * A `block_on` nested inside a task — a runtime built within another one —
+//!   reports the two as separate tasks, but both of their spans are entered on
+//!   the same stack. The console attributes the polls to the inner one for as
+//!   long as that is the case.
 //! * The resources tab stays empty: timers and in-flight operations are not
 //!   instrumented yet.
 //! * A task's span is closed even when the thread is unwinding, or the console
@@ -75,7 +79,7 @@ cfg_select! {
     }
 }
 
-pub use imp::SpawnMeta;
+pub use imp::{SpawnMeta, instrument_block_on};
 pub(crate) use imp::TaskSpan;
 
 /// An operation on a task's waker, reported as a `runtime::waker` event.

--- a/compio-executor/src/console.rs
+++ b/compio-executor/src/console.rs
@@ -1,0 +1,69 @@
+//! [`tokio-console`] instrumentation.
+//!
+//! [`tokio-console`] collects its data through [`tracing`] spans and events
+//! that follow a fixed naming convention. It is *not* tied to tokio's internals
+//! in any way, so any executor emitting the same spans and events can be
+//! observed with it.
+//!
+//! Enable the `console` feature to make this executor emit them:
+//!
+//! * every task gets a `runtime.spawn` span, entered while the task is polled,
+//!   so that the console can compute poll counts, busy/idle/scheduled times and
+//!   the poll time histogram.
+//!
+//! When the feature is disabled, all of this compiles down to nothing: the
+//! types in this module become zero-sized and every method an empty inlined
+//! function.
+//!
+//! # Usage
+//!
+//! `console-subscriber` refuses to run unless it can prove that the runtime is
+//! instrumented, which for tokio means the `tokio_unstable` cfg. For other
+//! runtimes it provides the `console_without_tokio_unstable` escape hatch, so a
+//! binary observing compio needs:
+//!
+//! ```toml
+//! # .cargo/config.toml
+//! [build]
+//! rustflags = ["--cfg", "console_without_tokio_unstable"]
+//! ```
+//!
+//! Depending on `console-subscriber` and installing it is then all it takes:
+//!
+//! ```ignore
+//! console_subscriber::init();
+//! compio::runtime::Runtime::new().unwrap().block_on(async {
+//!     // ...
+//! });
+//! ```
+//!
+//! # Limitations
+//!
+//! * The console's data model has one runtime per process, while compio is
+//!   thread-per-core and has one executor per thread. The tasks of all of them
+//!   are listed together; the `thread` field tells them apart.
+//! * The blocking pool is part of the driver rather than the executor, so a
+//!   task spawned by `spawn_blocking` is reported as an ordinary task waiting
+//!   for an operation, and the time spent in the closure counts as idle.
+//! * The resources tab stays empty: timers and in-flight operations are not
+//!   instrumented yet.
+//! * A task's span is closed even when the thread is unwinding, or the console
+//!   would show the task as running forever. The subscriber therefore runs
+//!   during a panic, where a panic of its own aborts instead of unwinding.
+//!
+//! [`tokio-console`]: https://github.com/tokio-rs/console
+//! [`tracing`]: https://docs.rs/tracing
+
+cfg_select! {
+    feature = "console" => {
+        mod enabled;
+        use enabled as imp;
+    }
+    _ => {
+        mod disabled;
+        use disabled as imp;
+    }
+}
+
+pub use imp::SpawnMeta;
+pub(crate) use imp::TaskSpan;

--- a/compio-executor/src/console.rs
+++ b/compio-executor/src/console.rs
@@ -65,7 +65,10 @@
 //! * A task spawned by an `async fn` is attributed to that function rather than
 //!   to its caller, since [`#[track_caller]`][async-track-caller] is a no-op on
 //!   `async fn`s and [`SpawnMeta`] therefore cannot be forwarded through them.
-//!   The ones compio spawns itself are named to make up for it.
+//!   The ones compio spawns itself are named to make up for it. A crate willing
+//!   to build on nightly can lift this for its own `async fn`s with the
+//!   `async_fn_track_caller` feature, which attributes them to the `.await` of
+//!   the future they return.
 //! * The resources tab stays empty: timers and in-flight operations are not
 //!   instrumented yet.
 //! * A task's span is closed even when the thread is unwinding, or the console

--- a/compio-executor/src/console.rs
+++ b/compio-executor/src/console.rs
@@ -9,7 +9,9 @@
 //!
 //! * every task gets a `runtime.spawn` span, entered while the task is polled,
 //!   so that the console can compute poll counts, busy/idle/scheduled times and
-//!   the poll time histogram.
+//!   the poll time histogram;
+//! * every waker operation emits a `runtime::waker` event, so that the console
+//!   can compute waker counts and detect self-wakes and lost wakers.
 //!
 //! When the feature is disabled, all of this compiles down to nothing: the
 //! types in this module become zero-sized and every method an empty inlined
@@ -42,6 +44,14 @@
 //! * The console's data model has one runtime per process, while compio is
 //!   thread-per-core and has one executor per thread. The tasks of all of them
 //!   are listed together; the `thread` field tells them apart.
+//! * The subscriber has to be the global default, which
+//!   `console_subscriber::init` makes it. A span carries the subscriber it was
+//!   created with, but an event goes to whichever one is current on the thread
+//!   emitting it, so a thread-local subscriber misses the waker operations
+//!   other threads perform. Wakers cross threads routinely — that is what
+//!   waking a task from another executor is — and the clone and drop counts of
+//!   one that does no longer balance, leaving the console to report a lost
+//!   waker that is not lost.
 //! * The blocking pool is part of the driver rather than the executor, so a
 //!   task spawned by `spawn_blocking` is reported as an ordinary task waiting
 //!   for an operation, and the time spent in the closure counts as idle.
@@ -67,3 +77,32 @@ cfg_select! {
 
 pub use imp::SpawnMeta;
 pub(crate) use imp::TaskSpan;
+
+/// An operation on a task's waker, reported as a `runtime::waker` event.
+///
+/// Note that [`Waker::wake`](std::task::Waker::wake) does not call the `drop`
+/// implementation, so the console counts [`Self::Wake`] as both a wake and a
+/// drop. Emitting an additional [`Self::Drop`] for it would make the live waker
+/// count (clones - drops) go negative.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum WakerOp {
+    Clone,
+    Drop,
+    Wake,
+    WakeByRef,
+}
+
+impl WakerOp {
+    /// The `op` value of the event, as expected by the console.
+    ///
+    /// Only the enabled variant reports anything, so only it reads this.
+    #[cfg(feature = "console")]
+    pub(crate) const fn as_str(self) -> &'static str {
+        match self {
+            Self::Clone => "waker.clone",
+            Self::Drop => "waker.drop",
+            Self::Wake => "waker.wake",
+            Self::WakeByRef => "waker.wake_by_ref",
+        }
+    }
+}

--- a/compio-executor/src/console.rs
+++ b/compio-executor/src/console.rs
@@ -118,3 +118,46 @@ impl WakerOp {
         }
     }
 }
+/// Assertions that the two variants above present the same surface.
+///
+/// Only one of them is ever compiled, and the one compiled by default is the
+/// one nearly every build uses: a difference between the two shows up as a
+/// build failure for whoever turns the feature on, long after the code that
+/// assumed the other shape was written.
+///
+/// Coercing each item to a function pointer pins its whole signature, and
+/// naming [`EnterGuard`] with a lifetime pins the shape of the guard: the
+/// enabled one borrows the span, so a disabled one that owns itself, and would
+/// let code outlive the span it is timing, does not have a lifetime to name.
+#[cfg(test)]
+mod parity {
+    use std::{fmt::Debug, future::Future};
+
+    use super::{imp::EnterGuard, *};
+
+    const _: fn() -> SpawnMeta = SpawnMeta::capture;
+    const _: fn(SpawnMeta, &'static str) -> SpawnMeta = SpawnMeta::named;
+    const _: fn() -> SpawnMeta = SpawnMeta::untracked;
+
+    const _: fn(SpawnMeta) -> TaskSpan = TaskSpan::new::<()>;
+    const _: for<'a> fn(&'a TaskSpan) -> EnterGuard<'a> = TaskSpan::enter;
+    const _: fn(&TaskSpan, WakerOp) = TaskSpan::waker_op;
+
+    /// [`SpawnMeta`] is copied out of a spawn call rather than moved, and
+    /// reaches the dispatcher's threads through its channel.
+    const fn meta<T: Copy + Send + Sync + Unpin + Debug + 'static>() {}
+    const _: () = meta::<SpawnMeta>();
+
+    /// [`TaskSpan`] sits in the task header, which threads share.
+    const fn span<T: Send + Sync + Debug>() {}
+    const _: () = span::<TaskSpan>();
+
+    /// The wrappers return `impl Trait`, so pin them by use instead.
+    #[test]
+    fn the_wrappers_pass_their_argument_through() {
+        assert_eq!(instrument_blocking(SpawnMeta::untracked(), || 1u8)(), 1);
+
+        let fut = instrument_block_on(std::future::ready(1u8));
+        let _: &dyn Future<Output = u8> = &fut;
+    }
+}

--- a/compio-executor/src/console.rs
+++ b/compio-executor/src/console.rs
@@ -62,6 +62,10 @@
 //! * A blocking task has no waker operations, since it is a closure rather than
 //!   a future. The console knows this from its `kind` and does not report a
 //!   lost waker for it.
+//! * A task spawned by an `async fn` is attributed to that function rather than
+//!   to its caller, since [`#[track_caller]`][async-track-caller] is a no-op on
+//!   `async fn`s and [`SpawnMeta`] therefore cannot be forwarded through them.
+//!   The ones compio spawns itself are named to make up for it.
 //! * The resources tab stays empty: timers and in-flight operations are not
 //!   instrumented yet.
 //! * A task's span is closed even when the thread is unwinding, or the console
@@ -70,6 +74,7 @@
 //!
 //! [`tokio-console`]: https://github.com/tokio-rs/console
 //! [`tracing`]: https://docs.rs/tracing
+//! [async-track-caller]: https://github.com/rust-lang/rust/issues/110011
 
 cfg_select! {
     feature = "console" => {

--- a/compio-executor/src/console.rs
+++ b/compio-executor/src/console.rs
@@ -157,7 +157,7 @@ mod parity {
     fn the_wrappers_pass_their_argument_through() {
         assert_eq!(instrument_blocking(SpawnMeta::untracked(), || 1u8)(), 1);
 
-        let fut = instrument_block_on(std::future::ready(1u8));
+        let fut = instrument_block_on(SpawnMeta::untracked(), std::future::ready(1u8));
         let _: &dyn Future<Output = u8> = &fut;
     }
 }

--- a/compio-executor/src/console.rs
+++ b/compio-executor/src/console.rs
@@ -11,7 +11,10 @@
 //!   so that the console can compute poll counts, busy/idle/scheduled times and
 //!   the poll time histogram;
 //! * every waker operation emits a `runtime::waker` event, so that the console
-//!   can compute waker counts and detect self-wakes and lost wakers.
+//!   can compute waker counts and detect self-wakes and lost wakers;
+//! * a closure handed to the blocking pool gets such a span too, entered around
+//!   the closure instead of around a poll, so that the time spent in it is
+//!   reported as busy time rather than as idle time.
 //!
 //! When the feature is disabled, all of this compiles down to nothing: the
 //! types in this module become zero-sized and every method an empty inlined
@@ -52,13 +55,13 @@
 //!   waking a task from another executor is — and the clone and drop counts of
 //!   one that does no longer balance, leaving the console to report a lost
 //!   waker that is not lost.
-//! * The blocking pool is part of the driver rather than the executor, so a
-//!   task spawned by `spawn_blocking` is reported as an ordinary task waiting
-//!   for an operation, and the time spent in the closure counts as idle.
 //! * A `block_on` nested inside a task — a runtime built within another one —
 //!   reports the two as separate tasks, but both of their spans are entered on
 //!   the same stack. The console attributes the polls to the inner one for as
 //!   long as that is the case.
+//! * A blocking task has no waker operations, since it is a closure rather than
+//!   a future. The console knows this from its `kind` and does not report a
+//!   lost waker for it.
 //! * The resources tab stays empty: timers and in-flight operations are not
 //!   instrumented yet.
 //! * A task's span is closed even when the thread is unwinding, or the console
@@ -79,8 +82,8 @@ cfg_select! {
     }
 }
 
-pub use imp::{SpawnMeta, instrument_block_on};
 pub(crate) use imp::TaskSpan;
+pub use imp::{SpawnMeta, instrument_block_on, instrument_blocking};
 
 /// An operation on a task's waker, reported as a `runtime::waker` event.
 ///

--- a/compio-executor/src/console/disabled.rs
+++ b/compio-executor/src/console/disabled.rs
@@ -21,6 +21,12 @@ impl SpawnMeta {
         Self
     }
 
+    /// Name the task, which the console displays in a column of its own.
+    #[inline(always)]
+    pub fn named(self, _name: &'static str) -> Self {
+        self
+    }
+
     /// Do not report the task to the console at all.
     #[inline(always)]
     pub fn untracked() -> Self {

--- a/compio-executor/src/console/disabled.rs
+++ b/compio-executor/src/console/disabled.rs
@@ -90,6 +90,6 @@ pub fn instrument_blocking<T, F: FnOnce() -> T>(_meta: SpawnMeta, f: F) -> impl 
 /// Plumbing for `compio-runtime`, not covered by this crate's semver.
 #[doc(hidden)]
 #[inline(always)]
-pub fn instrument_block_on<F: Future>(fut: F) -> impl Future<Output = F::Output> {
+pub fn instrument_block_on<F: Future>(_meta: SpawnMeta, fut: F) -> impl Future<Output = F::Output> {
     fut
 }

--- a/compio-executor/src/console/disabled.rs
+++ b/compio-executor/src/console/disabled.rs
@@ -57,3 +57,15 @@ impl TaskSpan {
     #[inline(always)]
     pub(crate) fn waker_op(&self, _op: super::WakerOp) {}
 }
+
+/// Instrument a future blocked on by the runtime, so that it shows up as a
+/// task in the console.
+///
+/// This is a no-op unless the `console` feature is enabled.
+///
+/// Plumbing for `compio-runtime`, not covered by this crate's semver.
+#[doc(hidden)]
+#[inline(always)]
+pub fn instrument_block_on<F: Future>(fut: F) -> impl Future<Output = F::Output> {
+    fut
+}

--- a/compio-executor/src/console/disabled.rs
+++ b/compio-executor/src/console/disabled.rs
@@ -1,0 +1,56 @@
+//! No-op stand-ins used when the `console` feature is disabled.
+
+use std::marker::PhantomData;
+
+/// Metadata of a spawned task, reported to the console.
+///
+/// Zero-sized and inert unless the `console` feature is enabled.
+#[derive(Debug, Clone, Copy)]
+pub struct SpawnMeta;
+
+impl SpawnMeta {
+    /// Capture the location of the caller.
+    ///
+    /// Discards it. The spawns that call this stay `#[track_caller]` either
+    /// way: a feature of this crate cannot reach the wrappers in the crates
+    /// that depend on it, so gating them on one of their own would attribute
+    /// every task to compio itself in a build that enables only this one. The
+    /// implicit argument is dead here, and mostly optimised away.
+    #[inline(always)]
+    pub fn capture() -> Self {
+        Self
+    }
+}
+
+/// The guard returned by [`TaskSpan::enter`].
+///
+/// The enabled variant measures the busy time of a task as the time its guard
+/// is alive, so dropping it right away is a bug that this makes visible in both
+/// configurations. It borrows the span for the same reason: the enabled guard
+/// does, and code that compiles without the feature has to compile with it.
+#[must_use = "the task span is exited as soon as this is dropped"]
+pub(crate) struct Entered<'a>(PhantomData<&'a TaskSpan>);
+
+/// The guard [`TaskSpan::enter`] returns, named the same in both variants so
+/// that the parity assertions can reach it.
+pub(crate) type EnterGuard<'a> = Entered<'a>;
+
+/// The `runtime.spawn` span of a task.
+#[derive(Debug)]
+pub(crate) struct TaskSpan;
+
+impl TaskSpan {
+    #[inline(always)]
+    #[expect(
+        clippy::extra_unused_type_parameters,
+        reason = "mirrors the enabled variant, which records the future's size"
+    )]
+    pub(crate) fn new<F>(_meta: SpawnMeta) -> Self {
+        Self
+    }
+
+    #[inline(always)]
+    pub(crate) fn enter(&self) -> EnterGuard<'_> {
+        Entered(PhantomData)
+    }
+}

--- a/compio-executor/src/console/disabled.rs
+++ b/compio-executor/src/console/disabled.rs
@@ -53,4 +53,7 @@ impl TaskSpan {
     pub(crate) fn enter(&self) -> EnterGuard<'_> {
         Entered(PhantomData)
     }
+
+    #[inline(always)]
+    pub(crate) fn waker_op(&self, _op: super::WakerOp) {}
 }

--- a/compio-executor/src/console/disabled.rs
+++ b/compio-executor/src/console/disabled.rs
@@ -93,3 +93,15 @@ pub fn instrument_blocking<T, F: FnOnce() -> T>(_meta: SpawnMeta, f: F) -> impl 
 pub fn instrument_block_on<F: Future>(_meta: SpawnMeta, fut: F) -> impl Future<Output = F::Output> {
     fut
 }
+
+/// Instrument a future executed by a compatibility layer, so that it shows up
+/// as a task in the console.
+///
+/// This is a no-op unless the `console` feature is enabled.
+///
+/// Plumbing for `compio-compat`, not covered by this crate's semver.
+#[doc(hidden)]
+#[inline(always)]
+pub fn instrument_execute<F: Future>(_meta: SpawnMeta, fut: F) -> impl Future<Output = F::Output> {
+    fut
+}

--- a/compio-executor/src/console/disabled.rs
+++ b/compio-executor/src/console/disabled.rs
@@ -20,6 +20,12 @@ impl SpawnMeta {
     pub fn capture() -> Self {
         Self
     }
+
+    /// Do not report the task to the console at all.
+    #[inline(always)]
+    pub fn untracked() -> Self {
+        Self
+    }
 }
 
 /// The guard returned by [`TaskSpan::enter`].
@@ -56,6 +62,18 @@ impl TaskSpan {
 
     #[inline(always)]
     pub(crate) fn waker_op(&self, _op: super::WakerOp) {}
+}
+
+/// Instrument a closure about to be handed to the blocking pool, so that it
+/// shows up as a blocking task in the console.
+///
+/// This is a no-op unless the `console` feature is enabled.
+///
+/// Plumbing for `compio-runtime`, not covered by this crate's semver.
+#[doc(hidden)]
+#[inline(always)]
+pub fn instrument_blocking<T, F: FnOnce() -> T>(_meta: SpawnMeta, f: F) -> impl FnOnce() -> T {
+    f
 }
 
 /// Instrument a future blocked on by the runtime, so that it shows up as a

--- a/compio-executor/src/console/enabled.rs
+++ b/compio-executor/src/console/enabled.rs
@@ -1,0 +1,108 @@
+//! The actual [`tokio-console`] instrumentation.
+//!
+//! [`tokio-console`]: https://github.com/tokio-rs/console
+
+use std::{
+    mem,
+    panic::Location,
+    sync::atomic::{AtomicU64, Ordering},
+};
+
+use tracing::Span;
+
+/// Target of the task spans. The console accepts any target for spans named
+/// `runtime.spawn`, but the target is displayed, so make it a useful one.
+const TARGET: &str = "compio::task";
+
+/// Id displayed by the console in its `ID` column.
+///
+/// This is deliberately *not* the executor's [`TaskId`], which is a slot index
+/// and thus both reused and duplicated across the executors of a
+/// thread-per-core application.
+///
+/// [`TaskId`]: crate::queue::TaskId
+fn next_task_id() -> u64 {
+    static NEXT: AtomicU64 = AtomicU64::new(1);
+
+    NEXT.fetch_add(1, Ordering::Relaxed)
+}
+
+std::thread_local! {
+    /// Label of the current thread, to tell the tasks of the executors of a
+    /// thread-per-core application apart.
+    static THREAD: String = {
+        let thread = std::thread::current();
+        match thread.name() {
+            Some(name) => name.to_owned(),
+            None => format!("{:?}", thread.id()),
+        }
+    };
+}
+
+fn spawn_span(kind: &'static str, size: usize, loc: &'static Location<'static>) -> Span {
+    fn build(
+        kind: &'static str,
+        size: usize,
+        loc: &'static Location<'static>,
+        thread: &str,
+    ) -> Span {
+        tracing::trace_span!(
+            target: TARGET,
+            // The console attributes polls of a task to the innermost task span
+            // that is entered, so task spans must never be nested.
+            parent: None,
+            "runtime.spawn",
+            kind = kind,
+            task.id = next_task_id(),
+            size.bytes = size,
+            thread = thread,
+            loc.file = loc.file(),
+            loc.line = loc.line(),
+            loc.col = loc.column(),
+        )
+    }
+
+    // The label is gone once the thread tears its locals down, which a task
+    // spawned from another destructor still runs after. Report it unlabelled
+    // rather than panicking on the way out.
+    THREAD
+        .try_with(|thread| build(kind, size, loc, thread.as_str()))
+        .unwrap_or_else(|_| build(kind, size, loc, ""))
+}
+
+/// Metadata of a spawned task, reported to the console.
+///
+/// The disabled variant of this is zero-sized, so nothing here may be
+/// load-bearing outside of the console.
+#[derive(Debug, Clone, Copy)]
+pub struct SpawnMeta(&'static Location<'static>);
+
+impl SpawnMeta {
+    /// Capture the location of the caller.
+    #[inline]
+    #[track_caller]
+    pub fn capture() -> Self {
+        Self(Location::caller())
+    }
+}
+
+/// The guard [`TaskSpan::enter`] returns, named the same in both variants so
+/// that the parity assertions can reach it.
+pub(crate) type EnterGuard<'a> = tracing::span::Entered<'a>;
+
+/// The `runtime.spawn` span of a task.
+#[derive(Debug)]
+pub(crate) struct TaskSpan(Span);
+
+impl TaskSpan {
+    pub(crate) fn new<F>(meta: SpawnMeta) -> Self {
+        Self(spawn_span("task", mem::size_of::<F>(), meta.0))
+    }
+
+    /// Enter the task span. The console measures the time the span is entered
+    /// as the busy time of the task, and counts one poll per entry.
+    #[inline]
+    pub(crate) fn enter(&self) -> EnterGuard<'_> {
+        self.0.enter()
+    }
+}

--- a/compio-executor/src/console/enabled.rs
+++ b/compio-executor/src/console/enabled.rs
@@ -70,8 +70,19 @@ std::thread_local! {
     };
 }
 
-fn spawn_span(kind: TaskKind, size: usize, loc: &'static Location<'static>) -> Span {
-    fn build(kind: TaskKind, size: usize, loc: &'static Location<'static>, thread: &str) -> Span {
+fn spawn_span(
+    kind: TaskKind,
+    size: usize,
+    loc: &'static Location<'static>,
+    name: Option<&'static str>,
+) -> Span {
+    fn build(
+        kind: TaskKind,
+        size: usize,
+        loc: &'static Location<'static>,
+        name: Option<&'static str>,
+        thread: &str,
+    ) -> Span {
         tracing::trace_span!(
             target: TARGET,
             // The console attributes polls of a task to the innermost task span
@@ -80,6 +91,9 @@ fn spawn_span(kind: TaskKind, size: usize, loc: &'static Location<'static>) -> S
             "runtime.spawn",
             kind = kind.as_str(),
             task.id = next_task_id(),
+            // The console gives this field a column of its own, and leaves it
+            // empty for the tasks that do not have it.
+            task.name = name,
             size.bytes = size,
             thread = thread,
             loc.file = loc.file(),
@@ -92,8 +106,8 @@ fn spawn_span(kind: TaskKind, size: usize, loc: &'static Location<'static>) -> S
     // spawned from another destructor still runs after. Report it unlabelled
     // rather than panicking on the way out.
     THREAD
-        .try_with(|thread| build(kind, size, loc, thread.as_str()))
-        .unwrap_or_else(|_| build(kind, size, loc, ""))
+        .try_with(|thread| build(kind, size, loc, name, thread.as_str()))
+        .unwrap_or_else(|_| build(kind, size, loc, name, ""))
 }
 
 fn waker_op(id: u64, op: WakerOp) {
@@ -113,6 +127,7 @@ pub struct SpawnMeta(Option<Reported>);
 #[derive(Debug, Clone, Copy)]
 struct Reported {
     loc: &'static Location<'static>,
+    name: Option<&'static str>,
 }
 
 impl SpawnMeta {
@@ -122,6 +137,19 @@ impl SpawnMeta {
     pub fn capture() -> Self {
         Self(Some(Reported {
             loc: Location::caller(),
+            name: None,
+        }))
+    }
+
+    /// Name the task, which the console displays in a column of its own.
+    ///
+    /// This is worth doing for the tasks a user did not spawn themselves, since
+    /// the location of those points into compio rather than into their code.
+    #[inline]
+    pub fn named(self, name: &'static str) -> Self {
+        Self(self.0.map(|it| Reported {
+            name: Some(name),
+            ..it
         }))
     }
 
@@ -142,7 +170,7 @@ impl SpawnMeta {
     /// nothing downstream has to know about the difference.
     fn span(self, kind: TaskKind, size: usize) -> Span {
         match self.0 {
-            Some(it) => spawn_span(kind, size, it.loc),
+            Some(it) => spawn_span(kind, size, it.loc, it.name),
             None => Span::none(),
         }
     }

--- a/compio-executor/src/console/enabled.rs
+++ b/compio-executor/src/console/enabled.rs
@@ -21,6 +21,30 @@ use super::WakerOp;
 /// `runtime.spawn`, but the target is displayed, so make it a useful one.
 const TARGET: &str = "compio::task";
 
+/// What a task span reports the task as being.
+///
+/// The console considers a task whose kind is not [`Self::Task`] to not be
+/// driven by a future, and skips the lints that only make sense for one: the
+/// self-wake ratio, the lost waker, the never-yielded and the large future
+/// ones.
+#[derive(Debug, Clone, Copy)]
+enum TaskKind {
+    Task,
+    Blocking,
+    BlockOn,
+}
+
+impl TaskKind {
+    /// The `kind` value of the span, as expected by the console.
+    const fn as_str(self) -> &'static str {
+        match self {
+            Self::Task => "task",
+            Self::Blocking => "blocking",
+            Self::BlockOn => "block_on",
+        }
+    }
+}
+
 /// Id displayed by the console in its `ID` column.
 ///
 /// This is deliberately *not* the executor's [`TaskId`], which is a slot index
@@ -46,20 +70,15 @@ std::thread_local! {
     };
 }
 
-fn spawn_span(kind: &'static str, size: usize, loc: &'static Location<'static>) -> Span {
-    fn build(
-        kind: &'static str,
-        size: usize,
-        loc: &'static Location<'static>,
-        thread: &str,
-    ) -> Span {
+fn spawn_span(kind: TaskKind, size: usize, loc: &'static Location<'static>) -> Span {
+    fn build(kind: TaskKind, size: usize, loc: &'static Location<'static>, thread: &str) -> Span {
         tracing::trace_span!(
             target: TARGET,
             // The console attributes polls of a task to the innermost task span
             // that is entered, so task spans must never be nested.
             parent: None,
             "runtime.spawn",
-            kind = kind,
+            kind = kind.as_str(),
             task.id = next_task_id(),
             size.bytes = size,
             thread = thread,
@@ -85,17 +104,47 @@ fn waker_op(id: u64, op: WakerOp) {
 
 /// Metadata of a spawned task, reported to the console.
 ///
-/// The disabled variant of this is zero-sized, so nothing here may be
-/// load-bearing outside of the console.
+/// `None` for a task that is not reported at all. The disabled variant of this
+/// is zero-sized, so nothing here may be load-bearing outside of the console.
 #[derive(Debug, Clone, Copy)]
-pub struct SpawnMeta(&'static Location<'static>);
+pub struct SpawnMeta(Option<Reported>);
+
+/// What is reported about a task, for the tasks that are reported at all.
+#[derive(Debug, Clone, Copy)]
+struct Reported {
+    loc: &'static Location<'static>,
+}
 
 impl SpawnMeta {
     /// Capture the location of the caller.
     #[inline]
     #[track_caller]
     pub fn capture() -> Self {
-        Self(Location::caller())
+        Self(Some(Reported {
+            loc: Location::caller(),
+        }))
+    }
+
+    /// Do not report the task to the console at all.
+    ///
+    /// This is for tasks that only wrap work reported by something else, like
+    /// the future waiting for a blocking closure: reporting both would count
+    /// the same work twice, and hide the interesting one behind a wrapper that
+    /// is idle the whole time.
+    #[inline]
+    pub fn untracked() -> Self {
+        Self(None)
+    }
+
+    /// The span of the task, or a disabled span if it is not to be reported.
+    ///
+    /// Entering a disabled span and asking for its id are both no-ops, so
+    /// nothing downstream has to know about the difference.
+    fn span(self, kind: TaskKind, size: usize) -> Span {
+        match self.0 {
+            Some(it) => spawn_span(kind, size, it.loc),
+            None => Span::none(),
+        }
     }
 }
 
@@ -109,7 +158,7 @@ pub(crate) struct TaskSpan(Span);
 
 impl TaskSpan {
     pub(crate) fn new<F>(meta: SpawnMeta) -> Self {
-        Self(spawn_span("task", mem::size_of::<F>(), meta.0))
+        Self(meta.span(TaskKind::Task, mem::size_of::<F>()))
     }
 
     /// Enter the task span. The console measures the time the span is entered
@@ -215,6 +264,25 @@ impl<F: Future> Future for BlockOn<F> {
     }
 }
 
+/// Instrument a closure about to be handed to the blocking pool, so that it
+/// shows up as a blocking task in the console.
+///
+/// The span is created here rather than on the pool thread, so that the task
+/// shows up as soon as it is queued and the wait for a worker is reported as
+/// idle time. It is entered around the closure itself, so that the time spent
+/// in it is reported as busy time.
+///
+/// Plumbing for `compio-runtime`, not covered by this crate's semver.
+#[doc(hidden)]
+pub fn instrument_blocking<T, F: FnOnce() -> T>(meta: SpawnMeta, f: F) -> impl FnOnce() -> T {
+    let span = meta.span(TaskKind::Blocking, mem::size_of::<F>());
+
+    move || {
+        let _entered = span.enter();
+        f()
+    }
+}
+
 /// Instrument a future blocked on by the runtime, so that it shows up as a
 /// task in the console.
 ///
@@ -222,7 +290,7 @@ impl<F: Future> Future for BlockOn<F> {
 #[doc(hidden)]
 #[track_caller]
 pub fn instrument_block_on<F: Future>(fut: F) -> impl Future<Output = F::Output> {
-    let span = spawn_span("block_on", mem::size_of::<F>(), Location::caller());
+    let span = SpawnMeta::capture().span(TaskKind::BlockOn, mem::size_of::<F>());
     let id = span.id().map(|id| id.into_u64());
 
     BlockOn {

--- a/compio-executor/src/console/enabled.rs
+++ b/compio-executor/src/console/enabled.rs
@@ -5,7 +5,12 @@
 use std::{
     mem,
     panic::Location,
-    sync::atomic::{AtomicU64, Ordering},
+    pin::Pin,
+    sync::{
+        Arc,
+        atomic::{AtomicU64, Ordering},
+    },
+    task::{Context, Poll, Wake, Waker},
 };
 
 use tracing::Span;
@@ -120,5 +125,110 @@ impl TaskSpan {
         if let Some(id) = self.0.id() {
             waker_op(id.into_u64(), op);
         }
+    }
+}
+
+/// A [`Waker`] that reports its operations to the console, on behalf of a task
+/// that is not owned by the executor.
+///
+/// The console derives the number of live wakers of a task from the clone and
+/// drop events, and cloning a [`Waker`] made of an [`Arc`] only bumps its
+/// refcount, which no hook of ours observes. The shim therefore reports the
+/// allocation rather than the handles to it: a `waker.clone` when it is made
+/// and a `waker.drop` when the last handle to it is gone. The console shows one
+/// live waker for as long as the task holds any, instead of how many.
+struct ShimWaker {
+    inner: Waker,
+    id: u64,
+}
+
+impl ShimWaker {
+    fn waker(inner: Waker, id: u64) -> Waker {
+        let this = Arc::new(Self { inner, id });
+        // The shim is a live waker of the task, and its drop reports a
+        // `waker.drop`, so report the matching `waker.clone` here.
+        this.report(WakerOp::Clone);
+        Waker::from(this)
+    }
+
+    #[inline]
+    fn report(&self, op: WakerOp) {
+        waker_op(self.id, op);
+    }
+}
+
+impl Wake for ShimWaker {
+    /// Report the wake as a [`WakerOp::WakeByRef`] even though this one
+    /// consumes a handle: the console counts a [`WakerOp::Wake`] as a drop too,
+    /// since [`Waker::wake`] does not run the [`Drop`] implementation — but the
+    /// [`Arc`] taken here does, once it is the last handle, and the drop would
+    /// be reported twice.
+    fn wake(self: Arc<Self>) {
+        self.wake_by_ref();
+    }
+
+    fn wake_by_ref(self: &Arc<Self>) {
+        self.report(WakerOp::WakeByRef);
+        self.inner.wake_by_ref();
+    }
+}
+
+impl Drop for ShimWaker {
+    fn drop(&mut self) {
+        self.report(WakerOp::Drop);
+    }
+}
+
+/// A future instrumented as a `block_on` task, returned by
+/// [`instrument_block_on`].
+struct BlockOn<F> {
+    span: Span,
+    id: Option<u64>,
+    /// The waker given to us by the runtime and the shim wrapping it, cached to
+    /// avoid rebuilding the shim on every poll.
+    waker: Option<(Waker, Waker)>,
+    fut: F,
+}
+
+impl<F: Future> Future for BlockOn<F> {
+    type Output = F::Output;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        // SAFETY: we never move out of `fut`, and all other fields are `Unpin`.
+        let this = unsafe { self.get_unchecked_mut() };
+        let fut = unsafe { Pin::new_unchecked(&mut this.fut) };
+
+        let _entered = this.span.enter();
+
+        let Some(id) = this.id else {
+            return fut.poll(cx);
+        };
+
+        if !matches!(&this.waker, Some((given, _)) if given.will_wake(cx.waker())) {
+            let given = cx.waker().clone();
+            let shim = ShimWaker::waker(given.clone(), id);
+            this.waker = Some((given, shim));
+        }
+
+        let shim = &this.waker.as_ref().expect("waker was just set").1;
+        fut.poll(&mut Context::from_waker(shim))
+    }
+}
+
+/// Instrument a future blocked on by the runtime, so that it shows up as a
+/// task in the console.
+///
+/// Plumbing for `compio-runtime`, not covered by this crate's semver.
+#[doc(hidden)]
+#[track_caller]
+pub fn instrument_block_on<F: Future>(fut: F) -> impl Future<Output = F::Output> {
+    let span = spawn_span("block_on", mem::size_of::<F>(), Location::caller());
+    let id = span.id().map(|id| id.into_u64());
+
+    BlockOn {
+        span,
+        id,
+        waker: None,
+        fut,
     }
 }

--- a/compio-executor/src/console/enabled.rs
+++ b/compio-executor/src/console/enabled.rs
@@ -23,10 +23,11 @@ const TARGET: &str = "compio::task";
 
 /// What a task span reports the task as being.
 ///
-/// The console considers a task whose kind is not [`Self::Task`] to not be
-/// driven by a future, and skips the lints that only make sense for one: the
-/// self-wake ratio, the lost waker, the never-yielded and the large future
-/// ones.
+/// The console knows [`Self::Blocking`] and [`Self::BlockOn`] by name as the
+/// kinds it does not drive itself, and skips the lints that only make sense
+/// for a task it does: the self-wake ratio, the lost waker, the never-yielded
+/// and the large future ones. It treats every other kind, including one it
+/// does not know, as a task of its own.
 #[derive(Debug, Clone, Copy)]
 enum TaskKind {
     Task,

--- a/compio-executor/src/console/enabled.rs
+++ b/compio-executor/src/console/enabled.rs
@@ -312,6 +312,20 @@ pub fn instrument_blocking<T, F: FnOnce() -> T>(meta: SpawnMeta, f: F) -> impl F
     }
 }
 
+/// Instrument a future executed by a compatibility layer, so that it shows up
+/// as a task in the console.
+///
+/// `compio-compat` executes a future the way the runtime blocks on one, only
+/// driven by a foreign event loop instead of by a loop of its own, so report
+/// it as the same kind of task: the console has none that fits it better, and
+/// would take a kind of its own for one it drives itself.
+///
+/// Plumbing for `compio-compat`, not covered by this crate's semver.
+#[doc(hidden)]
+pub fn instrument_execute<F: Future>(meta: SpawnMeta, fut: F) -> impl Future<Output = F::Output> {
+    instrument_block_on(meta, fut)
+}
+
 /// Instrument a future blocked on by the runtime, so that it shows up as a
 /// task in the console.
 ///

--- a/compio-executor/src/console/enabled.rs
+++ b/compio-executor/src/console/enabled.rs
@@ -10,6 +10,8 @@ use std::{
 
 use tracing::Span;
 
+use super::WakerOp;
+
 /// Target of the task spans. The console accepts any target for spans named
 /// `runtime.spawn`, but the target is displayed, so make it a useful one.
 const TARGET: &str = "compio::task";
@@ -70,6 +72,12 @@ fn spawn_span(kind: &'static str, size: usize, loc: &'static Location<'static>) 
         .unwrap_or_else(|_| build(kind, size, loc, ""))
 }
 
+fn waker_op(id: u64, op: WakerOp) {
+    // `task.id` of a waker event is the *span* id of the task, which is how the
+    // console looks the task up.
+    tracing::trace!(target: "runtime::waker", op = op.as_str(), task.id = id);
+}
+
 /// Metadata of a spawned task, reported to the console.
 ///
 /// The disabled variant of this is zero-sized, so nothing here may be
@@ -104,5 +112,13 @@ impl TaskSpan {
     #[inline]
     pub(crate) fn enter(&self) -> EnterGuard<'_> {
         self.0.enter()
+    }
+
+    /// Record a waker operation on this task.
+    #[inline]
+    pub(crate) fn waker_op(&self, op: WakerOp) {
+        if let Some(id) = self.0.id() {
+            waker_op(id.into_u64(), op);
+        }
     }
 }

--- a/compio-executor/src/console/enabled.rs
+++ b/compio-executor/src/console/enabled.rs
@@ -316,9 +316,8 @@ pub fn instrument_blocking<T, F: FnOnce() -> T>(meta: SpawnMeta, f: F) -> impl F
 ///
 /// Plumbing for `compio-runtime`, not covered by this crate's semver.
 #[doc(hidden)]
-#[track_caller]
-pub fn instrument_block_on<F: Future>(fut: F) -> impl Future<Output = F::Output> {
-    let span = SpawnMeta::capture().span(TaskKind::BlockOn, mem::size_of::<F>());
+pub fn instrument_block_on<F: Future>(meta: SpawnMeta, fut: F) -> impl Future<Output = F::Output> {
+    let span = meta.span(TaskKind::BlockOn, mem::size_of::<F>());
     let id = span.id().map(|id| id.into_u64());
 
     BlockOn {

--- a/compio-executor/src/lib.rs
+++ b/compio-executor/src/lib.rs
@@ -15,6 +15,7 @@ use std::{any::Any, fmt::Debug, ptr::NonNull, task::Waker};
 
 use crate::queue::{TaskId, TaskQueue};
 
+pub mod console;
 mod join_handle;
 mod queue;
 mod task;
@@ -23,6 +24,7 @@ mod waker;
 
 use compio_log::{instrument, trace};
 use compio_send_wrapper::SendWrapper;
+pub use console::SpawnMeta;
 use crossbeam_queue::ArrayQueue;
 pub use join_handle::{JoinError, JoinHandle, ResumeUnwind};
 use util::panic_guard;
@@ -173,12 +175,25 @@ impl Executor {
     }
 
     /// Spawn a future onto the executor.
+    #[track_caller]
     pub fn spawn<F: Future + 'static>(&self, fut: F) -> JoinHandle<F::Output> {
+        self.spawn_at(fut, SpawnMeta::capture())
+    }
+
+    /// Spawn a future onto the executor, attributing it to `meta`.
+    ///
+    /// This is only useful for wrappers around [`spawn`] that want
+    /// [`tokio-console`] to blame their own caller instead of themselves;
+    /// [`SpawnMeta`] is a zero-sized no-op without the `console` feature.
+    ///
+    /// [`spawn`]: Self::spawn
+    /// [`tokio-console`]: crate::console
+    pub fn spawn_at<F: Future + 'static>(&self, fut: F, meta: SpawnMeta) -> JoinHandle<F::Output> {
         let shared = self.shared();
         let tracker = shared.queue.tracker();
         // SAFETY: Executor cannot be sent to ther thread
         let queue = unsafe { shared.queue.get_unchecked() };
-        let task = queue.insert(self.ptr, tracker, fut);
+        let task = queue.insert(self.ptr, tracker, fut, meta);
 
         JoinHandle::new(task)
     }

--- a/compio-executor/src/queue.rs
+++ b/compio-executor/src/queue.rs
@@ -3,7 +3,7 @@ use std::{fmt::Debug, ptr::NonNull};
 use compio_send_wrapper::SendWrapper;
 use slotmap::new_key_type;
 
-use crate::{Shared, task::Task, util::assert_not_impl};
+use crate::{Shared, console::SpawnMeta, task::Task, util::assert_not_impl};
 
 new_key_type! { pub struct TaskId; }
 
@@ -136,12 +136,13 @@ impl TaskQueue {
         shared: NonNull<Shared>,
         tracker: SendWrapper<()>,
         future: F,
+        meta: SpawnMeta,
     ) -> Task {
         unsafe {
             self.with_inner(|inner| {
                 let mut ret = None;
                 let key = inner.map.insert_with_key(|key| {
-                    let [ptr, r] = Task::new::<F, 2>(key, shared, tracker, future);
+                    let [ptr, r] = Task::new::<F, 2>(key, shared, tracker, future, meta);
                     ret = Some(r);
                     Item {
                         prev: None,

--- a/compio-executor/src/task/mod.rs
+++ b/compio-executor/src/task/mod.rs
@@ -14,6 +14,7 @@ use compio_send_wrapper::SendWrapper;
 
 use crate::{
     AtomicPtr, PanicResult, Shared, UnsafeCell,
+    console::{SpawnMeta, TaskSpan},
     queue::TaskId,
     task::{
         local::Local,
@@ -60,6 +61,8 @@ struct Header {
     tracker: ManuallyDrop<SendWrapper<()>>,
     shared: AtomicPtr<Shared>,
     waker: UnsafeCell<MaybeUninit<Waker>>,
+    /// Zero-sized unless the `console` feature is enabled.
+    span: TaskSpan,
 }
 
 union FutureState<F: Future> {
@@ -154,6 +157,11 @@ impl<F: Future + 'static> TaskAlloc<F> {
     }
 
     unsafe fn dealloc(header: NonNull<Header>) {
+        // Unlike `drop_future`, this runs during a panic as well: the header
+        // holds the task's span, and leaking it would leave the task running in
+        // the console forever. The subscriber is then reentered while
+        // unwinding, so a panic inside it aborts rather than unwinds.
+        //
         // SAFETY: The caller guarantees that the pointer is valid and properly aligned
         // for `TaskAlloc<F>`, and that no other reference to the allocation
         // exists.
@@ -167,6 +175,7 @@ impl Task {
         shared: NonNull<Shared>,
         tracker: SendWrapper<()>,
         future: F,
+        meta: SpawnMeta,
     ) -> [Task; N] {
         let alloc = Box::new(TaskAlloc {
             header: Header {
@@ -176,6 +185,7 @@ impl Task {
                 tracker: ManuallyDrop::new(tracker),
                 shared: AtomicPtr::new(shared.as_ptr()),
                 waker: UnsafeCell::new(MaybeUninit::uninit()),
+                span: TaskSpan::new::<F>(meta),
             },
             future: UnsafeCell::new(FutureState {
                 future: ManuallyDrop::new(future),
@@ -238,6 +248,10 @@ impl Task {
             debug!(?state, "Cancelled");
             return Poll::Ready(());
         }
+
+        // The console counts one poll of the task per entry of its span, and
+        // measures the time it stays entered as the busy time of the task.
+        let _entered = header.span.enter();
 
         self.with_waker(|waker| {
             let ctx = &mut Context::from_waker(waker);
@@ -385,8 +399,10 @@ impl Drop for Task {
         // The future/result and waker types are unwind-unsafe (ManuallyDrop in
         // union, MaybeUninit). Dropping them during an existing panic could
         // trigger a second panic, which would be UB. Skip content drops but
-        // still deallocate the memory since dealloc does not run destructors
-        // on the inner types.
+        // still deallocate the memory, since dealloc does not run destructors
+        // on the inner types. (It does run the one of the task span of the
+        // `console` feature, which is wanted: the console would otherwise show
+        // the task as running forever.)
         if ::std::thread::panicking() {
             unsafe { (header.vtable.dealloc)(self.0) }
             return;
@@ -440,9 +456,14 @@ mod test {
         }
     }
 
-    /// All dropping is handled manually by [`Executor`]. The memory is
+    /// All dropping is handled manually by [`Executor`], and the memory is
     /// deallocated by [`Task`].
     ///
+    /// The `console` feature is the one exception: it puts a `tracing` span in
+    /// the header, which is dropped along with the allocation by
+    /// [`TaskAlloc::dealloc`]. Asserting the difference rather than skipping
+    /// the assertion keeps it meaningful in both configurations.
+    ///
     /// [`Executor`]: crate::Executor
-    const _: () = assert!(!needs_drop::<TaskAlloc<NeedsDrop>>());
+    const _: () = assert!(needs_drop::<TaskAlloc<NeedsDrop>>() == cfg!(feature = "console"));
 }

--- a/compio-executor/src/task/mod.rs
+++ b/compio-executor/src/task/mod.rs
@@ -14,7 +14,7 @@ use compio_send_wrapper::SendWrapper;
 
 use crate::{
     AtomicPtr, PanicResult, Shared, UnsafeCell,
-    console::{SpawnMeta, TaskSpan},
+    console::{SpawnMeta, TaskSpan, WakerOp},
     queue::TaskId,
     task::{
         local::Local,
@@ -209,6 +209,20 @@ impl Task {
 
     pub unsafe fn increment_count(ptr: *const ()) {
         unsafe { &*(ptr as *const Header) }.state.inc();
+    }
+
+    /// Record a waker operation of this task for [`tokio-console`].
+    ///
+    /// This is a no-op unless the `console` feature is enabled.
+    ///
+    /// # Safety
+    ///
+    /// `ptr` must point to a live task allocation.
+    ///
+    /// [`tokio-console`]: crate::console
+    #[inline(always)]
+    pub(crate) unsafe fn record_waker_op(ptr: *const (), op: WakerOp) {
+        unsafe { &*(ptr as *const Header) }.span.waker_op(op);
     }
 
     pub fn schedule(&self) {

--- a/compio-executor/src/waker.rs
+++ b/compio-executor/src/waker.rs
@@ -3,7 +3,7 @@ use std::{
     task::{RawWaker, RawWakerVTable, Waker},
 };
 
-use crate::task::Task;
+use crate::{console::WakerOp, task::Task};
 
 impl Task {
     const VTABLE: &'static RawWakerVTable = {
@@ -17,19 +17,23 @@ impl Task {
 
     #[inline(always)]
     unsafe fn clone_waker(ptr: *const ()) -> RawWaker {
+        unsafe { Task::record_waker_op(ptr, WakerOp::Clone) };
         unsafe { Task::increment_count(ptr) };
         RawWaker::new(ptr, Self::VTABLE)
     }
 
     unsafe fn wake(ptr: *const ()) {
+        unsafe { Task::record_waker_op(ptr, WakerOp::Wake) };
         unsafe { Task::from_raw(ptr) }.schedule();
     }
 
     unsafe fn wake_by_ref(ptr: *const ()) {
+        unsafe { Task::record_waker_op(ptr, WakerOp::WakeByRef) };
         ManuallyDrop::new(unsafe { Task::from_raw(ptr) }).schedule();
     }
 
     unsafe fn drop_waker(ptr: *const ()) {
+        unsafe { Task::record_waker_op(ptr, WakerOp::Drop) };
         drop(unsafe { Task::from_raw(ptr) });
     }
 

--- a/compio-executor/tests/console.rs
+++ b/compio-executor/tests/console.rs
@@ -219,8 +219,9 @@ fn untyped(field: &Field, value: &dyn std::fmt::Debug) -> ! {
     );
 }
 
+#[track_caller]
 fn block_on<F: Future>(exe: &Executor, fut: F) -> F::Output {
-    let fut = console::instrument_block_on(fut);
+    let fut = console::instrument_block_on(SpawnMeta::capture(), fut);
     let cx = &mut Context::from_waker(Waker::noop());
     let mut fut = pin!(fut);
     loop {
@@ -366,6 +367,39 @@ fn untracked_task_is_not_reported() {
     let tasks = recorder.tasks();
     assert_eq!(tasks.len(), 1, "only the `block_on` task: {tasks:?}");
     assert_eq!(tasks[0].kind, "block_on");
+}
+
+#[test]
+fn untracked_blocked_on_future_is_not_reported() {
+    let recorder = Recorder::default();
+    let _guard = recorder.install();
+    let exe = Executor::new();
+
+    // The runtime blocks on futures of its own, which it leaves unreported.
+    // Such a task has no id, so it is polled with the waker it was given
+    // rather than a shim reporting the operations on it.
+    let handle = exe.spawn(yield_now());
+    let fut = console::instrument_block_on(SpawnMeta::untracked(), handle);
+    let cx = &mut Context::from_waker(Waker::noop());
+    let mut fut = pin!(fut);
+    loop {
+        if let Poll::Ready(res) = fut.as_mut().poll(cx) {
+            res.unwrap();
+            break;
+        }
+        exe.tick();
+    }
+
+    let tasks = recorder.tasks();
+    assert_eq!(tasks.len(), 1, "only the spawned task: {tasks:?}");
+    assert_eq!(tasks[0].kind, "task");
+    assert_eq!(
+        tasks[0].live_wakers(),
+        0,
+        "an unreported task wraps no waker of its own, so the ones of the task it polls still \
+         balance out: {:?}",
+        tasks[0].waker_ops
+    );
 }
 
 #[test]

--- a/compio-executor/tests/console.rs
+++ b/compio-executor/tests/console.rs
@@ -219,9 +219,9 @@ fn untyped(field: &Field, value: &dyn std::fmt::Debug) -> ! {
     );
 }
 
-#[track_caller]
-fn block_on<F: Future>(exe: &Executor, fut: F) -> F::Output {
-    let fut = console::instrument_block_on(SpawnMeta::capture(), fut);
+/// Poll an instrumented future to completion, ticking the executor whenever it
+/// has nothing to do, the way a runtime drives the future it was handed.
+fn drive<F: Future>(exe: &Executor, fut: F) -> F::Output {
     let cx = &mut Context::from_waker(Waker::noop());
     let mut fut = pin!(fut);
     loop {
@@ -230,6 +230,18 @@ fn block_on<F: Future>(exe: &Executor, fut: F) -> F::Output {
         }
         exe.tick();
     }
+}
+
+#[track_caller]
+fn block_on<F: Future>(exe: &Executor, fut: F) -> F::Output {
+    drive(exe, console::instrument_block_on(SpawnMeta::capture(), fut))
+}
+
+/// Drive a future the way `compio-compat` does: from a foreign event loop,
+/// rather than from one of the runtime's own.
+#[track_caller]
+fn execute<F: Future>(exe: &Executor, fut: F) -> F::Output {
+    drive(exe, console::instrument_execute(SpawnMeta::capture(), fut))
 }
 
 async fn yield_now() {
@@ -329,6 +341,29 @@ fn blocking_closure_is_reported_as_a_blocking_task() {
 }
 
 #[test]
+fn executed_future_is_reported_the_way_a_blocked_on_one_is() {
+    let recorder = Recorder::default();
+    let _guard = recorder.install();
+    let exe = Executor::new();
+
+    execute(&exe, async {
+        exe.spawn(yield_now()).await.unwrap();
+    });
+
+    // Whoever executes the future has to name it to tell it apart from one the
+    // runtime blocks on; the console has no kind of its own for it.
+    let tasks = recorder.tasks();
+    assert_eq!(tasks.len(), 2);
+    assert_eq!(tasks[0].kind, "block_on");
+    assert_eq!(tasks[0].name, None);
+    assert_eq!(tasks[0].file, file!(), "the metadata it was given is used");
+    assert_eq!(tasks[1].kind, "task");
+    assert!(tasks[0].polls >= 2 && tasks[1].polls >= 2);
+    assert_eq!(tasks[0].live_wakers(), 0);
+    assert_eq!(tasks[1].live_wakers(), 0);
+}
+
+#[test]
 fn task_can_be_named() {
     let recorder = Recorder::default();
     let _guard = recorder.install();
@@ -380,15 +415,7 @@ fn untracked_blocked_on_future_is_not_reported() {
     // rather than a shim reporting the operations on it.
     let handle = exe.spawn(yield_now());
     let fut = console::instrument_block_on(SpawnMeta::untracked(), handle);
-    let cx = &mut Context::from_waker(Waker::noop());
-    let mut fut = pin!(fut);
-    loop {
-        if let Poll::Ready(res) = fut.as_mut().poll(cx) {
-            res.unwrap();
-            break;
-        }
-        exe.tick();
-    }
+    drive(&exe, fut).unwrap();
 
     let tasks = recorder.tasks();
     assert_eq!(tasks.len(), 1, "only the spawned task: {tasks:?}");

--- a/compio-executor/tests/console.rs
+++ b/compio-executor/tests/console.rs
@@ -1,0 +1,385 @@
+//! Assert that the executor emits what [`tokio-console`] expects.
+//!
+//! [`tokio-console`]: https://github.com/tokio-rs/console
+#![cfg(feature = "console")]
+
+use std::{
+    collections::{HashMap, HashSet},
+    future::Future,
+    pin::pin,
+    sync::{Arc, Mutex},
+    task::{Context, Poll, Waker},
+};
+
+use compio_executor::Executor;
+use tracing::{
+    Event, Metadata, Subscriber,
+    field::{Field, Visit},
+    span::{Attributes, Id, Record},
+};
+
+/// Everything we care about a `runtime.spawn` span.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+struct Task {
+    kind: String,
+    id: u64,
+    size: u64,
+    /// Label telling the executors of a thread-per-core application apart,
+    /// which the console displays among the fields of the task.
+    thread: String,
+    file: String,
+    line: u64,
+    col: u64,
+    /// Number of times the span was entered, which the console reports as the
+    /// number of polls of the task.
+    polls: usize,
+    exits: usize,
+    closed: bool,
+    /// `op` values of the `runtime::waker` events of this task, in order.
+    waker_ops: Vec<String>,
+}
+
+impl Task {
+    fn wakes(&self) -> usize {
+        self.count("waker.wake") + self.count("waker.wake_by_ref")
+    }
+
+    fn count(&self, op: &str) -> usize {
+        self.waker_ops.iter().filter(|it| *it == op).count()
+    }
+
+    /// The console derives the number of live wakers of a task this way, and
+    /// warns about tasks that have lost all of them.
+    fn live_wakers(&self) -> isize {
+        // `Waker::wake` consumes the waker without dropping it.
+        let created = self.count("waker.clone") as isize;
+        let destroyed = (self.count("waker.drop") + self.count("waker.wake")) as isize;
+        created - destroyed
+    }
+}
+
+/// A subscriber recording the same things `console-subscriber` would.
+#[derive(Debug, Default, Clone)]
+struct Recorder(Arc<Mutex<HashMap<u64, Task>>>);
+
+impl Recorder {
+    /// Install this recorder for the current thread.
+    ///
+    /// Only for the current one: an event reaches whichever subscriber is
+    /// current where it is emitted, not the one its task's span holds, so a
+    /// waker operation performed by a thread without a recorder goes
+    /// unrecorded. No test wakes a task from another thread yet; one that does
+    /// has to install the recorder there too, or watch its waker counts
+    /// silently not balance.
+    fn install(&self) -> tracing::subscriber::DefaultGuard {
+        tracing::subscriber::set_default(self.clone())
+    }
+
+    /// The recorded tasks, in the order they were spawned.
+    fn tasks(&self) -> Vec<Task> {
+        let tasks = self.0.lock().unwrap();
+        let mut tasks: Vec<_> = tasks.iter().collect();
+        tasks.sort_unstable_by_key(|(span, _)| **span);
+        tasks.into_iter().map(|(_, task)| task.clone()).collect()
+    }
+
+    /// The only recorded spawned task, ignoring the `block_on` one.
+    fn spawned(&self) -> Task {
+        let mut tasks = self.tasks();
+        tasks.retain(|task| task.kind == "task");
+        assert_eq!(tasks.len(), 1);
+        tasks.into_iter().next().unwrap()
+    }
+
+    fn with(&self, id: &Id, f: impl FnOnce(&mut Task)) {
+        if let Some(task) = self.0.lock().unwrap().get_mut(&id.into_u64()) {
+            f(task);
+        }
+    }
+}
+
+impl Subscriber for Recorder {
+    /// `console-subscriber` recognizes a task by this span name and a waker
+    /// operation by this event target, whatever their other metadata, and
+    /// ignores everything else. Filtering the same way keeps this recorder from
+    /// tripping over the unrelated spans and events of the `enable_log`
+    /// feature.
+    fn enabled(&self, meta: &Metadata<'_>) -> bool {
+        meta.name() == "runtime.spawn" || meta.target() == "runtime::waker"
+    }
+
+    fn new_span(&self, attrs: &Attributes<'_>) -> Id {
+        assert!(
+            attrs.parent().is_none() && attrs.is_root(),
+            "task spans must not be nested, or the console attributes the polls of a task to its \
+             parent"
+        );
+
+        let mut task = Task::default();
+        attrs.record(&mut TaskVisitor(&mut task));
+
+        // The id is only unique among live spans, which is enough here since
+        // the recorder never forgets a task. Hold the lock across the whole
+        // read-modify-write, or two threads pick the same id.
+        let mut tasks = self.0.lock().unwrap();
+        let id = Id::from_u64(tasks.len() as u64 + 1);
+        tasks.insert(id.into_u64(), task);
+        id
+    }
+
+    fn record(&self, _span: &Id, _values: &Record<'_>) {}
+
+    fn record_follows_from(&self, _span: &Id, _follows: &Id) {}
+
+    fn event(&self, event: &Event<'_>) {
+        let mut op = WakerVisitor::default();
+        event.record(&mut op);
+        let (id, op) = (op.id.expect("task.id"), op.op.expect("op"));
+        self.with(&Id::from_u64(id), |task| task.waker_ops.push(op));
+    }
+
+    fn enter(&self, span: &Id) {
+        self.with(span, |task| task.polls += 1);
+    }
+
+    fn exit(&self, span: &Id) {
+        self.with(span, |task| task.exits += 1);
+    }
+
+    fn try_close(&self, span: Id) -> bool {
+        self.with(&span, |task| task.closed = true);
+        true
+    }
+}
+
+struct TaskVisitor<'a>(&'a mut Task);
+
+impl Visit for TaskVisitor<'_> {
+    fn record_u64(&mut self, field: &Field, value: u64) {
+        match field.name() {
+            "task.id" => self.0.id = value,
+            "size.bytes" => self.0.size = value,
+            "loc.line" => self.0.line = value,
+            "loc.col" => self.0.col = value,
+            _ => {}
+        }
+    }
+
+    fn record_str(&mut self, field: &Field, value: &str) {
+        match field.name() {
+            "kind" => self.0.kind = value.to_owned(),
+            "thread" => self.0.thread = value.to_owned(),
+            "loc.file" => self.0.file = value.to_owned(),
+            _ => {}
+        }
+    }
+
+    fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
+        untyped(field, value);
+    }
+}
+
+#[derive(Default)]
+struct WakerVisitor {
+    op: Option<String>,
+    id: Option<u64>,
+}
+
+impl Visit for WakerVisitor {
+    fn record_u64(&mut self, field: &Field, value: u64) {
+        if field.name() == "task.id" {
+            self.id = Some(value);
+        }
+    }
+
+    fn record_str(&mut self, field: &Field, value: &str) {
+        if field.name() == "op" {
+            self.op = Some(value.to_owned());
+        }
+    }
+
+    fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
+        untyped(field, value);
+    }
+}
+
+/// Reject a field recorded without a type of its own.
+///
+/// `console-subscriber` keeps a field recorded that way as an opaque string, so
+/// a field it is supposed to interpret must be recorded with its own type
+/// instead. An `Option` that is `None` records nothing at all, rather than a
+/// `None` for the console to display.
+fn untyped(field: &Field, value: &dyn std::fmt::Debug) -> ! {
+    panic!(
+        "`{}` is recorded as `{value:?}` rather than with a type of its own",
+        field.name()
+    );
+}
+
+fn block_on<F: Future>(exe: &Executor, fut: F) -> F::Output {
+    let fut = compio_executor::console::instrument_block_on(fut);
+    let cx = &mut Context::from_waker(Waker::noop());
+    let mut fut = pin!(fut);
+    loop {
+        if let Poll::Ready(res) = fut.as_mut().poll(cx) {
+            return res;
+        }
+        exe.tick();
+    }
+}
+
+async fn yield_now() {
+    let mut yielded = false;
+    std::future::poll_fn(move |cx| {
+        if yielded {
+            return Poll::Ready(());
+        }
+        yielded = true;
+        cx.waker().wake_by_ref();
+        Poll::Pending
+    })
+    .await
+}
+
+#[test]
+fn spawned_task_is_reported() {
+    let recorder = Recorder::default();
+    let _guard = recorder.install();
+    let exe = Executor::new();
+
+    let line = line!() + 1;
+    let handle = exe.spawn(async {
+        yield_now().await;
+        yield_now().await;
+    });
+    block_on(&exe, handle).unwrap();
+
+    let task = recorder.spawned();
+    assert_eq!(task.file, file!());
+    assert_eq!(task.line, line as u64, "the caller of spawn is reported");
+    assert_ne!(task.col, 0, "the column is recorded as a number");
+    assert_ne!(task.size, 0);
+    assert!(!task.thread.is_empty(), "the thread is labelled");
+
+    // Initial poll plus one per yield.
+    assert_eq!(task.polls, 3);
+    assert_eq!(task.exits, task.polls);
+    assert!(task.closed);
+
+    assert_eq!(task.wakes(), 2, "one wake per yield");
+    assert_eq!(
+        task.live_wakers(),
+        0,
+        "wakers must balance out, or the console reports a lost waker: {:?}",
+        task.waker_ops
+    );
+}
+
+#[test]
+fn blocked_on_future_is_reported_as_a_task() {
+    let recorder = Recorder::default();
+    let _guard = recorder.install();
+    let exe = Executor::new();
+
+    block_on(&exe, async {
+        exe.spawn(yield_now()).await.unwrap();
+    });
+
+    let tasks = recorder.tasks();
+    assert_eq!(tasks.len(), 2);
+    assert_eq!(tasks[0].kind, "block_on");
+    assert_eq!(tasks[0].file, file!());
+    assert_eq!(tasks[1].kind, "task");
+    assert!(tasks[0].polls >= 2 && tasks[1].polls >= 2);
+    assert_eq!(tasks[0].live_wakers(), 0);
+    assert_eq!(tasks[1].live_wakers(), 0);
+}
+
+#[test]
+fn task_ids_are_unique_across_executors() {
+    const EXECUTORS: usize = 4;
+
+    let recorder = Recorder::default();
+    // One executor per thread, as a thread-per-core application has.
+    let threads: Vec<_> = (0..EXECUTORS)
+        .map(|it| {
+            let recorder = recorder.clone();
+            std::thread::Builder::new()
+                .name(format!("executor-{it}"))
+                .spawn(move || {
+                    // The subscriber is thread-local, so each thread installs
+                    // the shared recorder for itself.
+                    let _guard = recorder.install();
+                    let exe = Executor::new();
+                    block_on(&exe, exe.spawn(std::future::ready(()))).unwrap();
+                })
+                .expect("spawn a thread")
+        })
+        .collect();
+    for thread in threads {
+        thread.join().expect("the thread shouldn't panic");
+    }
+
+    let tasks = recorder.tasks();
+    let ids: HashSet<_> = tasks.iter().map(|it| it.id).collect();
+    assert_eq!(ids.len(), tasks.len(), "{tasks:?}");
+    // The console displays this to tell the executors apart.
+    let labels: HashSet<_> = tasks.iter().map(|it| it.thread.as_str()).collect();
+    assert_eq!(labels.len(), EXECUTORS, "{labels:?}");
+}
+
+#[test]
+fn dropped_task_closes_its_span() {
+    let recorder = Recorder::default();
+    let _guard = recorder.install();
+    let exe = Executor::new();
+
+    let handle = exe.spawn(std::future::pending::<()>());
+    exe.tick();
+    drop(handle);
+    // Let the executor reclaim the cancelled task.
+    exe.tick();
+    exe.tick();
+
+    let task = recorder.spawned();
+    assert_eq!(task.polls, 1);
+    assert!(task.closed, "the console would show it as running forever");
+}
+
+#[test]
+fn panicking_task_closes_its_span() {
+    let recorder = Recorder::default();
+    let _guard = recorder.install();
+    let exe = Executor::new();
+
+    // The executor catches this, so the thread never unwinds and the task ends
+    // like any other. See `task_span_closes_while_unwinding` for the other one.
+    let handle = exe.spawn(async { panic!("task panic") });
+    exe.tick();
+    drop(handle);
+    exe.tick();
+
+    let task = recorder.spawned();
+    assert_eq!(task.polls, 1);
+    assert!(task.closed, "the console would show it as running forever");
+}
+
+#[test]
+fn task_span_closes_while_unwinding() {
+    let recorder = Recorder::default();
+    let _guard = recorder.install();
+
+    // Dropping a task while the thread unwinds deallocates it without running
+    // the future's destructor, but the span is closed all the same.
+    let panicked = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        let exe = Executor::new();
+        let _handle = exe.spawn(std::future::pending::<()>());
+        exe.tick();
+        panic!("unwind through a live task");
+    }));
+
+    assert!(panicked.is_err());
+    let task = recorder.spawned();
+    assert_eq!(task.polls, 1);
+    assert!(task.closed, "the console would show it as running forever");
+}

--- a/compio-executor/tests/console.rs
+++ b/compio-executor/tests/console.rs
@@ -11,7 +11,7 @@ use std::{
     task::{Context, Poll, Waker},
 };
 
-use compio_executor::Executor;
+use compio_executor::{Executor, SpawnMeta, console};
 use tracing::{
     Event, Metadata, Subscriber,
     field::{Field, Visit},
@@ -217,7 +217,7 @@ fn untyped(field: &Field, value: &dyn std::fmt::Debug) -> ! {
 }
 
 fn block_on<F: Future>(exe: &Executor, fut: F) -> F::Output {
-    let fut = compio_executor::console::instrument_block_on(fut);
+    let fut = console::instrument_block_on(fut);
     let cx = &mut Context::from_waker(Waker::noop());
     let mut fut = pin!(fut);
     loop {
@@ -293,6 +293,49 @@ fn blocked_on_future_is_reported_as_a_task() {
     assert!(tasks[0].polls >= 2 && tasks[1].polls >= 2);
     assert_eq!(tasks[0].live_wakers(), 0);
     assert_eq!(tasks[1].live_wakers(), 0);
+}
+
+#[test]
+fn blocking_closure_is_reported_as_a_blocking_task() {
+    let recorder = Recorder::default();
+    let _guard = recorder.install();
+
+    let line = line!() + 1;
+    let f = console::instrument_blocking(SpawnMeta::capture(), {
+        let recorder = recorder.clone();
+        // The console counts one poll per entry of the span and measures the
+        // busy time of the task as the time it stays entered, so the closure
+        // must run while it is.
+        move || recorder.tasks()[0].polls
+    });
+
+    let task = &recorder.tasks()[0];
+    assert_eq!(
+        task.kind, "blocking",
+        "the console skips its future lints for this kind"
+    );
+    assert_eq!(task.file, file!());
+    assert_eq!(task.line, line as u64, "the caller is reported");
+    assert_eq!(task.polls, 0, "the task shows up as soon as it is queued");
+
+    assert_eq!(f(), 1, "the closure runs while the span is entered");
+    let task = &recorder.tasks()[0];
+    assert_eq!(task.exits, 1, "and the span is left afterwards");
+    assert!(task.waker_ops.is_empty(), "a closure has no waker");
+}
+
+#[test]
+fn untracked_task_is_not_reported() {
+    let recorder = Recorder::default();
+    let _guard = recorder.install();
+    let exe = Executor::new();
+
+    let handle = exe.spawn_at(yield_now(), SpawnMeta::untracked());
+    block_on(&exe, handle).unwrap();
+
+    let tasks = recorder.tasks();
+    assert_eq!(tasks.len(), 1, "only the `block_on` task: {tasks:?}");
+    assert_eq!(tasks[0].kind, "block_on");
 }
 
 #[test]

--- a/compio-executor/tests/console.rs
+++ b/compio-executor/tests/console.rs
@@ -23,6 +23,8 @@ use tracing::{
 struct Task {
     kind: String,
     id: u64,
+    /// The console displays this in a column of its own, when present.
+    name: Option<String>,
     size: u64,
     /// Label telling the executors of a thread-per-core application apart,
     /// which the console displays among the fields of the task.
@@ -168,6 +170,7 @@ impl Visit for TaskVisitor<'_> {
     fn record_str(&mut self, field: &Field, value: &str) {
         match field.name() {
             "kind" => self.0.kind = value.to_owned(),
+            "task.name" => self.0.name = Some(value.to_owned()),
             "thread" => self.0.thread = value.to_owned(),
             "loc.file" => self.0.file = value.to_owned(),
             _ => {}
@@ -322,6 +325,33 @@ fn blocking_closure_is_reported_as_a_blocking_task() {
     let task = &recorder.tasks()[0];
     assert_eq!(task.exits, 1, "and the span is left afterwards");
     assert!(task.waker_ops.is_empty(), "a closure has no waker");
+}
+
+#[test]
+fn task_can_be_named() {
+    let recorder = Recorder::default();
+    let _guard = recorder.install();
+    let exe = Executor::new();
+
+    let handle = exe.spawn_at(yield_now(), SpawnMeta::capture().named("named"));
+    block_on(&exe, handle).unwrap();
+
+    assert_eq!(recorder.spawned().name.as_deref(), Some("named"));
+}
+
+#[test]
+fn unnamed_task_has_no_name() {
+    let recorder = Recorder::default();
+    let _guard = recorder.install();
+    let exe = Executor::new();
+
+    block_on(&exe, exe.spawn(yield_now())).unwrap();
+
+    assert_eq!(
+        recorder.spawned().name,
+        None,
+        "the console leaves the column empty rather than showing a placeholder"
+    );
 }
 
 #[test]

--- a/compio-log/Cargo.toml
+++ b/compio-log/Cargo.toml
@@ -9,7 +9,7 @@ license = { workspace = true }
 repository = { workspace = true }
 
 [dependencies]
-tracing = { version = "0.1", default-features = false }
+tracing = { workspace = true }
 
 [dev-dependencies]
 tracing-subscriber = { workspace = true }


### PR DESCRIPTION
Instruments the executor for `tokio-console`, behind a `console` feature.
Without it every type here is zero-sized and does nothing.

Tasks get a `runtime.spawn` span, wakers emit `runtime::waker` events, and
`block_on` and the blocking pool report as tasks of their own kind so the
console's lints do not misjudge them.

`console-subscriber` needs `--cfg console_without_tokio_unstable`; that and
the rest of the limitations are documented in the `console` module.

The spawns are `#[track_caller]` unconditionally, so the console reports the
call site rather than compio's own line. Gating that on the feature does not
work: features do not propagate backwards, so a build that enables
`compio-executor/console` without `compio-runtime/console` would silently
attribute every task to `compio-runtime/src/lib.rs`. Tokio does the same, and
for what it costs — with the feature off, dropping the attributes moves
`.text` by 0.05% in the `dispatcher` example, in either direction depending on
how the implicit argument lands in the inliner.

First of six, tracked in #988. The rest follow as this one lands.
