### PR TITLE
style: format the cfg_select! bodies

### DIFF
--- a/compio-driver/src/control.rs
+++ b/compio-driver/src/control.rs
@@ -6,7 +6,7 @@ use crate::{DriverType, OpCode};
 
 cfg_select! {
     fusion => {
-        use crate::{PollOpCode, IourOpCode};
+        use crate::{IourOpCode, PollOpCode};
     }
     io_uring => {
         use crate::OpCode as IourOpCode;

--- a/compio-driver/src/sys/op/mod.rs
+++ b/compio-driver/src/sys/op/mod.rs
@@ -14,8 +14,9 @@ cfg_select! {
     unix => {
         mod_use![unix];
 
-        pub use crate::sys::pal::{CurrentDir, FileAttr, Interest};
         pub use rustix::fs::{Mode, OFlags, Stat};
+
+        pub use crate::sys::pal::{CurrentDir, FileAttr, Interest};
     }
     _ => {}
 }

--- a/compio-driver/src/sys/sys_slice.rs
+++ b/compio-driver/src/sys/sys_slice.rs
@@ -10,6 +10,7 @@ use compio_buf::{IoBuf, IoBufMut, IoVectoredBuf, IoVectoredBufMut};
 cfg_select! {
     unix => {
         use std::mem::MaybeUninit;
+
         use libc::iovec as Inner;
 
         fn new(ptr: *mut MaybeUninit<u8>, len: usize) -> Inner {
@@ -21,6 +22,7 @@ cfg_select! {
     }
     windows => {
         use std::mem::MaybeUninit;
+
         use windows_sys::Win32::Networking::WinSock::WSABUF as Inner;
 
         fn new(ptr: *mut MaybeUninit<u8>, len: usize) -> Inner {

--- a/compio-executor/src/lib.rs
+++ b/compio-executor/src/lib.rs
@@ -29,15 +29,10 @@ use util::panic_guard;
 
 cfg_select! {
     loom => {
-        use loom::cell::UnsafeCell;
-        use loom::hint;
-        use loom::thread::yield_now;
-        use loom::sync::atomic::*;
+        use loom::{cell::UnsafeCell, hint, sync::atomic::*, thread::yield_now};
     }
     _ => {
-        use std::hint;
-        use std::thread::yield_now;
-        use std::sync::atomic::*;
+        use std::{hint, sync::atomic::*, thread::yield_now};
 
         #[repr(transparent)]
         struct UnsafeCell<T>(std::cell::UnsafeCell<T>);

--- a/compio-net/src/socket/mod.rs
+++ b/compio-net/src/socket/mod.rs
@@ -35,13 +35,19 @@ use crate::Incoming;
 
 cfg_select! {
     any(
-        target_os = "linux", target_os = "android",
+        target_os = "linux",
+        target_os = "android",
         target_os = "hurd",
-        target_os = "dragonfly", target_os = "freebsd",
-        target_os = "openbsd", target_os = "netbsd",
-        target_os = "solaris", target_os = "illumos",
-        target_os = "haiku", target_os = "nto",
-        target_os = "cygwin") => {
+        target_os = "dragonfly",
+        target_os = "freebsd",
+        target_os = "openbsd",
+        target_os = "netbsd",
+        target_os = "solaris",
+        target_os = "illumos",
+        target_os = "haiku",
+        target_os = "nto",
+        target_os = "cygwin"
+    ) => {
         pub(crate) const MSG_NOSIGNAL: SendFlags =
             SendFlags::from_bits_retain(libc::MSG_NOSIGNAL as _);
     }


### PR DESCRIPTION
`cfg_select!` bodies are formatted as of nightly 2026-07-31, so the crate's
import rules reach inside them for the first time and `cargo fmt --check`
fails on master. This is just what `cargo fmt` does.

Blocking #987.
