### PR TITLE
feat(runtime): shut down the write side when closing a PollFd

### DIFF
--- a/compio-net/tests/poll.rs
+++ b/compio-net/tests/poll.rs
@@ -2,6 +2,7 @@ use std::{
     io::{self, IoSlice},
     net::{Ipv4Addr, SocketAddrV4},
     pin::Pin,
+    time::Duration,
 };
 
 use compio_runtime::fd::PollFd;
@@ -109,6 +110,62 @@ async fn poll_write_vectored() {
 
     assert_eq!(read, 12);
     assert_eq!(buffer, b"Hello world!");
+}
+
+#[compio_macros::test]
+async fn poll_close_half_closes() {
+    let (mut tx, rx) = connected_pair();
+
+    futures_util::AsyncWriteExt::write_all(&mut tx, b"Hello world!")
+        .await
+        .unwrap();
+    futures_util::AsyncWriteExt::close(&mut tx).await.unwrap();
+
+    // The peer must see EOF while `tx` is still alive, so this cannot be the
+    // FIN that the kernel sends when the descriptor is dropped.
+    let mut buffer = Vec::with_capacity(32);
+    let read_to_eof = async {
+        let mut total = 0;
+        loop {
+            let read = std::future::poll_fn(|cx| {
+                rx.poll_read_with(cx, |rx| {
+                    let n = rx.recv(&mut buffer.spare_capacity_mut()[total..])?;
+                    unsafe { buffer.set_len(total + n) };
+                    Ok(n)
+                })
+            })
+            .await
+            .unwrap();
+            if read == 0 {
+                break;
+            }
+            total += read;
+        }
+    };
+    compio_runtime::time::timeout(Duration::from_secs(10), read_to_eof)
+        .await
+        .expect("closing the write half did not make the peer observe EOF");
+
+    assert_eq!(buffer, b"Hello world!");
+    drop(tx);
+}
+
+#[cfg(unix)]
+#[compio_macros::test]
+async fn poll_close_ignores_sources_without_a_write_half() {
+    use std::os::fd::{FromRawFd, OwnedFd};
+
+    // A pipe has no write half to shut down, so closing it must still succeed.
+    let mut fds = [0; 2];
+    let rc = unsafe { libc::pipe(fds.as_mut_ptr()) };
+    assert_eq!(rc, 0, "{}", io::Error::last_os_error());
+    let [reader, writer] = fds;
+    let reader = unsafe { OwnedFd::from_raw_fd(reader) };
+    let writer = unsafe { OwnedFd::from_raw_fd(writer) };
+
+    PollFd::new(writer).unwrap().shutdown_write().unwrap();
+
+    drop(reader);
 }
 
 fn connected_pair() -> (PollFd<Socket>, PollFd<Socket>) {

--- a/compio-net/tests/poll.rs
+++ b/compio-net/tests/poll.rs
@@ -1,6 +1,7 @@
 use std::{
-    io,
+    io::{self, IoSlice},
     net::{Ipv4Addr, SocketAddrV4},
+    pin::Pin,
 };
 
 use compio_runtime::fd::PollFd;
@@ -72,4 +73,56 @@ async fn poll_connect() {
     assert_eq!(write, 12);
     assert_eq!(read, 12);
     assert_eq!(buffer, b"Hello world!");
+}
+
+#[compio_macros::test]
+async fn poll_write_vectored() {
+    let (mut tx, rx) = connected_pair();
+
+    // Exercise the `AsyncWrite` impl rather than the inherent method: the trait's
+    // default only writes the first non-empty buffer.
+    let bufs = [
+        IoSlice::new(b"Hello"),
+        IoSlice::new(b" "),
+        IoSlice::new(b"world!"),
+    ];
+    let written = std::future::poll_fn(|cx| {
+        futures_util::AsyncWrite::poll_write_vectored(Pin::new(&mut tx), cx, &bufs)
+    })
+    .await
+    .unwrap();
+    assert_eq!(
+        written, 12,
+        "expected a single writev covering every buffer"
+    );
+
+    let mut buffer = Vec::with_capacity(12);
+    let read = std::future::poll_fn(|cx| {
+        rx.poll_read_with(cx, |rx| {
+            let n = rx.recv(buffer.spare_capacity_mut())?;
+            unsafe { buffer.set_len(n) };
+            Ok(n)
+        })
+    })
+    .await
+    .unwrap();
+
+    assert_eq!(read, 12);
+    assert_eq!(buffer, b"Hello world!");
+}
+
+fn connected_pair() -> (PollFd<Socket>, PollFd<Socket>) {
+    let listener = Socket::new(Domain::IPV4, Type::STREAM, Some(Protocol::TCP)).unwrap();
+    listener
+        .bind(&SockAddr::from(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 0)))
+        .unwrap();
+    listener.listen(1).unwrap();
+
+    let client = Socket::new(Domain::IPV4, Type::STREAM, Some(Protocol::TCP)).unwrap();
+    client.connect(&listener.local_addr().unwrap()).unwrap();
+    let (server, _) = listener.accept().unwrap();
+
+    client.set_nonblocking(true).unwrap();
+    server.set_nonblocking(true).unwrap();
+    (PollFd::new(client).unwrap(), PollFd::new(server).unwrap())
 }

--- a/compio-runtime/Cargo.toml
+++ b/compio-runtime/Cargo.toml
@@ -32,6 +32,7 @@ synchrony = { workspace = true, features = ["event"] }
 [target.'cfg(windows)'.dependencies]
 compio-io = { workspace = true, features = ["compat"] }
 windows-sys = { workspace = true, features = [
+    "Win32_Networking_WinSock",
     "Win32_System_IO",
     "Win32_System_Threading",
 ] }

--- a/compio-runtime/src/fd/poll_fd/mod.rs
+++ b/compio-runtime/src/fd/poll_fd/mod.rs
@@ -185,6 +185,21 @@ where
     }
 }
 
+impl<T: AsFd> PollFd<T> {
+    /// Shut down the write half, so the peer of a connected socket observes the
+    /// end of the stream while this side can still read.
+    ///
+    /// Sources that cannot be half-closed report success and are left as they
+    /// are, since there is no write half to shut down.
+    pub fn shutdown_write(&self) -> io::Result<()> {
+        match sys::shutdown_write(self.0.as_fd()) {
+            // Not a socket, or a socket that never reached a connected state.
+            Err(e) if is_not_connected(&e) => Ok(()),
+            result => result,
+        }
+    }
+}
+
 impl<T: AsFd> IntoInner for PollFd<T> {
     type Inner = SharedFd<T>;
 
@@ -234,6 +249,27 @@ fn is_would_block(e: &io::Error) -> bool {
     #[cfg(not(unix))]
     {
         e.kind() == io::ErrorKind::WouldBlock
+    }
+}
+
+fn is_not_connected(e: &io::Error) -> bool {
+    #[cfg(unix)]
+    {
+        matches!(
+            e.raw_os_error(),
+            Some(libc::ENOTSOCK) | Some(libc::ENOTCONN)
+        )
+    }
+    #[cfg(windows)]
+    {
+        use windows_sys::Win32::Networking::WinSock::{WSAENOTCONN, WSAENOTSOCK};
+
+        matches!(e.raw_os_error(), Some(WSAENOTSOCK) | Some(WSAENOTCONN))
+    }
+    #[cfg(not(any(unix, windows)))]
+    {
+        let _ = e;
+        false
     }
 }
 
@@ -288,7 +324,7 @@ where
     }
 
     fn poll_close(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<()>> {
-        Poll::Ready(Ok(()))
+        Poll::Ready(self.shutdown_write())
     }
 }
 
@@ -317,6 +353,6 @@ where
     }
 
     fn poll_close(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<()>> {
-        Poll::Ready(Ok(()))
+        Poll::Ready(self.shutdown_write())
     }
 }

--- a/compio-runtime/src/fd/poll_fd/mod.rs
+++ b/compio-runtime/src/fd/poll_fd/mod.rs
@@ -163,6 +163,26 @@ where
     pub fn poll_write(&self, cx: &mut Context<'_>, buf: &[u8]) -> Poll<io::Result<usize>> {
         self.poll_write_with(cx, |fd| std::io::Write::write(&mut &*fd, buf))
     }
+
+    /// Poll for write readiness and write data from a slice of buffers.
+    ///
+    /// Whether this is more efficient than [`poll_write`] depends on the
+    /// source: it is a single `writev` for sockets and files, while other
+    /// sources may fall back to writing the first non-empty buffer.
+    ///
+    /// [`poll_write`]: Self::poll_write
+    pub fn poll_write_vectored(
+        &self,
+        cx: &mut Context<'_>,
+        bufs: &[io::IoSlice<'_>],
+    ) -> Poll<io::Result<usize>> {
+        self.poll_write_with(cx, |fd| std::io::Write::write_vectored(&mut &*fd, bufs))
+    }
+
+    /// Poll for write readiness and flush the source.
+    pub fn poll_flush(&self, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        self.poll_write_with(cx, |fd| std::io::Write::flush(&mut &*fd))
+    }
 }
 
 impl<T: AsFd> IntoInner for PollFd<T> {
@@ -255,8 +275,16 @@ where
         (*self).poll_write(cx, buf)
     }
 
-    fn poll_flush(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<()>> {
-        Poll::Ready(Ok(()))
+    fn poll_write_vectored(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        bufs: &[io::IoSlice<'_>],
+    ) -> Poll<io::Result<usize>> {
+        (*self).poll_write_vectored(cx, bufs)
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        (*self).poll_flush(cx)
     }
 
     fn poll_close(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<()>> {
@@ -276,8 +304,16 @@ where
         (*self).poll_write(cx, buf)
     }
 
-    fn poll_flush(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<()>> {
-        Poll::Ready(Ok(()))
+    fn poll_write_vectored(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        bufs: &[io::IoSlice<'_>],
+    ) -> Poll<io::Result<usize>> {
+        (*self).poll_write_vectored(cx, bufs)
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        (*self).poll_flush(cx)
     }
 
     fn poll_close(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<()>> {

--- a/compio-runtime/src/fd/poll_fd/unix.rs
+++ b/compio-runtime/src/fd/poll_fd/unix.rs
@@ -122,3 +122,8 @@ impl<T: AsFd> Deref for PollFd<T> {
         &self.inner
     }
 }
+
+pub fn shutdown_write(fd: BorrowedFd<'_>) -> io::Result<()> {
+    compio_driver::syscall!(libc::shutdown(fd.as_raw_fd(), libc::SHUT_WR))?;
+    Ok(())
+}

--- a/compio-runtime/src/fd/poll_fd/windows.rs
+++ b/compio-runtime/src/fd/poll_fd/windows.rs
@@ -282,3 +282,10 @@ impl<T: AsFd> IntoInner for WaitWSAEvent<T> {
         self.events
     }
 }
+
+pub fn shutdown_write(fd: BorrowedFd<'_>) -> io::Result<()> {
+    use windows_sys::Win32::Networking::WinSock::{SD_SEND, shutdown};
+
+    syscall!(SOCKET, shutdown(fd.as_raw_fd() as _, SD_SEND as _))?;
+    Ok(())
+}


### PR DESCRIPTION
Closing a `PollFd` through `AsyncWrite` returned `Ready(Ok(()))` without touching the source, so a connected socket never sent FIN and the peer only saw EOF once the descriptor was dropped. Protocols that half-close and then keep reading — a WebSocket close handshake, `Connection: close`, graceful shutdown — wait for a FIN that is not coming.

`poll_close` now shuts down the write half. Sources that cannot be half-closed (`ENOTSOCK`, `ENOTCONN`) report success and are left alone, so pipes and eventfds behave as before. `PollFd::shutdown_write` is also exposed for callers that need it directly.

Stacked on #993.