### PR TITLE
ci: run the console tests

### DIFF
--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -55,6 +55,15 @@ jobs:
             no_default_features: true
           - os: 'ubuntu-22.04'
             features: 'native-tls,ring,py-dynamic-openssl'
+          # Neither `console` nor `compat` is part of `all`, so they need a
+          # setup of their own to hold any test at all. The two go together:
+          # the compatibility layer instruments the future it executes, and
+          # only a build with both covers that.
+          - os: 'ubuntu-22.04'
+            features: 'console,compat-all'
+          - os: 'windows-latest'
+            target: 'x86_64-pc-windows-msvc'
+            features: 'console,compat-all'
           - os: 'ubuntu-22.04'
             target: 'x86_64-unknown-linux-musl'
             features: 'native-tls-vendored,ring,sync,polling'

--- a/.github/workflows/ci_test_executor.yml
+++ b/.github/workflows/ci_test_executor.yml
@@ -62,6 +62,12 @@ jobs:
             -p compio-executor \
             --test executor
 
+          cargo miri test \
+            -p compio-executor \
+            --features console \
+            --test executor \
+            --test console
+
           RUSTFLAGS="--cfg loom" \
           LOOM_LOCATION=1 \
           LOOM_LOG=info,compio_executor=trace \


### PR DESCRIPTION
`compio-executor` came with 12 console tests in #987, and none of them has ever run. The suite is behind `#![cfg(feature = "console")]`, `console` is not part of `all`, and no job asks for it, so every existing job builds the
file into a test binary holding nothing:

```console
$ cargo test --features all --no-run
   Executable tests/console.rs (target/debug/deps/console-927b8808618dad15)
$ ./target/debug/deps/console-927b8808618dad15 --list
0 tests, 0 benchmarks
```

Give the feature a setup of its own, and run the executor's suite under miri too, where the same 12 tests pass alongside the 7 already covered.

`compat-all` comes along because the two go together: the compatibility layer instruments the future it executes, and only a build with both covers that.
The entries are forward-looking in the same way — `--features console` reaches whichever crates have grown the feature by then, so the suites the rest of the series adds start running as they land, with no further change here.

Sixth of six, tracked in #988, brought forward: it depends only on the executor, which is already on master, and everything it turns on there is merged. Raised from #1002, where the same question was asked of the tests it adds, those will be covered by the ubuntu entry once both land.