### PR TITLE
feat: name the tasks the crates spawn

### DIFF
--- a/compio-compat/Cargo.toml
+++ b/compio-compat/Cargo.toml
@@ -51,6 +51,9 @@ futures-util = { workspace = true }
 tokio = ["dep:tokio"]
 futures = ["dep:async-io", "dep:futures-util"]
 
+# Instrumentation for `tokio-console`. See `compio_runtime::console`.
+console = ["compio-runtime/console"]
+
 [[test]]
 name = "net"
 required-features = ["tokio"]

--- a/compio-compat/Cargo.toml
+++ b/compio-compat/Cargo.toml
@@ -44,6 +44,7 @@ tokio = { workspace = true, features = [
     "io-util",
 ] }
 futures-executor = { workspace = true }
+tracing = { workspace = true }
 
 futures-util = { workspace = true }
 

--- a/compio-compat/src/lib.rs
+++ b/compio-compat/src/lib.rs
@@ -22,7 +22,7 @@ use std::{
 };
 
 use compio_log::error;
-use compio_runtime::Runtime;
+use compio_runtime::{Runtime, SpawnMeta, console};
 use mod_use::mod_use;
 
 mod_use![sys];
@@ -41,7 +41,21 @@ impl<A: Adapter> RuntimeCompat<A> {
     }
 
     /// Executes the given future on the runtime, driving it to completion.
-    pub async fn execute<F: Future>(&self, f: F) -> F::Output {
+    ///
+    /// This is a plain `fn` so that the console can report the caller:
+    /// `#[track_caller]` is a no-op on an `async fn`.
+    #[track_caller]
+    pub fn execute<F: Future>(&self, f: F) -> impl Future<Output = F::Output> {
+        // The console has no kind of its own for this, and reports it the way
+        // it reports a future the runtime blocks on, so the name is what tells
+        // the two apart. Captured before the future, which is where the caller
+        // is lost.
+        let f = console::instrument_execute(SpawnMeta::capture().named("execute"), f);
+
+        self.drive(f)
+    }
+
+    async fn drive<F: Future>(&self, f: F) -> F::Output {
         let waker = self.runtime.waker();
         let mut context = Context::from_waker(&waker);
         let mut future = std::pin::pin!(f);

--- a/compio-compat/tests/console.rs
+++ b/compio-compat/tests/console.rs
@@ -1,0 +1,179 @@
+//! Assert that the compatibility layer reports the future it executes to
+//! [`tokio-console`].
+//!
+//! [`tokio-console`]: https://github.com/tokio-rs/console
+#![cfg(feature = "console")]
+
+use std::{
+    fmt::Debug,
+    sync::{Arc, Mutex},
+};
+
+use compio_compat::{Adapter, RuntimeCompat};
+use compio_runtime::Runtime;
+use tracing::{
+    Event, Metadata, Subscriber,
+    field::{Field, Visit},
+    span::{Attributes, Id, Record},
+};
+
+/// What the console tells the tasks of a runtime apart by.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+struct Task {
+    kind: String,
+    /// Displayed in a column of its own, when present.
+    name: Option<String>,
+    /// Number of times the span was entered, which the console reports as the
+    /// number of polls of the task.
+    polls: usize,
+    exits: usize,
+    /// Where the console tells the user to look for the task.
+    file: String,
+    line: u64,
+}
+
+/// A subscriber recording the tasks `console-subscriber` would report.
+///
+/// `compio-executor` asserts what the spans hold; this only has to tell which
+/// of them the compatibility layer creates.
+#[derive(Debug, Default, Clone)]
+struct Recorder(Arc<Mutex<State>>);
+
+#[derive(Debug, Default)]
+struct State {
+    tasks: Vec<Task>,
+    /// Task spans currently entered. The console reads a span held while
+    /// another task is polled as the two being nested, and charges the inner
+    /// one's time to the outer.
+    entered: usize,
+    deepest: usize,
+}
+
+impl Recorder {
+    fn tasks(&self) -> Vec<Task> {
+        self.0.lock().unwrap().tasks.clone()
+    }
+
+    fn deepest(&self) -> usize {
+        self.0.lock().unwrap().deepest
+    }
+}
+
+impl Subscriber for Recorder {
+    fn enabled(&self, meta: &Metadata<'_>) -> bool {
+        meta.name() == "runtime.spawn"
+    }
+
+    fn new_span(&self, attrs: &Attributes<'_>) -> Id {
+        let mut task = Task::default();
+        attrs.record(&mut TaskVisitor(&mut task));
+
+        let state = &mut *self.0.lock().unwrap();
+        state.tasks.push(task);
+        Id::from_u64(state.tasks.len() as u64)
+    }
+
+    fn record(&self, _span: &Id, _values: &Record<'_>) {}
+
+    fn record_follows_from(&self, _span: &Id, _follows: &Id) {}
+
+    fn event(&self, _event: &Event<'_>) {}
+
+    fn enter(&self, span: &Id) {
+        let state = &mut *self.0.lock().unwrap();
+        state.tasks[span.into_u64() as usize - 1].polls += 1;
+        state.entered += 1;
+        state.deepest = state.deepest.max(state.entered);
+    }
+
+    fn exit(&self, span: &Id) {
+        let state = &mut *self.0.lock().unwrap();
+        state.tasks[span.into_u64() as usize - 1].exits += 1;
+        state.entered -= 1;
+    }
+}
+
+struct TaskVisitor<'a>(&'a mut Task);
+
+impl Visit for TaskVisitor<'_> {
+    fn record_str(&mut self, field: &Field, value: &str) {
+        match field.name() {
+            "kind" => self.0.kind = value.to_owned(),
+            "task.name" => self.0.name = Some(value.to_owned()),
+            "loc.file" => self.0.file = value.to_owned(),
+            _ => {}
+        }
+    }
+
+    fn record_u64(&mut self, field: &Field, value: u64) {
+        if field.name() == "loc.line" {
+            self.0.line = value;
+        }
+    }
+
+    fn record_debug(&mut self, _field: &Field, _value: &dyn Debug) {}
+}
+
+async fn test_impl<A: Adapter>() {
+    let recorder = Recorder::default();
+    let _guard = tracing::subscriber::set_default(recorder.clone());
+
+    let runtime = RuntimeCompat::<A>::new(Runtime::new().unwrap()).unwrap();
+    let f = async {
+        compio_runtime::spawn(std::future::ready(())).await.unwrap();
+        42
+    };
+    let called = u64::from(line!()) + 1;
+    let answer = runtime.execute(f).await;
+    assert_eq!(answer, 42);
+
+    let tasks = recorder.tasks();
+    let executed: Vec<_> = tasks
+        .iter()
+        .filter(|it| it.name.as_deref() == Some("execute"))
+        .collect();
+    assert_eq!(executed.len(), 1, "one task per executed future: {tasks:?}");
+    assert_eq!(
+        executed[0].kind, "block_on",
+        "the console has no kind of its own for a future executed this way, so the name is what \
+         tells it apart from one the runtime blocks on"
+    );
+    assert!(
+        tasks.iter().any(|it| it.kind == "task"),
+        "the tasks it spawns are reported alongside it: {tasks:?}"
+    );
+    assert!(
+        executed[0].polls >= 2,
+        "the future does not finish in one poll: {tasks:?}"
+    );
+    assert_eq!(
+        executed[0].exits, executed[0].polls,
+        "its span is left between polls rather than held across the `.await`s of `execute`, which \
+         would report the time the task is idle as time spent polling it: {tasks:?}"
+    );
+    assert_eq!(
+        recorder.deepest(),
+        1,
+        "and left before the runtime polls the tasks it spawned, or the console would read them \
+         as nested in it and charge their time to it as well: {tasks:?}"
+    );
+    assert_eq!(
+        (executed[0].file.as_str(), executed[0].line),
+        (file!(), called),
+        "it points at the call to `execute` rather than into the compatibility layer: {tasks:?}"
+    );
+}
+
+#[cfg(feature = "tokio")]
+#[tokio::test]
+async fn tokio() {
+    test_impl::<compio_compat::TokioAdapter>().await;
+}
+
+#[cfg(feature = "futures")]
+#[test]
+fn futures() {
+    futures_executor::block_on(async {
+        test_impl::<compio_compat::FuturesAdapter>().await;
+    })
+}

--- a/compio-executor/src/console.rs
+++ b/compio-executor/src/console.rs
@@ -65,10 +65,16 @@
 //! * A task spawned by an `async fn` is attributed to that function rather than
 //!   to its caller, since [`#[track_caller]`][async-track-caller] is a no-op on
 //!   `async fn`s and [`SpawnMeta`] therefore cannot be forwarded through them.
-//!   The ones compio spawns itself are named to make up for it. A crate willing
-//!   to build on nightly can lift this for its own `async fn`s with the
-//!   `async_fn_track_caller` feature, which attributes them to the `.await` of
-//!   the future they return.
+//!   A function that wants the caller instead can be a plain `fn` returning a
+//!   future, capturing the [`SpawnMeta`] before the `async` block it returns —
+//!   at the cost of an opaque return type, and of running whatever precedes the
+//!   block when it is called rather than when it is first polled. The ones
+//!   compio spawns itself are named either way.
+//!
+//!   Nightly's `async_fn_track_caller` is not a substitute: it reports the
+//!   caller of `poll`, which is the `.await` when a future is awaited directly,
+//!   but a line inside `join!`, `select!` or whichever combinator drives it
+//!   otherwise.
 //! * The resources tab stays empty: timers and in-flight operations are not
 //!   instrumented yet.
 //! * A task's span is closed even when the thread is unwinding, or the console

--- a/compio-fs/src/lib.rs
+++ b/compio-fs/src/lib.rs
@@ -46,7 +46,7 @@ pub mod pipe;
 #[deprecated(since = "0.12.0", note = "Use `compio::runtime::fd::AsyncFd` instead")]
 pub type AsyncFd<T> = compio_runtime::fd::AsyncFd<T>;
 
-use std::io;
+use std::{future::Future, io};
 
 #[cfg(unix)]
 pub(crate) fn path_string(path: impl AsRef<std::path::Path>) -> io::Result<std::ffi::CString> {
@@ -62,6 +62,32 @@ pub(crate) fn path_string(path: impl AsRef<std::path::Path>) -> io::Result<std::
 
 use compio_buf::{BufResult, IntoInner};
 use compio_driver::{SharedFd, op::AsyncifyFd};
+
+/// Run `f` on the blocking pool, reporting it to the console under `name`.
+///
+/// The tasks compio spawns itself are named, since their location points into
+/// compio rather than into the code that asked for the work. It still tells
+/// which fallback is running, so this is a plain `fn`: `#[track_caller]` is a
+/// no-op on an `async fn`, and every fallback would report this line instead
+/// of its own.
+#[allow(dead_code)] // Only some platforms have blocking fallbacks.
+#[track_caller]
+pub(crate) fn spawn_blocking_named<T: Send + 'static>(
+    name: &'static str,
+    f: impl (FnOnce() -> T) + Send + 'static,
+) -> impl Future<Output = T> {
+    use compio_runtime::{ResumeUnwind, SpawnMeta};
+
+    // Captured before the future, which is where the caller is lost.
+    let meta = SpawnMeta::capture().named(name);
+
+    async move {
+        compio_runtime::spawn_blocking_at(f, meta)
+            .await
+            .resume_unwind()
+            .expect("shouldn't be cancelled")
+    }
+}
 
 pub(crate) async fn spawn_blocking_with<T, R, F>(fd: SharedFd<T>, f: F) -> io::Result<R>
 where

--- a/compio-fs/src/metadata/unix.rs
+++ b/compio-fs/src/metadata/unix.rs
@@ -14,7 +14,6 @@ use compio_buf::{BufResult, IntoInner};
 #[cfg(dirfd)]
 use compio_driver::ToSharedFd;
 use compio_driver::op::{CurrentDir, FileAttr, PathStat, Stat};
-use compio_runtime::ResumeUnwind;
 use rustix::fs::FileType as FileTypeInner;
 
 use crate::path_string;
@@ -53,10 +52,10 @@ pub async fn symlink_metadata_at(
 
 pub async fn set_permissions(path: impl AsRef<Path>, perm: Permissions) -> io::Result<()> {
     let path = path.as_ref().to_path_buf();
-    compio_runtime::spawn_blocking(move || std::fs::set_permissions(path, perm))
-        .await
-        .resume_unwind()
-        .expect("shouldn't be cancelled")
+    crate::spawn_blocking_named("fs::set_permissions", move || {
+        std::fs::set_permissions(path, perm)
+    })
+    .await
 }
 
 #[derive(Clone)]

--- a/compio-fs/src/metadata/windows.rs
+++ b/compio-fs/src/metadata/windows.rs
@@ -2,27 +2,25 @@ use std::{io, os::windows::fs::MetadataExt, path::Path, time::SystemTime};
 
 #[cfg(dirfd)]
 use compio_driver::ToSharedFd;
-use compio_runtime::ResumeUnwind;
 
 #[cfg(dirfd)]
 use crate::File;
+use crate::spawn_blocking_named;
 
 pub async fn metadata(path: impl AsRef<Path>) -> io::Result<Metadata> {
     let path = path.as_ref().to_path_buf();
-    compio_runtime::spawn_blocking(move || std::fs::metadata(path))
+    spawn_blocking_named("fs::metadata", move || std::fs::metadata(path))
         .await
-        .resume_unwind()
-        .expect("shouldn't be cancelled")
         .map(Metadata::from)
 }
 
 pub async fn symlink_metadata(path: impl AsRef<Path>) -> io::Result<Metadata> {
     let path = path.as_ref().to_path_buf();
-    compio_runtime::spawn_blocking(move || std::fs::symlink_metadata(path))
-        .await
-        .resume_unwind()
-        .expect("shouldn't be cancelled")
-        .map(Metadata::from)
+    spawn_blocking_named("fs::symlink_metadata", move || {
+        std::fs::symlink_metadata(path)
+    })
+    .await
+    .map(Metadata::from)
 }
 
 #[cfg(dirfd)]
@@ -59,7 +57,7 @@ pub async fn symlink_metadata_at(dir: &File, path: impl AsRef<Path>) -> io::Resu
 
 pub async fn set_permissions(path: impl AsRef<Path>, perm: Permissions) -> io::Result<()> {
     let path = path.as_ref().to_path_buf();
-    compio_runtime::spawn_blocking(move || {
+    spawn_blocking_named("fs::set_permissions", move || {
         // Reduce syscalls at best effort.
         if let Some(p) = perm.original {
             std::fs::set_permissions(&path, p)
@@ -70,8 +68,6 @@ pub async fn set_permissions(path: impl AsRef<Path>, perm: Permissions) -> io::R
         }
     })
     .await
-    .resume_unwind()
-    .expect("shouldn't be cancelled")
 }
 
 #[derive(Clone)]

--- a/compio-fs/src/open_options/windows.rs
+++ b/compio-fs/src/open_options/windows.rs
@@ -2,12 +2,11 @@ use std::{io, os::windows::fs::OpenOptionsExt, path::Path};
 
 #[cfg(dirfd)]
 use compio_driver::ToSharedFd;
-use compio_runtime::ResumeUnwind;
 use windows_sys::Win32::Storage::FileSystem::{
     FILE_FLAG_OVERLAPPED, FILE_SHARE_DELETE, FILE_SHARE_READ, FILE_SHARE_WRITE,
 };
 
-use crate::File;
+use crate::{File, spawn_blocking_named};
 
 #[derive(Clone, Debug)]
 pub struct OpenOptions {
@@ -82,10 +81,7 @@ impl OpenOptions {
     pub async fn open(&self, p: impl AsRef<Path>) -> io::Result<File> {
         let opt = std::fs::OpenOptions::from(self);
         let p = p.as_ref().to_path_buf();
-        let file = compio_runtime::spawn_blocking(move || opt.open(p))
-            .await
-            .resume_unwind()
-            .expect("shouldn't be cancelled")?;
+        let file = spawn_blocking_named("fs::open", move || opt.open(p)).await?;
         File::from_std(file)
     }
 

--- a/compio-fs/src/utils/windows.rs
+++ b/compio-fs/src/utils/windows.rs
@@ -2,61 +2,49 @@ use std::{io, path::Path};
 
 #[cfg(dirfd)]
 use compio_driver::ToSharedFd;
-use compio_runtime::ResumeUnwind;
 
 #[cfg(dirfd)]
 use crate::File;
+use crate::spawn_blocking_named;
 
 pub async fn remove_file(path: impl AsRef<Path>) -> io::Result<()> {
     let path = path.as_ref().to_path_buf();
-    compio_runtime::spawn_blocking(move || std::fs::remove_file(path))
-        .await
-        .resume_unwind()
-        .expect("shouldn't be cancelled")
+    spawn_blocking_named("fs::remove_file", move || std::fs::remove_file(path)).await
 }
 
 pub async fn remove_dir(path: impl AsRef<Path>) -> io::Result<()> {
     let path = path.as_ref().to_path_buf();
-    compio_runtime::spawn_blocking(move || std::fs::remove_dir(path))
-        .await
-        .resume_unwind()
-        .expect("shouldn't be cancelled")
+    spawn_blocking_named("fs::remove_dir", move || std::fs::remove_dir(path)).await
 }
 
 pub async fn rename(from: impl AsRef<Path>, to: impl AsRef<Path>) -> io::Result<()> {
     let from = from.as_ref().to_path_buf();
     let to = to.as_ref().to_path_buf();
-    compio_runtime::spawn_blocking(move || std::fs::rename(from, to))
-        .await
-        .resume_unwind()
-        .expect("shouldn't be cancelled")
+    spawn_blocking_named("fs::rename", move || std::fs::rename(from, to)).await
 }
 
 pub async fn symlink_file(original: impl AsRef<Path>, link: impl AsRef<Path>) -> io::Result<()> {
     let original = original.as_ref().to_path_buf();
     let link = link.as_ref().to_path_buf();
-    compio_runtime::spawn_blocking(move || std::os::windows::fs::symlink_file(original, link))
-        .await
-        .resume_unwind()
-        .expect("shouldn't be cancelled")
+    spawn_blocking_named("fs::symlink_file", move || {
+        std::os::windows::fs::symlink_file(original, link)
+    })
+    .await
 }
 
 pub async fn symlink_dir(original: impl AsRef<Path>, link: impl AsRef<Path>) -> io::Result<()> {
     let original = original.as_ref().to_path_buf();
     let link = link.as_ref().to_path_buf();
-    compio_runtime::spawn_blocking(move || std::os::windows::fs::symlink_dir(original, link))
-        .await
-        .resume_unwind()
-        .expect("shouldn't be cancelled")
+    spawn_blocking_named("fs::symlink_dir", move || {
+        std::os::windows::fs::symlink_dir(original, link)
+    })
+    .await
 }
 
 pub async fn hard_link(original: impl AsRef<Path>, link: impl AsRef<Path>) -> io::Result<()> {
     let original = original.as_ref().to_path_buf();
     let link = link.as_ref().to_path_buf();
-    compio_runtime::spawn_blocking(move || std::fs::hard_link(original, link))
-        .await
-        .resume_unwind()
-        .expect("shouldn't be cancelled")
+    spawn_blocking_named("fs::hard_link", move || std::fs::hard_link(original, link)).await
 }
 
 pub struct DirBuilder;
@@ -68,10 +56,7 @@ impl DirBuilder {
 
     pub async fn create(&self, path: &Path) -> io::Result<()> {
         let path = path.to_path_buf();
-        compio_runtime::spawn_blocking(move || std::fs::create_dir(path))
-            .await
-            .resume_unwind()
-            .expect("shouldn't be cancelled")
+        spawn_blocking_named("fs::create_dir", move || std::fs::create_dir(path)).await
     }
 
     #[cfg(dirfd)]

--- a/compio-net/src/resolve/unix.rs
+++ b/compio-net/src/resolve/unix.rs
@@ -3,14 +3,17 @@ use std::{
     net::{SocketAddr, ToSocketAddrs},
 };
 
-use compio_runtime::ResumeUnwind;
+use compio_runtime::{ResumeUnwind, SpawnMeta};
 
 pub async fn resolve_sock_addrs(
     host: &str,
     port: u16,
 ) -> io::Result<std::vec::IntoIter<SocketAddr>> {
     let host = host.to_string();
-    compio_runtime::spawn_blocking(move || (host, port).to_socket_addrs())
+    // Name the task: its location points here rather than into the code that
+    // asked for the address, since this is an `async fn`.
+    let meta = SpawnMeta::capture().named("resolve");
+    compio_runtime::spawn_blocking_at(move || (host, port).to_socket_addrs(), meta)
         .await
         .resume_unwind()
         .expect("shouldn't be cancelled")

--- a/compio-process/src/unix.rs
+++ b/compio-process/src/unix.rs
@@ -6,12 +6,15 @@ use compio_driver::{
     op::{BufResultExt, Read, ReadManaged, Write},
 };
 use compio_io::{AsyncRead, AsyncReadManaged, AsyncWrite};
-use compio_runtime::{ResumeUnwind, Runtime};
+use compio_runtime::{ResumeUnwind, Runtime, SpawnMeta};
 
 use crate::{ChildStderr, ChildStdin, ChildStdout};
 
 pub async fn child_wait(mut child: process::Child) -> io::Result<process::ExitStatus> {
-    compio_runtime::spawn_blocking(move || child.wait())
+    // Name the task: its location points here rather than into the code that
+    // waited for the child, since this is an `async fn`.
+    let meta = SpawnMeta::capture().named("process::wait");
+    compio_runtime::spawn_blocking_at(move || child.wait(), meta)
         .await
         .resume_unwind()
         .expect("shouldn't be cancelled")

--- a/compio-quic/Cargo.toml
+++ b/compio-quic/Cargo.toml
@@ -66,10 +66,13 @@ rand = { workspace = true }
 rcgen = { workspace = true }
 socket2 = { workspace = true, features = ["all"] }
 tokio = { workspace = true, features = ["macros", "rt"] }
+tracing = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
 
 [features]
 default = ["ring"]
+# Instrumentation for `tokio-console`. See `compio_runtime::console`.
+console = ["compio-runtime/console"]
 io-compat = ["futures-util/io"]
 platform-verifier = ["dep:rustls-platform-verifier"]
 native-certs = ["dep:rustls-native-certs"]

--- a/compio-quic/src/builder.rs
+++ b/compio-quic/src/builder.rs
@@ -1,4 +1,4 @@
-use std::{io, sync::Arc};
+use std::{future::Future, io, sync::Arc};
 
 use compio_net::ToSocketAddrsAsync;
 use quinn_proto::{
@@ -6,7 +6,7 @@ use quinn_proto::{
     crypto::rustls::{QuicClientConfig, QuicServerConfig},
 };
 
-use crate::Endpoint;
+use crate::{Endpoint, endpoint};
 
 /// Helper to construct an [`Endpoint`] for use with outgoing connections only.
 ///
@@ -155,10 +155,14 @@ impl ClientBuilder<rustls::ClientConfig> {
     /// Create a new [`Endpoint`].
     ///
     /// See [`Endpoint::client`] for more information.
-    pub async fn bind(self, addr: impl ToSocketAddrsAsync) -> io::Result<Endpoint> {
-        let mut endpoint = Endpoint::client(addr).await?;
-        endpoint.default_client_config = Some(self.build());
-        Ok(endpoint)
+    #[track_caller]
+    pub fn bind(self, addr: impl ToSocketAddrsAsync) -> impl Future<Output = io::Result<Endpoint>> {
+        let meta = endpoint::worker_meta();
+        async move {
+            let mut endpoint = Endpoint::client_at(addr, meta).await?;
+            endpoint.default_client_config = Some(self.build());
+            Ok(endpoint)
+        }
     }
 }
 
@@ -217,8 +221,9 @@ impl ServerBuilder<rustls::ServerConfig> {
     /// Create a new [`Endpoint`].
     ///
     /// See [`Endpoint::server`] for more information.
-    pub async fn bind(self, addr: impl ToSocketAddrsAsync) -> io::Result<Endpoint> {
-        Endpoint::server(addr, self.build()).await
+    #[track_caller]
+    pub fn bind(self, addr: impl ToSocketAddrsAsync) -> impl Future<Output = io::Result<Endpoint>> {
+        Endpoint::server_at(addr, self.build(), endpoint::worker_meta())
     }
 }
 

--- a/compio-quic/src/connection.rs
+++ b/compio-quic/src/connection.rs
@@ -393,6 +393,7 @@ pub struct Connecting(Shared<ConnectionInner>);
 impl Connecting {
     conn_fn!();
 
+    #[track_caller]
     pub(crate) fn new(
         handle: ConnectionHandle,
         conn: quinn_proto::Connection,
@@ -405,6 +406,9 @@ impl Connecting {
         ));
         // Name the task: the caller of this is compio rather than user code, so
         // its location alone does not say what the task is.
+        // Unlike the endpoint's worker, this one can be attributed to the user:
+        // every path here is a plain `fn`, so the caller reaches us and the
+        // console tells a connection they made apart from one they accepted.
         let meta = SpawnMeta::capture().named("quic::connection");
         let worker = compio_runtime::spawn_at(
             {

--- a/compio-quic/src/connection.rs
+++ b/compio-quic/src/connection.rs
@@ -9,7 +9,7 @@ use std::{
 
 use compio_buf::bytes::Bytes;
 use compio_log::Instrument;
-use compio_runtime::JoinHandle;
+use compio_runtime::{JoinHandle, SpawnMeta};
 use flume::{Receiver, Sender};
 use futures_util::{
     FutureExt, StreamExt,
@@ -403,10 +403,16 @@ impl Connecting {
         let inner = Shared::new(ConnectionInner::new(
             handle, conn, socket, events_tx, events_rx,
         ));
-        let worker = compio_runtime::spawn({
-            let inner = inner.clone();
-            async move { inner.run().await }.in_current_span()
-        });
+        // Name the task: the caller of this is compio rather than user code, so
+        // its location alone does not say what the task is.
+        let meta = SpawnMeta::capture().named("quic::connection");
+        let worker = compio_runtime::spawn_at(
+            {
+                let inner = inner.clone();
+                async move { inner.run().await }.in_current_span()
+            },
+            meta,
+        );
         inner.state().worker = Some(worker);
         Self(inner)
     }

--- a/compio-quic/src/endpoint.rs
+++ b/compio-quic/src/endpoint.rs
@@ -18,7 +18,7 @@ use compio_log::{Instrument, error};
 #[cfg(rustls)]
 use compio_net::ToSocketAddrsAsync;
 use compio_net::UdpSocket;
-use compio_runtime::JoinHandle;
+use compio_runtime::{JoinHandle, SpawnMeta};
 use flume::{Receiver, Sender, unbounded};
 use futures_util::{FutureExt, StreamExt, future, select, task::AtomicWaker};
 use quinn_proto::{
@@ -229,9 +229,15 @@ impl EndpointInner {
 
     fn respond(&self, buf: Vec<u8>, transmit: Transmit) {
         let socket = self.socket.clone();
-        compio_runtime::spawn(async move {
-            socket.send(buf, &transmit).await;
-        })
+        // Name the task: the caller of this is compio rather than user code, so
+        // its location alone does not say what the task is.
+        let meta = SpawnMeta::capture().named("quic::respond");
+        compio_runtime::spawn_at(
+            async move {
+                socket.send(buf, &transmit).await;
+            },
+            meta,
+        )
         .detach();
     }
 
@@ -430,15 +436,20 @@ impl Endpoint {
             config,
             server_config,
         )?));
-        let worker = compio_runtime::spawn({
-            let inner = inner.clone();
-            async move {
-                if let Err(e) = inner.run().await {
-                    error!("I/O error: {:?}", e);
+        // See the note in `respond` on why this task is named.
+        let meta = SpawnMeta::capture().named("quic::endpoint");
+        let worker = compio_runtime::spawn_at(
+            {
+                let inner = inner.clone();
+                async move {
+                    if let Err(e) = inner.run().await {
+                        error!("I/O error: {:?}", e);
+                    }
                 }
-            }
-            .in_current_span()
-        });
+                .in_current_span()
+            },
+            meta,
+        );
         inner.state.lock().worker = Some(worker);
         Ok(Self {
             inner,

--- a/compio-quic/src/endpoint.rs
+++ b/compio-quic/src/endpoint.rs
@@ -125,6 +125,7 @@ impl EndpointState {
         }
     }
 
+    #[track_caller]
     fn new_connection(
         &mut self,
         handle: ConnectionHandle,
@@ -194,6 +195,7 @@ impl EndpointInner {
         })
     }
 
+    #[track_caller]
     fn connect(
         &self,
         remote: SocketAddr,
@@ -241,6 +243,7 @@ impl EndpointInner {
         .detach();
     }
 
+    #[track_caller]
     pub(crate) fn accept(
         &self,
         incoming: quinn_proto::Incoming,
@@ -436,7 +439,9 @@ impl Endpoint {
             config,
             server_config,
         )?));
-        // See the note in `respond` on why this task is named.
+        // See the note in `respond` on why this task is named. The location
+        // cannot be the user's: `client`, `server` and `bind` all reach us from
+        // an `async fn`, which `#[track_caller]` does not propagate through.
         let meta = SpawnMeta::capture().named("quic::endpoint");
         let worker = compio_runtime::spawn_at(
             {
@@ -498,6 +503,7 @@ impl Endpoint {
     }
 
     /// Connect to a remote endpoint.
+    #[track_caller]
     pub fn connect(
         &self,
         remote: SocketAddr,

--- a/compio-quic/src/endpoint.rs
+++ b/compio-quic/src/endpoint.rs
@@ -1,7 +1,7 @@
 use std::{
     collections::VecDeque,
     fmt::Debug,
-    future::poll_fn,
+    future::{Future, poll_fn},
     io,
     mem::ManuallyDrop,
     net::{SocketAddr, SocketAddrV6},
@@ -418,6 +418,17 @@ impl Deref for EndpointRef {
     }
 }
 
+/// The metadata of an endpoint's worker task, captured on behalf of whoever
+/// creates the endpoint.
+///
+/// `#[track_caller]` carries that caller through the constructors, which are
+/// plain `fn`s returning a future for the purpose: it does not propagate
+/// through an `async fn`.
+#[track_caller]
+pub(crate) fn worker_meta() -> SpawnMeta {
+    SpawnMeta::capture().named("quic::endpoint")
+}
+
 /// A QUIC endpoint.
 #[derive(Debug, Clone)]
 pub struct Endpoint {
@@ -428,21 +439,38 @@ pub struct Endpoint {
 
 impl Endpoint {
     /// Create a QUIC endpoint.
+    #[track_caller]
     pub fn new(
         socket: UdpSocket,
         config: EndpointConfig,
         server_config: Option<ServerConfig>,
         default_client_config: Option<ClientConfig>,
     ) -> io::Result<Self> {
+        Self::new_at(
+            socket,
+            config,
+            server_config,
+            default_client_config,
+            worker_meta(),
+        )
+    }
+
+    pub(crate) fn new_at(
+        socket: UdpSocket,
+        config: EndpointConfig,
+        server_config: Option<ServerConfig>,
+        default_client_config: Option<ClientConfig>,
+        meta: SpawnMeta,
+    ) -> io::Result<Self> {
         let inner = EndpointRef(Shared::new(EndpointInner::new(
             socket,
             config,
             server_config,
         )?));
-        // See the note in `respond` on why this task is named. The location
-        // cannot be the user's: `client`, `server` and `bind` all reach us from
-        // an `async fn`, which `#[track_caller]` does not propagate through.
-        let meta = SpawnMeta::capture().named("quic::endpoint");
+        // See the note in `respond` on why this task is named. Its metadata is
+        // taken rather than captured here, since the constructors that reach us
+        // return a future, and whoever called one is long gone by the time it
+        // is polled.
         let worker = compio_runtime::spawn_at(
             {
                 let inner = inner.clone();
@@ -477,10 +505,19 @@ impl Endpoint {
     ///
     /// IPv4 client is never dual-stack.
     #[cfg(rustls)]
-    pub async fn client(addr: impl ToSocketAddrsAsync) -> io::Result<Endpoint> {
+    #[track_caller]
+    pub fn client(addr: impl ToSocketAddrsAsync) -> impl Future<Output = io::Result<Endpoint>> {
+        Self::client_at(addr, worker_meta())
+    }
+
+    #[cfg(rustls)]
+    pub(crate) async fn client_at(
+        addr: impl ToSocketAddrsAsync,
+        meta: SpawnMeta,
+    ) -> io::Result<Endpoint> {
         // TODO: try to enable dual-stack on all platforms, notably Windows
         let socket = UdpSocket::bind(addr).await?;
-        Self::new(socket, EndpointConfig::default(), None, None)
+        Self::new_at(socket, EndpointConfig::default(), None, None, meta)
     }
 
     /// Helper to construct an endpoint for use with both incoming and outgoing
@@ -492,9 +529,22 @@ impl Endpoint {
     /// should bind an address that matches the family they wish to
     /// communicate within.
     #[cfg(rustls)]
-    pub async fn server(addr: impl ToSocketAddrsAsync, config: ServerConfig) -> io::Result<Self> {
+    #[track_caller]
+    pub fn server(
+        addr: impl ToSocketAddrsAsync,
+        config: ServerConfig,
+    ) -> impl Future<Output = io::Result<Self>> {
+        Self::server_at(addr, config, worker_meta())
+    }
+
+    #[cfg(rustls)]
+    pub(crate) async fn server_at(
+        addr: impl ToSocketAddrsAsync,
+        config: ServerConfig,
+        meta: SpawnMeta,
+    ) -> io::Result<Self> {
         let socket = UdpSocket::bind(addr).await?;
-        Self::new(socket, EndpointConfig::default(), Some(config), None)
+        Self::new_at(socket, EndpointConfig::default(), Some(config), None, meta)
     }
 
     /// Returns relevant stats from this Endpoint

--- a/compio-quic/src/incoming.rs
+++ b/compio-quic/src/incoming.rs
@@ -29,6 +29,7 @@ impl Incoming {
 
     /// Attempt to accept this incoming connection (an error may still
     /// occur).
+    #[track_caller]
     pub fn accept(mut self) -> Result<Connecting, ConnectionError> {
         let inner = self.0.take().unwrap();
         Ok(inner.endpoint.accept(inner.incoming, None)?)

--- a/compio-quic/tests/console.rs
+++ b/compio-quic/tests/console.rs
@@ -1,0 +1,176 @@
+//! Assert that the tasks compio-quic spawns are named, and that the one
+//! driving a connection points at the call that opened it, for
+//! [`tokio-console`].
+//!
+//! [`tokio-console`]: https://github.com/tokio-rs/console
+#![cfg(feature = "console")]
+
+use std::{
+    fmt::Debug,
+    sync::{Arc, Mutex},
+};
+
+use compio_quic::{ClientBuilder, Endpoint};
+use futures_util::join;
+use tracing::{
+    Event, Metadata, Subscriber,
+    field::{Field, Visit},
+    span::{Attributes, Id, Record},
+};
+
+#[allow(dead_code)]
+mod common;
+use common::config_pair;
+
+/// Where the console says a task came from.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+struct Task {
+    name: Option<String>,
+    file: String,
+    line: u64,
+}
+
+/// A subscriber recording the tasks `console-subscriber` would report.
+///
+/// `compio-executor` asserts what the spans hold; this only has to tell where
+/// the tasks of an endpoint point.
+#[derive(Debug, Default, Clone)]
+struct Recorder(Arc<Mutex<Vec<Task>>>);
+
+impl Recorder {
+    /// The tasks recorded under `name`, in the order they were spawned.
+    fn named(&self, name: &str) -> Vec<Task> {
+        self.0
+            .lock()
+            .unwrap()
+            .iter()
+            .filter(|it| it.name.as_deref() == Some(name))
+            .cloned()
+            .collect()
+    }
+
+    fn all(&self) -> Vec<Task> {
+        self.0.lock().unwrap().clone()
+    }
+}
+
+impl Subscriber for Recorder {
+    fn enabled(&self, meta: &Metadata<'_>) -> bool {
+        meta.name() == "runtime.spawn"
+    }
+
+    fn new_span(&self, attrs: &Attributes<'_>) -> Id {
+        let mut task = Task::default();
+        attrs.record(&mut TaskVisitor(&mut task));
+
+        let mut tasks = self.0.lock().unwrap();
+        tasks.push(task);
+        Id::from_u64(tasks.len() as u64)
+    }
+
+    fn record(&self, _span: &Id, _values: &Record<'_>) {}
+
+    fn record_follows_from(&self, _span: &Id, _follows: &Id) {}
+
+    fn event(&self, _event: &Event<'_>) {}
+
+    fn enter(&self, _span: &Id) {}
+
+    fn exit(&self, _span: &Id) {}
+}
+
+struct TaskVisitor<'a>(&'a mut Task);
+
+impl Visit for TaskVisitor<'_> {
+    fn record_u64(&mut self, field: &Field, value: u64) {
+        if field.name() == "loc.line" {
+            self.0.line = value;
+        }
+    }
+
+    fn record_str(&mut self, field: &Field, value: &str) {
+        match field.name() {
+            "task.name" => self.0.name = Some(value.to_owned()),
+            "loc.file" => self.0.file = value.to_owned(),
+            _ => {}
+        }
+    }
+
+    fn record_debug(&mut self, _field: &Field, _value: &dyn Debug) {}
+}
+
+/// One endpoint serving both ends, so that a connection opened here and one
+/// accepted here are told apart by their location alone.
+#[compio_macros::test]
+async fn connections_point_at_the_call_that_opened_them() {
+    let recorder = Recorder::default();
+    let _guard = tracing::subscriber::set_default(recorder.clone());
+
+    let (server_config, client_config) = config_pair(None);
+    let created = u64::from(line!()) + 1;
+    let mut endpoint = Endpoint::server("127.0.0.1:0", server_config)
+        .await
+        .unwrap();
+    endpoint.default_client_config = Some(client_config);
+    let addr = endpoint.local_addr().unwrap();
+
+    let connected = u64::from(line!()) + 2;
+    let (client, server) = join!(
+        async { endpoint.connect(addr, "localhost", None).unwrap().await },
+        async {
+            let incoming = endpoint.wait_incoming().await.unwrap();
+            incoming.accept().unwrap().await
+        },
+    );
+    let accepted = connected + 3;
+    client.unwrap();
+    server.unwrap();
+
+    let mut lines: Vec<_> = recorder
+        .named("quic::connection")
+        .iter()
+        .map(|it| (it.file.clone(), it.line))
+        .collect();
+    lines.sort();
+    assert_eq!(
+        lines,
+        [
+            (file!().to_owned(), connected),
+            (file!().to_owned(), accepted)
+        ],
+        "a connection points at the `connect` or `accept` that opened it, not into compio-quic: \
+         {:?}",
+        recorder.all()
+    );
+
+    let workers = recorder.named("quic::endpoint");
+    assert_eq!(workers.len(), 1, "one worker: {:?}", recorder.all());
+    assert_eq!(
+        (workers[0].file.as_str(), workers[0].line),
+        (file!(), created),
+        "the worker points at the call that created the endpoint: {:?}",
+        workers[0]
+    );
+}
+
+/// The builders reach an endpoint through `Endpoint::client`, so their `bind`
+/// is the longest chain the location has to survive.
+#[compio_macros::test]
+async fn a_built_endpoint_points_at_the_bind_that_created_it() {
+    let recorder = Recorder::default();
+    let _guard = tracing::subscriber::set_default(recorder.clone());
+
+    let builder = ClientBuilder::new_with_no_server_verification();
+    let bound = u64::from(line!()) + 1;
+    let endpoint = builder.bind("127.0.0.1:0").await.unwrap();
+    endpoint.shutdown().await.unwrap();
+
+    let workers = recorder.named("quic::endpoint");
+    assert_eq!(workers.len(), 1, "one worker: {:?}", recorder.all());
+    assert_eq!(
+        (workers[0].file.as_str(), workers[0].line),
+        (file!(), bound),
+        "the worker points at the `bind` that created the endpoint: {:?}",
+        workers[0]
+    );
+}


### PR DESCRIPTION
Every task compio spawns on a user's behalf reported a location inside compio itself, since that is where the spawn is. A name is the only attribution these can carry, so the console has something to show for a row other than a line
the user has never seen: `resolve`, `process::wait`, the blocking fallbacks of `compio-fs`, and quic's endpoint, respond and connection workers.

A connection is the exception. Every path from the user to that spawn is a plain `fn`, so `#[track_caller]` reaches it: annotating `Endpoint::connect`, `Incoming::accept` and the three internal calls between them makes the console report a connection against the line that opened it, and tells one the user made apart from one they accepted.

The endpoint's own worker follows too, at the price of a signature: `client`, `server` and the builders' `bind` become plain `fn`s returning a future, capturing the metadata before the `async` block and threading it down to the spawn. Awaiting them is unchanged.

`compio-compat` reports the future it executes as a task of its own, and `execute` takes the same shape for the same reason, so that the task points at the call rather than into compio-compat. Nightly's `async_fn_track_caller` is not an alternative: it reports the caller of `poll`, which is a line inside whichever combinator drives the future.

None of this needs a feature: `SpawnMeta` is a no-op without `console`, and these are the same `spawn_at` calls the wrappers in #1001 exist for. The tests do need one, so compio-quic and compio-compat gain a `console` feature that
forwards `compio-runtime`'s, as compio-dispatcher did in #1002.

The quic test is the one worth having: dropping `#[track_caller]` from any of the five links moves a connection's location back into compio-quic without failing to build, and one endpoint serving both ends means the two connections differ only in the call that opened them. The endpoint's worker is asserted twice over, for the constructor and for the longer chain the builders take through it.

Fourth of six, tracked in #988. Both suites run in CI as of #1003. The facade's feature arrives in the fifth, so none of this is reachable through `compio` yet.
