### PR TITLE
feat(dispatcher): attribute and name its tasks

### DIFF
--- a/compio-dispatcher/Cargo.toml
+++ b/compio-dispatcher/Cargo.toml
@@ -29,6 +29,7 @@ compio-macros = { workspace = true }
 compio-signal = { workspace = true }
 
 futures-util = { workspace = true }
+tracing = { workspace = true }
 
 [features]
 # Instrumentation for `tokio-console`. See `compio_runtime::console`.

--- a/compio-dispatcher/Cargo.toml
+++ b/compio-dispatcher/Cargo.toml
@@ -30,6 +30,10 @@ compio-signal = { workspace = true }
 
 futures-util = { workspace = true }
 
+[features]
+# Instrumentation for `tokio-console`. See `compio_runtime::console`.
+console = ["compio-runtime/console"]
+
 [[test]]
 name = "listener"
 required-features = ["compio-driver/sync"]

--- a/compio-dispatcher/src/lib.rs
+++ b/compio-dispatcher/src/lib.rs
@@ -183,9 +183,10 @@ impl Dispatcher {
     {
         let (concrete, rx) = Concrete::new(f);
 
+        let meta = SpawnMeta::capture().named("dispatch");
         match self.sender.send(Spawning {
             task: Box::new(concrete),
-            meta: SpawnMeta::capture(),
+            meta,
         }) {
             Ok(_) => Ok(rx),
             Err(err) => {

--- a/compio-dispatcher/src/lib.rs
+++ b/compio-dispatcher/src/lib.rs
@@ -20,14 +20,19 @@ use std::{
 };
 
 use compio_driver::{AsyncifyPool, DispatchError, Dispatchable, ProactorBuilder};
-use compio_runtime::{JoinHandle as CompioJoinHandle, Runtime};
+use compio_runtime::{JoinHandle as CompioJoinHandle, Runtime, SpawnMeta};
 use flume::{Sender, unbounded};
 use futures_channel::oneshot;
 
-type Spawning = Box<dyn Spawnable + Send>;
+/// A closure to spawn, and the [`SpawnMeta`] of the `dispatch` call it came
+/// from.
+struct Spawning {
+    task: Box<dyn Spawnable + Send>,
+    meta: SpawnMeta,
+}
 
 trait Spawnable {
-    fn spawn(self: Box<Self>, handle: &Runtime) -> CompioJoinHandle<()>;
+    fn spawn(self: Box<Self>, handle: &Runtime, meta: SpawnMeta) -> CompioJoinHandle<()>;
 }
 
 /// Concrete type for the closure we're sending to worker threads
@@ -49,12 +54,15 @@ where
     Fut: Future<Output = R>,
     R: Send + 'static,
 {
-    fn spawn(self: Box<Self>, handle: &Runtime) -> CompioJoinHandle<()> {
+    fn spawn(self: Box<Self>, handle: &Runtime, meta: SpawnMeta) -> CompioJoinHandle<()> {
         let Concrete { callback, func } = *self;
-        handle.spawn(async move {
-            let res = func().await;
-            callback.send(res).ok();
-        })
+        handle.spawn_at(
+            async move {
+                let res = func().await;
+                callback.send(res).ok();
+            },
+            meta,
+        )
     }
 }
 
@@ -123,8 +131,10 @@ impl Dispatcher {
                             .build()
                             .expect("cannot create compio runtime")
                             .block_on(async move {
-                                while let Ok(f) = receiver.recv_async().await {
-                                    let task = Runtime::with_current(|rt| f.spawn(rt));
+                                while let Ok(Spawning { task: f, meta }) =
+                                    receiver.recv_async().await
+                                {
+                                    let task = Runtime::with_current(|rt| f.spawn(rt, meta));
                                     if concurrent {
                                         task.detach()
                                     } else {
@@ -164,6 +174,7 @@ impl Dispatcher {
     ///
     /// If all threads have panicked, this method will return an error with the
     /// sent closure.
+    #[track_caller]
     pub fn dispatch<Fn, Fut, R>(&self, f: Fn) -> Result<oneshot::Receiver<R>, DispatchError<Fn>>
     where
         Fn: (FnOnce() -> Fut) + Send + 'static,
@@ -172,12 +183,15 @@ impl Dispatcher {
     {
         let (concrete, rx) = Concrete::new(f);
 
-        match self.sender.send(Box::new(concrete)) {
+        match self.sender.send(Spawning {
+            task: Box::new(concrete),
+            meta: SpawnMeta::capture(),
+        }) {
             Ok(_) => Ok(rx),
             Err(err) => {
                 // SAFETY: We know the dispatchable we sent has type `Concrete<Fn, R>`
                 let recovered =
-                    unsafe { Box::from_raw(Box::into_raw(err.0) as *mut Concrete<Fn, R>) };
+                    unsafe { Box::from_raw(Box::into_raw(err.0.task) as *mut Concrete<Fn, R>) };
                 Err(DispatchError(recovered.func))
             }
         }

--- a/compio-dispatcher/src/lib.rs
+++ b/compio-dispatcher/src/lib.rs
@@ -88,6 +88,7 @@ pub struct Dispatcher {
 
 impl Dispatcher {
     /// Create the dispatcher with specified number of threads.
+    #[track_caller]
     pub(crate) fn new_impl(builder: DispatcherBuilder) -> io::Result<Self> {
         let DispatcherBuilder {
             nthreads,
@@ -100,6 +101,9 @@ impl Dispatcher {
         proactor_builder.force_reuse_thread_pool();
         let pool = proactor_builder.create_or_get_thread_pool();
         let (sender, receiver) = unbounded::<Spawning>();
+        // Captured out here, since `#[track_caller]` does not reach into the
+        // closures the threads run, and every worker belongs to this call.
+        let meta = SpawnMeta::capture().named("dispatcher::worker");
 
         let threads = (0..nthreads)
             .map({
@@ -130,18 +134,21 @@ impl Dispatcher {
                             .thread_affinity(cpus)
                             .build()
                             .expect("cannot create compio runtime")
-                            .block_on(async move {
-                                while let Ok(Spawning { task: f, meta }) =
-                                    receiver.recv_async().await
-                                {
-                                    let task = Runtime::with_current(|rt| f.spawn(rt, meta));
-                                    if concurrent {
-                                        task.detach()
-                                    } else {
-                                        task.await.ok();
+                            .block_on_at(
+                                async move {
+                                    while let Ok(Spawning { task: f, meta }) =
+                                        receiver.recv_async().await
+                                    {
+                                        let task = Runtime::with_current(|rt| f.spawn(rt, meta));
+                                        if concurrent {
+                                            task.detach()
+                                        } else {
+                                            task.await.ok();
+                                        }
                                     }
-                                }
-                            });
+                                },
+                                meta,
+                            );
                     })
                 }
             })
@@ -155,6 +162,7 @@ impl Dispatcher {
     }
 
     /// Create the dispatcher with default config.
+    #[track_caller]
     pub fn new() -> io::Result<Self> {
         Self::builder().build()
     }
@@ -316,6 +324,7 @@ impl DispatcherBuilder {
     }
 
     /// Build the [`Dispatcher`].
+    #[track_caller]
     pub fn build(self) -> io::Result<Dispatcher> {
         Dispatcher::new_impl(self)
     }

--- a/compio-dispatcher/tests/console.rs
+++ b/compio-dispatcher/tests/console.rs
@@ -1,0 +1,143 @@
+//! Assert that the dispatcher names the tasks it runs, and points them at the
+//! call they came from rather than at its own internals, for [`tokio-console`].
+//!
+//! [`tokio-console`]: https://github.com/tokio-rs/console
+#![cfg(feature = "console")]
+
+use std::{
+    fmt::Debug,
+    num::NonZeroUsize,
+    sync::{Arc, Mutex},
+};
+
+use compio_dispatcher::Dispatcher;
+use tracing::{
+    Event, Metadata, Subscriber,
+    field::{Field, Visit},
+    span::{Attributes, Id, Record},
+};
+
+/// Where the console says a task came from.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+struct Task {
+    name: Option<String>,
+    file: String,
+    line: u64,
+}
+
+/// A subscriber recording the tasks `console-subscriber` would report.
+///
+/// `compio-executor` asserts what the spans hold; this only has to tell where
+/// the dispatcher's own tasks point.
+#[derive(Debug, Default, Clone)]
+struct Recorder(Arc<Mutex<Vec<Task>>>);
+
+impl Recorder {
+    /// The tasks recorded under `name`, whichever thread spawned them.
+    fn named(&self, name: &str) -> Vec<Task> {
+        self.0
+            .lock()
+            .unwrap()
+            .iter()
+            .filter(|it| it.name.as_deref() == Some(name))
+            .cloned()
+            .collect()
+    }
+
+    fn all(&self) -> Vec<Task> {
+        self.0.lock().unwrap().clone()
+    }
+}
+
+impl Subscriber for Recorder {
+    fn enabled(&self, meta: &Metadata<'_>) -> bool {
+        meta.name() == "runtime.spawn"
+    }
+
+    fn new_span(&self, attrs: &Attributes<'_>) -> Id {
+        let mut task = Task::default();
+        attrs.record(&mut TaskVisitor(&mut task));
+
+        let mut tasks = self.0.lock().unwrap();
+        tasks.push(task);
+        Id::from_u64(tasks.len() as u64)
+    }
+
+    fn record(&self, _span: &Id, _values: &Record<'_>) {}
+
+    fn record_follows_from(&self, _span: &Id, _follows: &Id) {}
+
+    fn event(&self, _event: &Event<'_>) {}
+
+    fn enter(&self, _span: &Id) {}
+
+    fn exit(&self, _span: &Id) {}
+}
+
+struct TaskVisitor<'a>(&'a mut Task);
+
+impl Visit for TaskVisitor<'_> {
+    fn record_u64(&mut self, field: &Field, value: u64) {
+        if field.name() == "loc.line" {
+            self.0.line = value;
+        }
+    }
+
+    fn record_str(&mut self, field: &Field, value: &str) {
+        match field.name() {
+            "task.name" => self.0.name = Some(value.to_owned()),
+            "loc.file" => self.0.file = value.to_owned(),
+            _ => {}
+        }
+    }
+
+    fn record_debug(&mut self, _field: &Field, _value: &dyn Debug) {}
+}
+
+const THREADS: usize = 2;
+
+/// The workers spawn on threads of their own, so the recorder has to be the
+/// global subscriber rather than this thread's. That it can only be installed
+/// once is why this file holds a single test.
+#[compio_macros::test]
+async fn dispatched_tasks_are_named_and_point_at_their_caller() {
+    let recorder = Recorder::default();
+    tracing::subscriber::set_global_default(recorder.clone()).unwrap();
+
+    let builder = Dispatcher::builder().worker_threads(NonZeroUsize::new(THREADS).unwrap());
+    let built = u64::from(line!()) + 1;
+    let dispatcher = builder.build().unwrap();
+
+    let dispatched = u64::from(line!()) + 1;
+    let handle = dispatcher.dispatch(|| std::future::ready(())).unwrap();
+    handle.await.unwrap();
+    dispatcher.join().await.unwrap();
+
+    let tasks = recorder.named("dispatch");
+    assert_eq!(
+        tasks.len(),
+        1,
+        "one task per dispatch: {:?}",
+        recorder.all()
+    );
+    assert_eq!(
+        (tasks[0].file.as_str(), tasks[0].line),
+        (file!(), dispatched),
+        "a dispatched task points at the `dispatch` call, not at the worker thread that ran it"
+    );
+
+    let workers = recorder.named("dispatcher::worker");
+    assert_eq!(
+        workers.len(),
+        THREADS,
+        "one task per worker: {:?}",
+        recorder.all()
+    );
+    for worker in &workers {
+        assert_eq!(
+            (worker.file.as_str(), worker.line),
+            (file!(), built),
+            "a worker points at the call that built the dispatcher, not into compio-dispatcher"
+        );
+    }
+}


### PR DESCRIPTION
The dispatcher runs its tasks on threads that know nothing about who asked for them, so the console blamed its own internals for every row: the workers all reported the same line inside `compio-dispatcher`, told apart only by the `thread` field, and a dispatched task pointed at the worker loop rather than at the `dispatch` call that produced it.

Both attributions now travel to the thread the task ends up on. A dispatched closure carries the `SpawnMeta` of its `dispatch` call through the channel, and the workers' is captured in `new_impl`, since `#[track_caller]` does not reach into the closure each thread runs; `new`, `build` and `new_impl` forward the caller so that the location is the `Dispatcher` call in the user's code. Both are named as well, so the task list reads without following the location of every row.

The capture is unconditional. `SpawnMeta` is a zero-sized no-op without the `console` feature, so the location is dead and the generated code identical.

The test records what `console-subscriber` would see, across every thread the dispatcher runs on. Dropping either capture, or moving the workers' into the closure, makes it fail with a location inside `compio-dispatcher` rather than with a build error, which is what it is there to catch.

Third of six, tracked in #988. The facade's feature arrives in the fifth, so nothing here is reachable through `compio` yet.