### PR TITLE
feat: forward the console feature, document observing compio

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,7 @@ bytes = "1.7.1"
 bytemuck = "1.25.0"
 cfg_aliases = "0.2.2"
 compio-send-wrapper = "0.7.1"
+console-subscriber = "0.5.0"
 criterion = "0.8.0"
 crossbeam-queue = "0.3.8"
 flume = { version = "0.12.0", default-features = false }

--- a/README.md
+++ b/README.md
@@ -43,6 +43,44 @@ async fn main() {
 
 It's also possible to use the low-level driver (the proactor, without async executor) manually. See [`driver` example](./compio/examples/driver.rs).
 
+## Observability
+
+The `console` feature makes the runtime emit the [`tracing`] spans and events that [`tokio-console`] consumes, so compio applications can be inspected with it:
+
+```bash
+cargo add compio --features console
+cargo add console-subscriber
+```
+
+```toml
+# .cargo/config.toml
+#
+# `console-subscriber` refuses to run unless the runtime is known to be
+# instrumented; this is the escape hatch it provides for runtimes other than
+# tokio.
+[build]
+rustflags = ["--cfg", "console_without_tokio_unstable"]
+```
+
+```rust
+console_subscriber::init();
+compio::runtime::Runtime::new().unwrap().block_on(async {
+    // ...
+});
+```
+
+Then run `tokio-console` to watch tasks, poll times and waker activity. The [`console` module docs](https://docs.rs/compio-runtime/latest/compio_runtime/console/) describe what is reported and what is not.
+
+The [`console` example](./compio/examples/console.rs) runs an echo server on a dispatcher, so that the console shows the tasks of a thread-per-core application spread over its worker threads, next to tasks that are wrong in the ways it warns about. It passes the cfg on the command line instead:
+
+```bash
+RUSTFLAGS="--cfg console_without_tokio_unstable" \
+    cargo run --example console --features console,time,net,dispatcher,sync
+```
+
+[`tracing`]: https://docs.rs/tracing
+[`tokio-console`]: https://github.com/tokio-rs/console
+
 ## Why the name?
 
 The name comes from "completion-based IO", and follows the non-existent convention that an async runtime should be named with a suffix "io".

--- a/compio/Cargo.toml
+++ b/compio/Cargo.toml
@@ -44,6 +44,7 @@ compio-buf = { workspace = true, features = ["bumpalo"] }
 compio-runtime = { workspace = true, features = ["criterion"] }
 compio-macros = { workspace = true }
 
+console-subscriber = { workspace = true }
 criterion = { workspace = true, features = ["async_tokio"] }
 futures-channel = { workspace = true }
 futures-executor = { workspace = true }
@@ -256,6 +257,10 @@ required-features = ["time", "signal", "macros"]
 [[example]]
 name = "dispatcher"
 required-features = ["macros", "dispatcher", "sync", "net"]
+
+[[example]]
+name = "console"
+required-features = ["console", "time", "net", "dispatcher", "sync"]
 
 [[bench]]
 name = "fs"

--- a/compio/Cargo.toml
+++ b/compio/Cargo.toml
@@ -190,6 +190,15 @@ compat-all = ["compat-tokio", "compat-futures"]
 # Logging
 enable_log = ["compio-log/enable_log"]
 
+# Instrumentation for `tokio-console`. See `compio::runtime::console`.
+console = [
+    "compio-runtime/console",
+    "compio-dispatcher?/console",
+    "compio-quic?/console",
+    "compio-compat?/console",
+    "runtime",
+]
+
 # Nightly features
 allocator_api = ["compio-buf/allocator_api", "compio-io?/allocator_api"]
 current_thread_id = ["compio-runtime?/current_thread_id"]

--- a/compio/examples/console.rs
+++ b/compio/examples/console.rs
@@ -1,0 +1,213 @@
+//! Observe a compio application with [`tokio-console`].
+//!
+//! This runs a small echo server on a [`Dispatcher`], so that the console shows
+//! the tasks of a thread-per-core application spread over its worker threads,
+//! next to a handful of tasks that are wrong on purpose, so that it shows the
+//! warnings it can raise about them.
+//!
+//! Run it with the cfg that lets `console-subscriber` instrument a runtime
+//! other than tokio:
+//!
+//! ```sh
+//! RUSTFLAGS="--cfg console_without_tokio_unstable" \
+//!     cargo run --example console --features console,time,net,dispatcher,sync
+//! ```
+//!
+//! Then, in another terminal:
+//!
+//! ```sh
+//! tokio-console
+//! ```
+//!
+//! The task list has a column for the thread a task belongs to, and one for its
+//! name, which is worth setting for the tasks a user did not spawn themselves,
+//! since the location of those points into compio rather than into their code.
+//! Press `w` to sort by warnings, or `t` to look at a single task.
+//!
+//! [`tokio-console`]: https://github.com/tokio-rs/console
+
+use std::{
+    future::poll_fn, hint::black_box, num::NonZeroUsize, task::Poll, thread, time::Duration,
+};
+
+use compio::{
+    BufResult,
+    dispatcher::Dispatcher,
+    io::{AsyncRead, AsyncWriteExt},
+    net::{TcpListener, TcpStream},
+    runtime::{Runtime, SpawnMeta, spawn_at, spawn_blocking_at},
+    time::sleep,
+};
+
+/// Worker threads of the dispatcher, each with an executor of its own.
+const WORKERS: usize = 4;
+
+fn main() {
+    // Install the subscriber before starting any runtime, so that the futures
+    // passed to `block_on` show up as tasks as well.
+    console_subscriber::init();
+
+    // The tasks that misbehave get threads of their own, both to keep them from
+    // disturbing the server and to fill in the thread column. The one that
+    // never yields needs one to itself: it never lets its executor run anything
+    // else, which is the point of the warning about it.
+    let lints = spawn_runtime("compio-lints", lints);
+    let hog = spawn_runtime("compio-hog", never_yields);
+
+    Runtime::new().unwrap().block_on(server());
+
+    lints.join().unwrap();
+    hog.join().unwrap();
+}
+
+/// Run a runtime of its own on a named thread. The console reads the name to
+/// tell the executors of a thread-per-core application apart.
+///
+/// The meta is captured out here rather than in the closure the thread runs,
+/// since `#[track_caller]` does not reach into a closure. Without it both of
+/// these report the `block_on` below as their location, and only the thread
+/// column tells them apart.
+#[track_caller]
+fn spawn_runtime<F: Future<Output = ()> + 'static>(
+    name: &'static str,
+    f: fn() -> F,
+) -> thread::JoinHandle<()> {
+    let meta = SpawnMeta::capture();
+    thread::Builder::new()
+        .name(name.to_owned())
+        .spawn(move || Runtime::new().unwrap().block_on_at(f(), meta))
+        .unwrap()
+}
+
+/// Spawn a named task on the current runtime.
+///
+/// Naming is what [`SpawnMeta`] is for. Without one, the console falls back to
+/// the location of the spawn, which this also records.
+///
+/// A wrapper around a spawn wants `#[track_caller]`, or the location it records
+/// is the one inside the wrapper, and every task spawned through it reports the
+/// same line.
+#[track_caller]
+fn spawn(name: &'static str, f: impl Future<Output = ()> + 'static) {
+    spawn_at(f, SpawnMeta::capture().named(name)).detach();
+}
+
+/// An echo server whose connections are handled by the dispatcher's workers,
+/// driven by clients of our own so that there is always something to look at.
+async fn server() {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    let dispatcher = Dispatcher::builder()
+        .worker_threads(NonZeroUsize::new(WORKERS).unwrap())
+        // Named for the same reason the threads above are.
+        .thread_names(|i| format!("compio-worker-{i}"))
+        .build()
+        .unwrap();
+
+    spawn("load-generator", async move {
+        loop {
+            let mut client = TcpStream::connect(&addr).await.unwrap();
+            client.write_all("hello from compio").await.unwrap();
+            sleep(Duration::from_millis(50)).await;
+        }
+    });
+
+    // A task on the blocking pool, which the console reports as busy while the
+    // closure runs rather than as idle, and as a `blocking` task rather than as
+    // one driven by a future.
+    spawn("blocking-pool", async {
+        loop {
+            spawn_blocking_at(
+                || thread::sleep(Duration::from_millis(200)),
+                SpawnMeta::capture().named("blocking-pool-work"),
+            )
+            .await
+            .unwrap();
+            sleep(Duration::from_millis(300)).await;
+        }
+    });
+
+    // A task that is idle almost all of the time, for contrast: the console
+    // shows where a task's time actually goes.
+    spawn("idle-timer", async {
+        loop {
+            sleep(Duration::from_millis(500)).await;
+        }
+    });
+
+    println!("run `tokio-console` to watch this process");
+
+    loop {
+        let (mut stream, _) = listener.accept().await.unwrap();
+        // Every dispatched closure becomes a task named `dispatch` on whichever
+        // worker picks it up. Dropping the receiver only discards the reply,
+        // the worker still runs the closure.
+        drop(
+            dispatcher
+                .dispatch(move || async move {
+                    let BufResult(read, buf) = stream.read(Vec::with_capacity(32)).await;
+                    read.unwrap();
+                    stream.write_all(buf).await.unwrap();
+                })
+                .unwrap(),
+        );
+    }
+}
+
+/// The tasks that the console warns about, other than the one that never
+/// yields, which needs a thread to itself.
+async fn lints() {
+    // Woken by itself three times for every time the timer wakes it, which is
+    // over the console's default threshold of half of the wakeups.
+    spawn("self-waker", async {
+        loop {
+            for _ in 0..3 {
+                let mut woken = false;
+                poll_fn(|cx| {
+                    if woken {
+                        return Poll::Ready(());
+                    }
+                    woken = true;
+                    cx.waker().wake_by_ref();
+                    Poll::Pending
+                })
+                .await;
+            }
+            sleep(Duration::from_millis(100)).await;
+        }
+    });
+
+    // Pending without ever holding on to the waker, so nothing can ever wake it
+    // again. The console counts the live wakers of a task and warns when a task
+    // that has not finished has none left.
+    spawn("lost-waker", poll_fn(|_| Poll::Pending));
+
+    // A future large enough that the console suggests boxing it: it is measured
+    // at the spawn, and this one holds its buffer across an await.
+    spawn("large-future", async {
+        loop {
+            let buf = [0u8; 8192];
+            sleep(Duration::from_millis(400)).await;
+            black_box(&buf);
+        }
+    });
+
+    std::future::pending().await
+}
+
+/// A task that takes its executor and never gives it back. The console warns
+/// about tasks that have been in their first poll for over a second.
+async fn never_yields() {
+    spawn("never-yields", async {
+        loop {
+            // Blocking work that never reaches an await point, so the executor
+            // cannot take the thread back and the task stays in its very first
+            // poll. Sleeping rather than spinning keeps the example from
+            // pinning a core for as long as it runs.
+            thread::sleep(Duration::from_millis(500));
+        }
+    });
+
+    std::future::pending().await
+}

--- a/compio/src/lib.rs
+++ b/compio/src/lib.rs
@@ -18,6 +18,19 @@
 //! println!("{}", buffer);
 //! # })
 //! ```
+//!
+//! ## Observability
+//! The `console` feature instruments the runtime for [`tokio-console`], which
+//! [`console_subscriber`] then reports to.
+//!
+//! See [`runtime::console`] for the setup it takes, and for what is reported
+//! and what is not.
+//!
+//! [`tokio-console`]: https://github.com/tokio-rs/console
+//! [`console_subscriber`]: https://docs.rs/console-subscriber
+// The module is only there with the `runtime` feature, so the link is spelled
+// out rather than resolved, like the two above.
+//! [`runtime::console`]: https://docs.rs/compio-runtime/latest/compio_runtime/console/
 
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![allow(unused_features)]


### PR DESCRIPTION
Observing a compio application with tokio-console took a feature on `compio-runtime` and, for the members with instrumentation of their own, one on each of them. Forward them all from one `console` feature on the facade.

Listing the members changes nothing about a build through the facade, Cargo resolving a package's features once for the whole graph: the `compio-runtime` the dispatcher, QUIC and the compatibility layer use is already the one `console` asks for. The list is there to say what the feature turns on rather than leave it to unification.

`console-subscriber` is not re-exported, per the review on #987 — an application depends on it directly. It is a dev-dependency here for the example alone.

The docs are the other half of this, since the feature is not enough on its own: `console-subscriber` refuses to run unless the runtime is known to be instrumented, and the escape hatch it offers other runtimes is a cfg the application has to set. The README says so, and the `console` module docs say what is reported and what is not.

The example runs an echo server on a dispatcher, so that the console shows a thread-per-core application's tasks spread over its worker threads, next to a handful that are wrong on purpose — one that never yields, one that wakes itself more often than anything else wakes it, one left with no waker at all, and one large enough that the console suggests boxing it — so that the warnings it raises show up too. It passes the cfg on the command line, so that trying it takes no `.cargo/config.toml`.

Last of six, tracked in #988. The suites run in CI as of #1003.
