### PR TITLE
fix(quic): inverted assert in SendStreamUnframed

### DIFF
--- a/compio-quic/src/send_stream.rs
+++ b/compio-quic/src/send_stream.rs
@@ -537,7 +537,7 @@ pub(crate) mod h3_impl {
         ) -> Poll<Result<usize, StreamErrorIncoming>> {
             // This signifies a bug in implementation
             debug_assert!(
-                self.buf.is_some(),
+                self.buf.is_none(),
                 "poll_send called while send stream is not ready"
             );
 


### PR DESCRIPTION
Reference implementation, `h3-quinn`, panics if buffer `is_some`:
https://github.com/hyperium/h3/blob/c38a1af632afbbbc8f6716c196ad67f40bc122e3/h3-quinn/src/lib.rs#L559-L561

Pre-fix implementation, instead, proceeds if buffer `is_some` and panics otherwise:
https://github.com/compio-rs/compio/blob/64eab17ef0582b510a9168aa998b8338ed7c5d2f/compio-quic/src/send_stream.rs#L539-L542