### PR TITLE
feat(runtime,tls,ws)!: use PollFd in TLS

### DIFF
--- a/compio-driver/src/sys/pal/windows/fd.rs
+++ b/compio-driver/src/sys/pal/windows/fd.rs
@@ -221,3 +221,21 @@ impl AsFd for std::process::ChildStderr {
         self.as_handle().into()
     }
 }
+
+impl AsFd for std::net::TcpListener {
+    fn as_fd(&self) -> BorrowedFd<'_> {
+        self.as_socket().into()
+    }
+}
+
+impl AsFd for std::net::TcpStream {
+    fn as_fd(&self) -> BorrowedFd<'_> {
+        self.as_socket().into()
+    }
+}
+
+impl AsFd for std::net::UdpSocket {
+    fn as_fd(&self) -> BorrowedFd<'_> {
+        self.as_socket().into()
+    }
+}

--- a/compio-net/Cargo.toml
+++ b/compio-net/Cargo.toml
@@ -46,6 +46,7 @@ libc = { workspace = true }
 
 # Shared dev dependencies for all platforms
 [dev-dependencies]
+compio-driver = { workspace = true, features = ["polling"] }
 compio-macros = { workspace = true }
 compio-runtime = { workspace = true, features = ["time"] }
 futures-channel = { workspace = true }

--- a/compio-net/Cargo.toml
+++ b/compio-net/Cargo.toml
@@ -46,7 +46,6 @@ libc = { workspace = true }
 
 # Shared dev dependencies for all platforms
 [dev-dependencies]
-compio-driver = { workspace = true, features = ["polling"] }
 compio-macros = { workspace = true }
 compio-runtime = { workspace = true, features = ["time"] }
 futures-channel = { workspace = true }

--- a/compio-net/tests/poll.rs
+++ b/compio-net/tests/poll.rs
@@ -24,34 +24,18 @@ fn is_would_block(e: &io::Error) -> bool {
 #[compio_macros::test]
 async fn poll_connect() {
     let listener = Socket::new(Domain::IPV4, Type::STREAM, Some(Protocol::TCP)).unwrap();
-    listener.set_nonblocking(true).unwrap();
     listener
         .bind(&SockAddr::from(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 0)))
         .unwrap();
     listener.listen(4).unwrap();
     let addr = listener.local_addr().unwrap();
     let listener = PollFd::new(listener).unwrap();
-    let accept_task = async {
-        std::future::poll_fn(|cx| listener.poll_accept_with(cx, |listener| listener.accept()))
-            .await
-            .unwrap()
-    };
+    let accept_task = listener.accept();
 
     let client = Socket::new(Domain::IPV4, Type::STREAM, Some(Protocol::TCP)).unwrap();
-    client.set_nonblocking(true).unwrap();
     let client = PollFd::new(client).unwrap();
-    let connect_task = async {
-        match client.connect(&addr) {
-            Ok(_) => Ok(()),
-            Err(e) if is_would_block(&e) => client.connect_ready().await,
-            Err(e) => Err(e),
-        }
-    };
-    let ((tx, _), res) = futures_util::join!(accept_task, connect_task);
-    res.unwrap();
-
-    tx.set_nonblocking(true).unwrap();
-    let mut tx = PollFd::new(tx).unwrap();
+    let connect_task = client.connect(&addr);
+    let ((mut tx, _), _) = futures_util::try_join!(accept_task, connect_task).unwrap();
 
     let send_task = async {
         futures_util::AsyncWriteExt::write(&mut tx, b"Hello world!")
@@ -76,6 +60,22 @@ async fn poll_connect() {
     assert_eq!(write, 12);
     assert_eq!(read, 12);
     assert_eq!(buffer, b"Hello world!");
+}
+
+#[compio_macros::test]
+async fn poll_connect_refused() {
+    let listener = std::net::TcpListener::bind(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 0)).unwrap();
+    let addr = SockAddr::from(listener.local_addr().unwrap());
+    drop(listener);
+
+    let client = Socket::new(Domain::IPV4, Type::STREAM, Some(Protocol::TCP)).unwrap();
+    let client = PollFd::new(client).unwrap();
+    let err = compio_runtime::time::timeout(Duration::from_secs(10), client.connect(&addr))
+        .await
+        .expect("connecting to a closed port timed out")
+        .unwrap_err();
+
+    assert_eq!(err.kind(), io::ErrorKind::ConnectionRefused);
 }
 
 #[compio_macros::test]
@@ -282,6 +282,15 @@ async fn poll_close_ignores_sources_without_a_write_half() {
         .await
         .unwrap();
     futures_util::AsyncWriteExt::close(&mut file).await.unwrap();
+}
+
+#[compio_macros::test]
+async fn poll_socket_operations_reject_files() {
+    let file = PollFd::new(tempfile::tempfile().unwrap()).unwrap();
+    let addr = SockAddr::from(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 1));
+
+    assert!(file.accept().await.is_err());
+    assert!(file.connect(&addr).await.is_err());
 }
 
 /// A socket that counts how often it is flushed, since flushing a socket is a

--- a/compio-net/tests/poll.rs
+++ b/compio-net/tests/poll.rs
@@ -1,12 +1,10 @@
 use std::{
-    cell::Cell,
     io::{self, IoSlice},
     net::{Ipv4Addr, SocketAddrV4},
     pin::Pin,
     time::Duration,
 };
 
-use compio_driver::{AsFd, BorrowedFd};
 use compio_runtime::fd::PollFd;
 use socket2::{Domain, Protocol, SockAddr, Socket, Type};
 
@@ -208,29 +206,6 @@ async fn poll_concurrent_read_write_readiness() {
 }
 
 #[compio_macros::test]
-async fn poll_flush_reaches_the_source() {
-    let (client, server) = connected_sockets();
-    let mut tx = PollFd::new(FlushCounter {
-        socket: client,
-        flushes: Cell::new(0),
-    })
-    .unwrap();
-
-    futures_util::AsyncWriteExt::write_all(&mut tx, b"Hello world!")
-        .await
-        .unwrap();
-    futures_util::AsyncWriteExt::flush(&mut tx).await.unwrap();
-    assert_eq!(tx.flushes.get(), 1, "flushing must reach the source");
-
-    // Closing only shuts down the write half, since flushing would steal the
-    // waker of a pending write.
-    futures_util::AsyncWriteExt::close(&mut tx).await.unwrap();
-    assert_eq!(tx.flushes.get(), 1, "closing must not flush the source");
-
-    drop(server);
-}
-
-#[compio_macros::test]
 async fn poll_close_half_closes() {
     let (mut tx, rx) = connected_pair();
 
@@ -273,6 +248,7 @@ async fn poll_close_half_closes() {
     drop(tx);
 }
 
+#[cfg(unix)]
 #[compio_macros::test]
 async fn poll_close_ignores_sources_without_a_write_half() {
     // A file has no write half to shut down, so closing it must still succeed.
@@ -284,6 +260,7 @@ async fn poll_close_ignores_sources_without_a_write_half() {
     futures_util::AsyncWriteExt::close(&mut file).await.unwrap();
 }
 
+#[cfg(unix)]
 #[compio_macros::test]
 async fn poll_socket_operations_reject_files() {
     let file = PollFd::new(tempfile::tempfile().unwrap()).unwrap();
@@ -291,34 +268,6 @@ async fn poll_socket_operations_reject_files() {
 
     assert!(file.accept().await.is_err());
     assert!(file.connect(&addr).await.is_err());
-}
-
-/// A socket that counts how often it is flushed, since flushing a socket is a
-/// no-op that cannot be observed on the peer.
-struct FlushCounter {
-    socket: Socket,
-    flushes: Cell<usize>,
-}
-
-impl AsFd for FlushCounter {
-    fn as_fd(&self) -> BorrowedFd<'_> {
-        self.socket.as_fd()
-    }
-}
-
-impl io::Write for &FlushCounter {
-    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        io::Write::write(&mut &self.socket, buf)
-    }
-
-    fn write_vectored(&mut self, bufs: &[IoSlice<'_>]) -> io::Result<usize> {
-        io::Write::write_vectored(&mut &self.socket, bufs)
-    }
-
-    fn flush(&mut self) -> io::Result<()> {
-        self.flushes.set(self.flushes.get() + 1);
-        io::Write::flush(&mut &self.socket)
-    }
 }
 
 fn connected_pair() -> (PollFd<Socket>, PollFd<Socket>) {

--- a/compio-runtime/Cargo.toml
+++ b/compio-runtime/Cargo.toml
@@ -26,6 +26,7 @@ compio-send-wrapper = { workspace = true }
 futures-util = { workspace = true, features = ["io"] }
 scoped-tls = { workspace = true }
 pin-project-lite = { workspace = true }
+socket2 = { workspace = true }
 synchrony = { workspace = true, features = ["event"] }
 
 # Windows specific dependencies

--- a/compio-runtime/Cargo.toml
+++ b/compio-runtime/Cargo.toml
@@ -41,6 +41,7 @@ windows-sys = { workspace = true, features = [
 # Unix specific dependencies
 [target.'cfg(unix)'.dependencies]
 libc = { workspace = true }
+rustix = { workspace = true }
 
 [target.'cfg(windows)'.dev-dependencies]
 windows-sys = { workspace = true, features = ["Win32_UI_WindowsAndMessaging"] }

--- a/compio-runtime/src/fd/poll_fd/mod.rs
+++ b/compio-runtime/src/fd/poll_fd/mod.rs
@@ -297,14 +297,23 @@ impl<T: AsFd> Deref for PollFd<T> {
 fn is_would_block(e: &io::Error) -> bool {
     cfg_select! {
         unix => {
-            matches!(e.kind(), io::ErrorKind::WouldBlock | io::ErrorKind::Interrupted) || e.raw_os_error() == Some(libc::EINPROGRESS)
+            matches!(
+                e.kind(),
+                io::ErrorKind::WouldBlock | io::ErrorKind::Interrupted
+            ) || e.raw_os_error() == Some(libc::EINPROGRESS)
         }
         windows => {
             use windows_sys::Win32::Networking::WinSock::WSAEINPROGRESS;
-            matches!(e.kind(), io::ErrorKind::WouldBlock | io::ErrorKind::Interrupted) || e.raw_os_error() == Some(WSAEINPROGRESS)
+            matches!(
+                e.kind(),
+                io::ErrorKind::WouldBlock | io::ErrorKind::Interrupted
+            ) || e.raw_os_error() == Some(WSAEINPROGRESS)
         }
         _ => {
-            matches!(e.kind(), io::ErrorKind::WouldBlock | io::ErrorKind::Interrupted)
+            matches!(
+                e.kind(),
+                io::ErrorKind::WouldBlock | io::ErrorKind::Interrupted
+            )
         }
     }
 }
@@ -315,16 +324,12 @@ fn is_connect_pending(e: &io::Error) -> bool {
     }
 
     cfg_select! {
-        unix => {
-            e.raw_os_error() == Some(libc::EALREADY)
-        }
+        unix => e.raw_os_error() == Some(libc::EALREADY),
         windows => {
             use windows_sys::Win32::Networking::WinSock::WSAEALREADY;
             e.raw_os_error() == Some(WSAEALREADY)
         }
-        _ => {
-            false
-        }
+        _ => false,
     }
 }
 

--- a/compio-runtime/src/fd/poll_fd/mod.rs
+++ b/compio-runtime/src/fd/poll_fd/mod.rs
@@ -176,13 +176,19 @@ impl<T: AsFd + 'static> PollFd<T> {
     }
 }
 
-impl<T: AsFd + 'static> PollFd<T>
-where
-    for<'a> &'a T: std::io::Read,
-{
+impl<T: AsFd + 'static> PollFd<T> {
     /// Poll for read readiness and read data.
     pub fn poll_read(&self, cx: &mut Context, buf: &mut [u8]) -> Poll<io::Result<usize>> {
-        self.poll_read_with(cx, |fd| std::io::Read::read(&mut &*fd, buf))
+        self.poll_read_with(cx, |fd| sys::read(fd.as_fd(), buf))
+    }
+
+    /// Poll for read readiness and read data into a slice of buffers.
+    pub fn poll_read_vectored(
+        &self,
+        cx: &mut Context<'_>,
+        bufs: &mut [io::IoSliceMut<'_>],
+    ) -> Poll<io::Result<usize>> {
+        self.poll_read_with(cx, |fd| sys::readv(fd.as_fd(), bufs))
     }
 
     /// Poll for read readiness and read data into an uninitialized buffer.
@@ -190,19 +196,21 @@ where
     pub fn poll_read_buf(
         &self,
         cx: &mut Context,
-        mut buf: std::io::BorrowedCursor<u8>,
+        mut buf: std::io::BorrowedCursor<'_, u8>,
     ) -> Poll<io::Result<()>> {
-        self.poll_read_with(cx, |fd| std::io::Read::read_buf(&mut &*fd, buf.reborrow()))
+        self.poll_read_with(cx, |fd| {
+            // SAFETY: platform reads only initialize the bytes they report.
+            let read = sys::read_uninit(fd.as_fd(), unsafe { buf.as_mut() })?;
+            unsafe { buf.advance(read) };
+            Ok(())
+        })
     }
 }
 
-impl<T: AsFd + 'static> PollFd<T>
-where
-    for<'a> &'a T: std::io::Write,
-{
+impl<T: AsFd + 'static> PollFd<T> {
     /// Poll for write readiness and write data.
     pub fn poll_write(&self, cx: &mut Context<'_>, buf: &[u8]) -> Poll<io::Result<usize>> {
-        self.poll_write_with(cx, |fd| std::io::Write::write(&mut &*fd, buf))
+        self.poll_write_with(cx, |fd| sys::write(fd.as_fd(), buf))
     }
 
     /// Poll for write readiness and write data from a slice of buffers.
@@ -217,12 +225,14 @@ where
         cx: &mut Context<'_>,
         bufs: &[io::IoSlice<'_>],
     ) -> Poll<io::Result<usize>> {
-        self.poll_write_with(cx, |fd| std::io::Write::write_vectored(&mut &*fd, bufs))
+        self.poll_write_with(cx, |fd| sys::writev(fd.as_fd(), bufs))
     }
 
-    /// Poll for write readiness and flush the source.
-    pub fn poll_flush(&self, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
-        self.poll_write_with(cx, |fd| std::io::Write::flush(&mut &*fd))
+    /// Flush pending writes.
+    ///
+    /// [`PollFd`] does not buffer writes, so this is a no-op.
+    pub fn poll_flush(&self, _cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        Poll::Ready(Ok(()))
     }
 }
 
@@ -237,7 +247,7 @@ impl<T: AsFd> PollFd<T> {
     /// Like the `shutdown` methods in `std`, this does not flush the source.
     fn shutdown_write(&self) -> io::Result<()> {
         match self.with_socket(|socket| socket.shutdown(Shutdown::Write)) {
-            Err(e) if e.kind() == io::ErrorKind::NotConnected => Ok(()),
+            Err(e) if is_not_a_connected_socket(&e) => Ok(()),
             result => result,
         }
     }
@@ -287,14 +297,14 @@ impl<T: AsFd> Deref for PollFd<T> {
 fn is_would_block(e: &io::Error) -> bool {
     cfg_select! {
         unix => {
-            e.kind() == io::ErrorKind::WouldBlock || e.raw_os_error() == Some(libc::EINPROGRESS)
+            matches!(e.kind(), io::ErrorKind::WouldBlock | io::ErrorKind::Interrupted) || e.raw_os_error() == Some(libc::EINPROGRESS)
         }
         windows => {
             use windows_sys::Win32::Networking::WinSock::WSAEINPROGRESS;
-            e.kind() == io::ErrorKind::WouldBlock || e.raw_os_error() == Some(WSAEINPROGRESS)
+            matches!(e.kind(), io::ErrorKind::WouldBlock | io::ErrorKind::Interrupted) || e.raw_os_error() == Some(WSAEINPROGRESS)
         }
         _ => {
-            e.kind() == io::ErrorKind::WouldBlock
+            matches!(e.kind(), io::ErrorKind::WouldBlock | io::ErrorKind::Interrupted)
         }
     }
 }
@@ -318,10 +328,23 @@ fn is_connect_pending(e: &io::Error) -> bool {
     }
 }
 
-impl<T: AsFd + 'static> futures_util::AsyncRead for &PollFd<T>
-where
-    for<'a> &'a T: std::io::Read,
-{
+fn is_not_a_connected_socket(e: &io::Error) -> bool {
+    cfg_select! {
+        unix => {
+            matches!(
+                e.raw_os_error(),
+                Some(libc::ENOTSOCK) | Some(libc::ENOTCONN)
+            )
+        }
+        windows => {
+            use windows_sys::Win32::Networking::WinSock::{WSAENOTCONN, WSAENOTSOCK};
+
+            matches!(e.raw_os_error(), Some(WSAENOTSOCK) | Some(WSAENOTCONN))
+        }
+    }
+}
+
+impl<T: AsFd + 'static> futures_util::AsyncRead for &PollFd<T> {
     fn poll_read(
         self: Pin<&mut Self>,
         cx: &mut Context<'_>,
@@ -329,12 +352,17 @@ where
     ) -> Poll<io::Result<usize>> {
         (*self).poll_read(cx, buf)
     }
+
+    fn poll_read_vectored(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        bufs: &mut [io::IoSliceMut<'_>],
+    ) -> Poll<io::Result<usize>> {
+        (*self).poll_read_vectored(cx, bufs)
+    }
 }
 
-impl<T: AsFd + 'static> futures_util::AsyncRead for PollFd<T>
-where
-    for<'a> &'a T: std::io::Read,
-{
+impl<T: AsFd + 'static> futures_util::AsyncRead for PollFd<T> {
     fn poll_read(
         self: Pin<&mut Self>,
         cx: &mut Context<'_>,
@@ -342,12 +370,17 @@ where
     ) -> Poll<io::Result<usize>> {
         (*self).poll_read(cx, buf)
     }
+
+    fn poll_read_vectored(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        bufs: &mut [io::IoSliceMut<'_>],
+    ) -> Poll<io::Result<usize>> {
+        (*self).poll_read_vectored(cx, bufs)
+    }
 }
 
-impl<T: AsFd + 'static> futures_util::AsyncWrite for &PollFd<T>
-where
-    for<'a> &'a T: std::io::Write,
-{
+impl<T: AsFd + 'static> futures_util::AsyncWrite for &PollFd<T> {
     fn poll_write(
         self: Pin<&mut Self>,
         cx: &mut Context<'_>,
@@ -369,16 +402,11 @@ where
     }
 
     fn poll_close(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<()>> {
-        // Deliberately not flushing: the write readiness registration is shared
-        // with any pending write, so flushing here would steal its waker.
         Poll::Ready(self.shutdown_write())
     }
 }
 
-impl<T: AsFd + 'static> futures_util::AsyncWrite for PollFd<T>
-where
-    for<'a> &'a T: std::io::Write,
-{
+impl<T: AsFd + 'static> futures_util::AsyncWrite for PollFd<T> {
     fn poll_write(
         self: Pin<&mut Self>,
         cx: &mut Context<'_>,
@@ -400,8 +428,6 @@ where
     }
 
     fn poll_close(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<()>> {
-        // Deliberately not flushing: the write readiness registration is shared
-        // with any pending write, so flushing here would steal its waker.
         Poll::Ready(self.shutdown_write())
     }
 }

--- a/compio-runtime/src/fd/poll_fd/mod.rs
+++ b/compio-runtime/src/fd/poll_fd/mod.rs
@@ -15,6 +15,7 @@ use std::os::windows::io::{AsRawSocket, RawSocket};
 use std::{
     future::poll_fn,
     io,
+    net::Shutdown,
     ops::Deref,
     pin::Pin,
     task::{Context, Poll},
@@ -22,12 +23,20 @@ use std::{
 
 use compio_buf::IntoInner;
 use compio_driver::{AsFd, AsRawFd, BorrowedFd, RawFd, SharedFd, ToSharedFd};
+use socket2::{SockAddr, Socket};
 
 /// Providing functionalities to wait for readiness.
+///
+/// ## Platform specific
+/// * Windows: only supports sockets.
 #[derive(Debug)]
 pub struct PollFd<T: AsFd>(sys::PollFd<T>);
 
 impl<T: AsFd> PollFd<T> {
+    fn with_socket<R>(&self, f: impl FnOnce(&Socket) -> io::Result<R>) -> io::Result<R> {
+        sys::with_socket(self.0.as_fd(), f)
+    }
+
     /// Create [`PollFd`] without attaching the source.
     ///
     /// Ready-based sources does not need to be attached.
@@ -37,11 +46,43 @@ impl<T: AsFd> PollFd<T> {
 
     /// Create [`PollFd`] from a shared file descriptor.
     pub fn from_shared_fd(inner: SharedFd<T>) -> io::Result<Self> {
+        sys::with_socket(inner.as_fd(), |socket| socket.set_nonblocking(true))?;
         Ok(Self(sys::PollFd::new(inner)?))
     }
 }
 
 impl<T: AsFd + 'static> PollFd<T> {
+    /// Accept a connection from this socket.
+    pub async fn accept(&self) -> io::Result<(PollFd<Socket>, SockAddr)> {
+        poll_fn(|cx| self.poll_accept(cx)).await
+    }
+
+    /// Poll to accept a connection from this socket.
+    pub fn poll_accept(
+        &self,
+        cx: &mut Context<'_>,
+    ) -> Poll<io::Result<(PollFd<Socket>, SockAddr)>> {
+        self.poll_accept_with(cx, |source| {
+            let (socket, addr) = sys::with_socket(source.as_fd(), Socket::accept)?;
+            Ok((PollFd::new(socket)?, addr))
+        })
+    }
+
+    /// Connect this socket to the specified address.
+    pub async fn connect(&self, addr: &SockAddr) -> io::Result<()> {
+        match self.with_socket(|socket| socket.connect(addr)) {
+            Ok(()) => return Ok(()),
+            Err(e) if is_connect_pending(&e) => {}
+            Err(e) => return Err(e),
+        }
+
+        self.connect_ready().await?;
+        self.with_socket(|socket| match socket.take_error()? {
+            Some(e) => Err(e),
+            None => Ok(()),
+        })
+    }
+
     /// Wait for accept readiness, before calling `accept`, or after `accept`
     /// returns `WouldBlock`.
     pub async fn accept_ready(&self) -> io::Result<()> {
@@ -195,9 +236,8 @@ impl<T: AsFd> PollFd<T> {
     ///
     /// Like the `shutdown` methods in `std`, this does not flush the source.
     fn shutdown_write(&self) -> io::Result<()> {
-        match sys::shutdown_write(self.0.as_fd()) {
-            // Not a socket, or a socket that never reached a connected state.
-            Err(e) if is_not_a_connected_socket(&e) => Ok(()),
+        match self.with_socket(|socket| socket.shutdown(Shutdown::Write)) {
+            Err(e) if e.kind() == io::ErrorKind::NotConnected => Ok(()),
             result => result,
         }
     }
@@ -245,30 +285,35 @@ impl<T: AsFd> Deref for PollFd<T> {
 }
 
 fn is_would_block(e: &io::Error) -> bool {
-    #[cfg(unix)]
-    {
-        e.kind() == io::ErrorKind::WouldBlock || e.raw_os_error() == Some(libc::EINPROGRESS)
-    }
-    #[cfg(not(unix))]
-    {
-        e.kind() == io::ErrorKind::WouldBlock
+    cfg_select! {
+        unix => {
+            e.kind() == io::ErrorKind::WouldBlock || e.raw_os_error() == Some(libc::EINPROGRESS)
+        }
+        windows => {
+            use windows_sys::Win32::Networking::WinSock::WSAEINPROGRESS;
+            e.kind() == io::ErrorKind::WouldBlock || e.raw_os_error() == Some(WSAEINPROGRESS)
+        }
+        _ => {
+            e.kind() == io::ErrorKind::WouldBlock
+        }
     }
 }
 
-/// Whether the error says that the source is not a socket, or is a socket that
-/// never reached a connected state.
-fn is_not_a_connected_socket(e: &io::Error) -> bool {
+fn is_connect_pending(e: &io::Error) -> bool {
+    if is_would_block(e) {
+        return true;
+    }
+
     cfg_select! {
         unix => {
-            matches!(
-                e.raw_os_error(),
-                Some(libc::ENOTSOCK) | Some(libc::ENOTCONN)
-            )
+            e.raw_os_error() == Some(libc::EALREADY)
         }
         windows => {
-            use windows_sys::Win32::Networking::WinSock::{WSAENOTCONN, WSAENOTSOCK};
-
-            matches!(e.raw_os_error(), Some(WSAENOTSOCK) | Some(WSAENOTCONN))
+            use windows_sys::Win32::Networking::WinSock::WSAEALREADY;
+            e.raw_os_error() == Some(WSAEALREADY)
+        }
+        _ => {
+            false
         }
     }
 }

--- a/compio-runtime/src/fd/poll_fd/mod.rs
+++ b/compio-runtime/src/fd/poll_fd/mod.rs
@@ -33,8 +33,8 @@ use socket2::{SockAddr, Socket};
 pub struct PollFd<T: AsFd>(sys::PollFd<T>);
 
 impl<T: AsFd> PollFd<T> {
-    fn with_socket<R>(&self, f: impl FnOnce(&Socket) -> io::Result<R>) -> io::Result<R> {
-        sys::with_socket(self.0.as_fd(), f)
+    fn run_socket_op<R>(&self, f: impl FnOnce(&Socket) -> io::Result<R>) -> io::Result<R> {
+        sys::run_socket_op(self.0.as_fd(), f)
     }
 
     /// Create [`PollFd`] without attaching the source.
@@ -46,7 +46,7 @@ impl<T: AsFd> PollFd<T> {
 
     /// Create [`PollFd`] from a shared file descriptor.
     pub fn from_shared_fd(inner: SharedFd<T>) -> io::Result<Self> {
-        sys::with_socket(inner.as_fd(), |socket| socket.set_nonblocking(true))?;
+        sys::run_socket_op(inner.as_fd(), |socket| socket.set_nonblocking(true))?;
         Ok(Self(sys::PollFd::new(inner)?))
     }
 }
@@ -63,21 +63,21 @@ impl<T: AsFd + 'static> PollFd<T> {
         cx: &mut Context<'_>,
     ) -> Poll<io::Result<(PollFd<Socket>, SockAddr)>> {
         self.poll_accept_with(cx, |source| {
-            let (socket, addr) = sys::with_socket(source.as_fd(), Socket::accept)?;
+            let (socket, addr) = sys::run_socket_op(source.as_fd(), Socket::accept)?;
             Ok((PollFd::new(socket)?, addr))
         })
     }
 
     /// Connect this socket to the specified address.
     pub async fn connect(&self, addr: &SockAddr) -> io::Result<()> {
-        match self.with_socket(|socket| socket.connect(addr)) {
+        match self.run_socket_op(|socket| socket.connect(addr)) {
             Ok(()) => return Ok(()),
             Err(e) if is_connect_pending(&e) => {}
             Err(e) => return Err(e),
         }
 
         self.connect_ready().await?;
-        self.with_socket(|socket| match socket.take_error()? {
+        self.run_socket_op(|socket| match socket.take_error()? {
             Some(e) => Err(e),
             None => Ok(()),
         })
@@ -246,7 +246,7 @@ impl<T: AsFd> PollFd<T> {
     ///
     /// Like the `shutdown` methods in `std`, this does not flush the source.
     fn shutdown_write(&self) -> io::Result<()> {
-        match self.with_socket(|socket| socket.shutdown(Shutdown::Write)) {
+        match self.run_socket_op(|socket| socket.shutdown(Shutdown::Write)) {
             Err(e) if is_not_a_connected_socket(&e) => Ok(()),
             result => result,
         }

--- a/compio-runtime/src/fd/poll_fd/unix.rs
+++ b/compio-runtime/src/fd/poll_fd/unix.rs
@@ -12,6 +12,7 @@ use compio_driver::{
     AsFd, AsRawFd, BorrowedFd, RawFd, SharedFd, ToSharedFd,
     op::{Interest, PollOnce},
 };
+use socket2::{SockRef, Socket};
 
 use crate::Submit;
 
@@ -123,7 +124,9 @@ impl<T: AsFd> Deref for PollFd<T> {
     }
 }
 
-pub fn shutdown_write(fd: BorrowedFd<'_>) -> io::Result<()> {
-    compio_driver::syscall!(libc::shutdown(fd.as_raw_fd(), libc::SHUT_WR))?;
-    Ok(())
+pub fn with_socket<R>(
+    fd: BorrowedFd<'_>,
+    f: impl FnOnce(&Socket) -> io::Result<R>,
+) -> io::Result<R> {
+    f(&SockRef::from(&fd))
 }

--- a/compio-runtime/src/fd/poll_fd/unix.rs
+++ b/compio-runtime/src/fd/poll_fd/unix.rs
@@ -6,6 +6,8 @@ use std::{
     pin::Pin,
     task::{Context, Poll},
 };
+#[cfg(feature = "read_buf")]
+use std::mem::MaybeUninit;
 
 use compio_buf::{BufResult, IntoInner};
 use compio_driver::{
@@ -38,6 +40,29 @@ impl<T: AsFd> PollFd<T> {
             write_submit: RefCell::new(None),
         })
     }
+}
+
+pub fn read(fd: BorrowedFd<'_>, buf: &mut [u8]) -> io::Result<usize> {
+    rustix::io::read(fd, buf).map_err(Into::into)
+}
+
+#[cfg(feature = "read_buf")]
+pub fn read_uninit(fd: BorrowedFd<'_>, buf: &mut [MaybeUninit<u8>]) -> io::Result<usize> {
+    rustix::io::read(fd, buf)
+        .map(|(initialized, _)| initialized.len())
+        .map_err(Into::into)
+}
+
+pub fn readv(fd: BorrowedFd<'_>, bufs: &mut [io::IoSliceMut<'_>]) -> io::Result<usize> {
+    rustix::io::readv(fd, bufs).map_err(Into::into)
+}
+
+pub fn write(fd: BorrowedFd<'_>, buf: &[u8]) -> io::Result<usize> {
+    rustix::io::write(fd, buf).map_err(Into::into)
+}
+
+pub fn writev(fd: BorrowedFd<'_>, bufs: &[io::IoSlice<'_>]) -> io::Result<usize> {
+    rustix::io::writev(fd, bufs).map_err(Into::into)
 }
 
 impl<T: AsFd + 'static> PollFd<T> {

--- a/compio-runtime/src/fd/poll_fd/unix.rs
+++ b/compio-runtime/src/fd/poll_fd/unix.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "read_buf")]
+use std::mem::MaybeUninit;
 use std::{
     cell::RefCell,
     fmt::Debug,
@@ -6,8 +8,6 @@ use std::{
     pin::Pin,
     task::{Context, Poll},
 };
-#[cfg(feature = "read_buf")]
-use std::mem::MaybeUninit;
 
 use compio_buf::{BufResult, IntoInner};
 use compio_driver::{

--- a/compio-runtime/src/fd/poll_fd/unix.rs
+++ b/compio-runtime/src/fd/poll_fd/unix.rs
@@ -149,7 +149,7 @@ impl<T: AsFd> Deref for PollFd<T> {
     }
 }
 
-pub fn with_socket<R>(
+pub fn run_socket_op<R>(
     fd: BorrowedFd<'_>,
     f: impl FnOnce(&Socket) -> io::Result<R>,
 ) -> io::Result<R> {

--- a/compio-runtime/src/fd/poll_fd/windows.rs
+++ b/compio-runtime/src/fd/poll_fd/windows.rs
@@ -9,6 +9,8 @@ use std::{
     sync::atomic::Ordering,
     task::{Context, Poll, Waker},
 };
+#[cfg(feature = "read_buf")]
+use std::mem::MaybeUninit;
 
 use compio_buf::{BufResult, IntoInner};
 use compio_driver::{
@@ -57,6 +59,27 @@ impl<T: AsFd> PollFd<T> {
             write_waker: RefCell::new(None),
         })
     }
+}
+
+pub fn read(fd: BorrowedFd<'_>, buf: &mut [u8]) -> io::Result<usize> {
+    with_socket(fd, |socket| io::Read::read(&mut &*socket, buf))
+}
+
+#[cfg(feature = "read_buf")]
+pub fn read_uninit(fd: BorrowedFd<'_>, buf: &mut [MaybeUninit<u8>]) -> io::Result<usize> {
+    with_socket(fd, |socket| socket.recv(buf))
+}
+
+pub fn readv(fd: BorrowedFd<'_>, bufs: &mut [io::IoSliceMut<'_>]) -> io::Result<usize> {
+    with_socket(fd, |socket| io::Read::read_vectored(&mut &*socket, bufs))
+}
+
+pub fn write(fd: BorrowedFd<'_>, buf: &[u8]) -> io::Result<usize> {
+    with_socket(fd, |socket| socket.send(buf))
+}
+
+pub fn writev(fd: BorrowedFd<'_>, bufs: &[io::IoSlice<'_>]) -> io::Result<usize> {
+    with_socket(fd, |socket| socket.send_vectored(bufs))
 }
 
 impl<T: AsFd + 'static> PollFd<T> {

--- a/compio-runtime/src/fd/poll_fd/windows.rs
+++ b/compio-runtime/src/fd/poll_fd/windows.rs
@@ -15,6 +15,7 @@ use compio_driver::{
     AsFd, AsRawFd, BorrowedFd, OpCode, OpType, RawFd, SharedFd, ToSharedFd, syscall,
 };
 use compio_io::compat::WakerArrayRef;
+use socket2::{SockRef, Socket};
 use synchrony::unsync::atomic::{AtomicI32, AtomicUsize};
 use windows_sys::Win32::{
     Networking::WinSock::{
@@ -287,16 +288,14 @@ impl<T: AsFd> IntoInner for WaitWSAEvent<T> {
     }
 }
 
-pub fn shutdown_write(fd: BorrowedFd<'_>) -> io::Result<()> {
-    use windows_sys::Win32::Networking::WinSock::{SD_SEND, shutdown};
+pub fn with_socket<R>(
+    fd: BorrowedFd<'_>,
+    f: impl FnOnce(&Socket) -> io::Result<R>,
+) -> io::Result<R> {
+    use windows_sys::Win32::Networking::WinSock::WSAENOTSOCK;
 
     match fd {
-        // Only sockets have a write half, and `shutdown` would need Winsock to
-        // be initialized just to tell us that a handle is not a socket.
-        BorrowedFd::File(_) => Ok(()),
-        BorrowedFd::Socket(socket) => {
-            syscall!(SOCKET, shutdown(socket.as_raw_socket() as _, SD_SEND as _))?;
-            Ok(())
-        }
+        BorrowedFd::File(_) => Err(io::Error::from_raw_os_error(WSAENOTSOCK)),
+        BorrowedFd::Socket(socket) => f(&SockRef::from(&socket)),
     }
 }

--- a/compio-runtime/src/fd/poll_fd/windows.rs
+++ b/compio-runtime/src/fd/poll_fd/windows.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "read_buf")]
+use std::mem::MaybeUninit;
 use std::{
     cell::RefCell,
     fmt::Debug,
@@ -9,8 +11,6 @@ use std::{
     sync::atomic::Ordering,
     task::{Context, Poll, Waker},
 };
-#[cfg(feature = "read_buf")]
-use std::mem::MaybeUninit;
 
 use compio_buf::{BufResult, IntoInner};
 use compio_driver::{

--- a/compio-runtime/src/fd/poll_fd/windows.rs
+++ b/compio-runtime/src/fd/poll_fd/windows.rs
@@ -62,24 +62,24 @@ impl<T: AsFd> PollFd<T> {
 }
 
 pub fn read(fd: BorrowedFd<'_>, buf: &mut [u8]) -> io::Result<usize> {
-    with_socket(fd, |socket| io::Read::read(&mut &*socket, buf))
+    run_socket_op(fd, |socket| io::Read::read(&mut &*socket, buf))
 }
 
 #[cfg(feature = "read_buf")]
 pub fn read_uninit(fd: BorrowedFd<'_>, buf: &mut [MaybeUninit<u8>]) -> io::Result<usize> {
-    with_socket(fd, |socket| socket.recv(buf))
+    run_socket_op(fd, |socket| socket.recv(buf))
 }
 
 pub fn readv(fd: BorrowedFd<'_>, bufs: &mut [io::IoSliceMut<'_>]) -> io::Result<usize> {
-    with_socket(fd, |socket| io::Read::read_vectored(&mut &*socket, bufs))
+    run_socket_op(fd, |socket| io::Read::read_vectored(&mut &*socket, bufs))
 }
 
 pub fn write(fd: BorrowedFd<'_>, buf: &[u8]) -> io::Result<usize> {
-    with_socket(fd, |socket| socket.send(buf))
+    run_socket_op(fd, |socket| socket.send(buf))
 }
 
 pub fn writev(fd: BorrowedFd<'_>, bufs: &[io::IoSlice<'_>]) -> io::Result<usize> {
-    with_socket(fd, |socket| socket.send_vectored(bufs))
+    run_socket_op(fd, |socket| socket.send_vectored(bufs))
 }
 
 impl<T: AsFd + 'static> PollFd<T> {
@@ -311,7 +311,7 @@ impl<T: AsFd> IntoInner for WaitWSAEvent<T> {
     }
 }
 
-pub fn with_socket<R>(
+pub fn run_socket_op<R>(
     fd: BorrowedFd<'_>,
     f: impl FnOnce(&Socket) -> io::Result<R>,
 ) -> io::Result<R> {

--- a/compio-tls/Cargo.toml
+++ b/compio-tls/Cargo.toml
@@ -39,6 +39,7 @@ rcgen = { workspace = true }
 rsa = "0.10.0-rc.17"
 rustls = { workspace = true, default-features = false, features = ["ring"] }
 rustls-native-certs = { workspace = true }
+socket2 = { workspace = true }
 tempfile = { workspace = true }
 
 futures-rustls = { workspace = true, default-features = false, features = [

--- a/compio-tls/Cargo.toml
+++ b/compio-tls/Cargo.toml
@@ -54,6 +54,3 @@ native-tls-vendored = ["native-tls/vendored"]
 py-dynamic-openssl = ["dep:compio-py-dynamic-openssl", "dep:pin-project-lite"]
 
 ring = ["rustls", "rustls/ring", "futures-rustls/ring"]
-
-# Kept empty while the workspace-level `compio/read_buf` feature forwards it.
-read_buf = []

--- a/compio-tls/Cargo.toml
+++ b/compio-tls/Cargo.toml
@@ -14,9 +14,6 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-compio-buf = { workspace = true }
-compio-io = { workspace = true, features = ["compat"] }
-
 native-tls = { workspace = true, optional = true, features = ["alpn"] }
 rustls = { workspace = true, default-features = false, optional = true, features = [
     "logging",
@@ -29,11 +26,11 @@ futures-rustls = { workspace = true, default-features = false, optional = true, 
     "logging",
     "tls12",
 ] }
-futures-util = { workspace = true }
+futures-util = { workspace = true, features = ["io"] }
 pin-project-lite = { workspace = true, optional = true }
 
 [dev-dependencies]
-compio-net = { workspace = true }
+compio-driver = { workspace = true, features = ["polling"] }
 compio-runtime = { workspace = true }
 compio-macros = { workspace = true }
 
@@ -58,5 +55,5 @@ py-dynamic-openssl = ["dep:compio-py-dynamic-openssl", "dep:pin-project-lite"]
 
 ring = ["rustls", "rustls/ring", "futures-rustls/ring"]
 
-read_buf = ["compio-buf/read_buf", "compio-io/read_buf"]
-nightly = ["read_buf"]
+# Kept empty while the workspace-level `compio/read_buf` feature forwards it.
+read_buf = []

--- a/compio-tls/Cargo.toml
+++ b/compio-tls/Cargo.toml
@@ -30,7 +30,6 @@ futures-util = { workspace = true, features = ["io"] }
 pin-project-lite = { workspace = true, optional = true }
 
 [dev-dependencies]
-compio-driver = { workspace = true, features = ["polling"] }
 compio-runtime = { workspace = true }
 compio-macros = { workspace = true }
 

--- a/compio-tls/README.md
+++ b/compio-tls/README.md
@@ -25,7 +25,7 @@ This crate provides TLS/SSL support for compio networking types. It offers both 
   - `native-tls`: Platform-specific TLS (SChannel on Windows, Secure Transport on macOS, OpenSSL on Linux)
   - `rustls`: Pure Rust TLS implementation
 - ALPN (Application-Layer Protocol Negotiation) support
-- Integration with compio's completion-based IO model
+- Integration with futures-based async IO traits
 
 ## Usage
 
@@ -39,7 +39,7 @@ cargo add compio --features tls,rustls # or native-tls
 
 ### For library
 
-If you are writing libraries that want to support completion-based async IO with TLS support, you can depend on this crate directly:
+If you are writing libraries that want to support futures-based async IO with TLS support, you can depend on this crate directly:
 
 ```bash
 cargo add compio-tls # native-tls by default

--- a/compio-tls/src/adapter.rs
+++ b/compio-tls/src/adapter.rs
@@ -1,6 +1,6 @@
 use std::{fmt::Debug, io};
 
-use compio_io::{AsyncRead, AsyncWrite, compat::AsyncStream, util::Splittable};
+use futures_util::{AsyncRead, AsyncWrite};
 
 use crate::TlsStream;
 
@@ -79,33 +79,14 @@ impl TlsConnector {
     /// example, a TCP connection to a remote server. That stream is then
     /// provided here to perform the client half of a connection to a
     /// TLS-powered server.
-    pub async fn connect<S: Splittable + 'static>(
-        &self,
-        domain: &str,
-        stream: S,
-    ) -> io::Result<TlsStream<S>>
+    pub async fn connect<S>(&self, domain: &str, stream: S) -> io::Result<TlsStream<S>>
     where
-        S::ReadHalf: AsyncRead + Unpin,
-        S::WriteHalf: AsyncWrite + Unpin,
-    {
-        self.connect_compat(domain, AsyncStream::new(stream)).await
-    }
-
-    /// Similar to `connect` but accepts an [`AsyncStream`] instead of a raw
-    /// stream. Users are free to adjust the inner buffer sizes and limits.
-    pub async fn connect_compat<S: Splittable + 'static>(
-        &self,
-        domain: &str,
-        stream: AsyncStream<S>,
-    ) -> io::Result<TlsStream<S>>
-    where
-        S::ReadHalf: AsyncRead + Unpin,
-        S::WriteHalf: AsyncWrite + Unpin,
+        S: AsyncRead + AsyncWrite + Unpin,
     {
         match &self.0 {
             #[cfg(feature = "native-tls")]
             TlsConnectorInner::NativeTls(c) => {
-                let client = c.connect(domain, Box::pin(stream)).await?;
+                let client = c.connect(domain, stream).await?;
                 Ok(TlsStream::from(client))
             }
             #[cfg(feature = "rustls")]
@@ -113,14 +94,14 @@ impl TlsConnector {
                 let client = c
                     .connect(
                         domain.to_string().try_into().map_err(io::Error::other)?,
-                        Box::pin(stream),
+                        stream,
                     )
                     .await?;
                 Ok(TlsStream::from(client))
             }
             #[cfg(feature = "py-dynamic-openssl")]
             TlsConnectorInner::PyDynamicOpenSsl(c) => {
-                let client = c.connect(domain, Box::pin(stream)).await?;
+                let client = c.connect(domain, stream).await?;
                 Ok(TlsStream::from(client))
             }
             #[cfg(not(any(
@@ -189,38 +170,24 @@ impl TlsAcceptor {
     /// This is typically used after a new socket has been accepted from a
     /// `TcpListener`. That socket is then passed to this function to perform
     /// the server half of accepting a client connection.
-    pub async fn accept<S: Splittable + 'static>(&self, stream: S) -> io::Result<TlsStream<S>>
+    pub async fn accept<S>(&self, stream: S) -> io::Result<TlsStream<S>>
     where
-        S::ReadHalf: AsyncRead + Unpin,
-        S::WriteHalf: AsyncWrite + Unpin,
-    {
-        self.accept_compat(AsyncStream::new(stream)).await
-    }
-
-    /// Similar to `accept` but accepts an [`AsyncStream`] instead of a raw
-    /// stream. Users are free to adjust the inner buffer sizes and limits.
-    pub async fn accept_compat<S: Splittable + 'static>(
-        &self,
-        stream: AsyncStream<S>,
-    ) -> io::Result<TlsStream<S>>
-    where
-        S::ReadHalf: AsyncRead + Unpin,
-        S::WriteHalf: AsyncWrite + Unpin,
+        S: AsyncRead + AsyncWrite + Unpin,
     {
         match &self.0 {
             #[cfg(feature = "native-tls")]
             TlsAcceptorInner::NativeTls(c) => {
-                let server = c.accept(Box::pin(stream)).await?;
+                let server = c.accept(stream).await?;
                 Ok(TlsStream::from(server))
             }
             #[cfg(feature = "rustls")]
             TlsAcceptorInner::Rustls(c) => {
-                let server = c.accept(Box::pin(stream)).await?;
+                let server = c.accept(stream).await?;
                 Ok(TlsStream::from(server))
             }
             #[cfg(feature = "py-dynamic-openssl")]
             TlsAcceptorInner::PyDynamicOpenSsl(a) => {
-                let server = a.accept(Box::pin(stream)).await?;
+                let server = a.accept(stream).await?;
                 Ok(TlsStream::from(server))
             }
             #[cfg(not(any(

--- a/compio-tls/src/lib.rs
+++ b/compio-tls/src/lib.rs
@@ -9,7 +9,6 @@
 #![doc(
     html_favicon_url = "https://github.com/compio-rs/compio-logo/raw/refs/heads/master/generated/colored-bold.svg"
 )]
-#![cfg_attr(feature = "read_buf", feature(read_buf, core_io_borrowed_buf))]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
 #[cfg(feature = "py-dynamic-openssl")]

--- a/compio-tls/src/maybe.rs
+++ b/compio-tls/src/maybe.rs
@@ -5,34 +5,25 @@ use std::{
     task::{Context, Poll},
 };
 
-use compio_buf::{BufResult, IoBuf, IoBufMut, IoVectoredBuf};
-use compio_io::{AsyncRead, AsyncWrite, compat::AsyncStream, util::Splittable};
+use futures_util::{AsyncRead, AsyncWrite};
 
-use crate::{TlsStream, read_futures};
+use crate::TlsStream;
 
 #[derive(Debug)]
 #[allow(clippy::large_enum_variant)]
-enum MaybeTlsStreamInner<S: Splittable> {
-    Plain(Pin<Box<AsyncStream<S>>>),
+enum MaybeTlsStreamInner<S> {
+    Plain(S),
     Tls(TlsStream<S>),
 }
 
-/// Stream that can be either plain TCP or TLS-encrypted, with compatibility for
-/// [`futures_util`].
+/// A futures-based stream that can be either plain TCP or TLS-encrypted.
 #[derive(Debug)]
-pub struct MaybeTlsStream<S: Splittable>(MaybeTlsStreamInner<S>);
+pub struct MaybeTlsStream<S>(MaybeTlsStreamInner<S>);
 
-impl<S: Splittable> MaybeTlsStream<S> {
+impl<S> MaybeTlsStream<S> {
     /// Create an unencrypted stream.
     pub fn new_plain(stream: S) -> Self {
-        Self(MaybeTlsStreamInner::Plain(Box::pin(AsyncStream::new(
-            stream,
-        ))))
-    }
-
-    /// Create an unencrypted stream from [`AsyncStream`].
-    pub fn new_plain_compat(stream: AsyncStream<S>) -> Self {
-        Self(MaybeTlsStreamInner::Plain(Box::pin(stream)))
+        Self(MaybeTlsStreamInner::Plain(stream))
     }
 
     /// Create a TLS-encrypted stream.
@@ -46,10 +37,9 @@ impl<S: Splittable> MaybeTlsStream<S> {
     }
 }
 
-impl<S: Splittable + 'static> MaybeTlsStream<S>
+impl<S> MaybeTlsStream<S>
 where
-    S::ReadHalf: AsyncRead + Unpin,
-    S::WriteHalf: AsyncWrite + Unpin,
+    S: AsyncRead + AsyncWrite + Unpin,
 {
     /// Returns the negotiated ALPN protocol.
     pub fn negotiated_alpn(&self) -> Option<Cow<'_, [u8]>> {
@@ -60,10 +50,9 @@ where
     }
 }
 
-impl<S: Splittable + 'static> futures_util::AsyncRead for MaybeTlsStream<S>
+impl<S> AsyncRead for MaybeTlsStream<S>
 where
-    S::ReadHalf: AsyncRead + Unpin,
-    S::WriteHalf: AsyncWrite + Unpin,
+    S: AsyncRead + AsyncWrite + Unpin,
 {
     fn poll_read(
         self: Pin<&mut Self>,
@@ -77,20 +66,9 @@ where
     }
 }
 
-impl<S: Splittable + 'static> AsyncRead for MaybeTlsStream<S>
+impl<S> AsyncWrite for MaybeTlsStream<S>
 where
-    S::ReadHalf: AsyncRead + Unpin,
-    S::WriteHalf: AsyncWrite + Unpin,
-{
-    async fn read<B: IoBufMut>(&mut self, buf: B) -> BufResult<usize, B> {
-        read_futures(self, buf).await
-    }
-}
-
-impl<S: Splittable + 'static> futures_util::AsyncWrite for MaybeTlsStream<S>
-where
-    S::ReadHalf: AsyncRead + Unpin,
-    S::WriteHalf: AsyncWrite + Unpin,
+    S: AsyncRead + AsyncWrite + Unpin,
 {
     fn poll_write(
         self: Pin<&mut Self>,
@@ -126,31 +104,5 @@ where
             MaybeTlsStreamInner::Plain(stream) => Pin::new(stream).poll_close(cx),
             MaybeTlsStreamInner::Tls(stream) => Pin::new(stream).poll_close(cx),
         }
-    }
-}
-
-impl<S: Splittable + 'static> AsyncWrite for MaybeTlsStream<S>
-where
-    S::ReadHalf: AsyncRead + Unpin,
-    S::WriteHalf: AsyncWrite + Unpin,
-{
-    async fn write<T: IoBuf>(&mut self, buf: T) -> BufResult<usize, T> {
-        let slice = buf.as_init();
-        let res = futures_util::AsyncWriteExt::write(self, slice).await;
-        BufResult(res, buf)
-    }
-
-    async fn write_vectored<T: IoVectoredBuf>(&mut self, buf: T) -> BufResult<usize, T> {
-        let slices = buf.iter_slice().map(io::IoSlice::new).collect::<Vec<_>>();
-        let res = futures_util::AsyncWriteExt::write_vectored(self, &slices).await;
-        BufResult(res, buf)
-    }
-
-    async fn flush(&mut self) -> io::Result<()> {
-        futures_util::AsyncWriteExt::flush(self).await
-    }
-
-    async fn shutdown(&mut self) -> io::Result<()> {
-        futures_util::AsyncWriteExt::close(self).await
     }
 }

--- a/compio-tls/src/rtls.rs
+++ b/compio-tls/src/rtls.rs
@@ -5,8 +5,7 @@ use std::{
     task::{Context, Poll},
 };
 
-use compio_io::{AsyncRead, AsyncWrite, compat::AsyncStream, util::Splittable};
-use futures_util::FutureExt;
+use futures_util::{AsyncRead, AsyncWrite, FutureExt};
 use rustls::{
     ServerConfig, ServerConnection,
     server::{Acceptor, ClientHello},
@@ -16,28 +15,21 @@ use crate::TlsStream;
 
 /// A lazy TLS acceptor that performs the initial handshake and allows access to
 /// the [`ClientHello`] message before completing the handshake.
-pub struct LazyConfigAcceptor<S: Splittable>(
-    futures_rustls::LazyConfigAcceptor<Pin<Box<AsyncStream<S>>>>,
-);
+pub struct LazyConfigAcceptor<S>(futures_rustls::LazyConfigAcceptor<S>);
 
-impl<S: Splittable + 'static> LazyConfigAcceptor<S>
+impl<S> LazyConfigAcceptor<S>
 where
-    S::ReadHalf: AsyncRead + Unpin,
-    S::WriteHalf: AsyncWrite + Unpin,
+    S: AsyncRead + AsyncWrite + Unpin,
 {
     /// Create a new [`LazyConfigAcceptor`] with the given acceptor and stream.
     pub fn new(acceptor: Acceptor, s: S) -> Self {
-        Self(futures_rustls::LazyConfigAcceptor::new(
-            acceptor,
-            Box::pin(AsyncStream::new(s)),
-        ))
+        Self(futures_rustls::LazyConfigAcceptor::new(acceptor, s))
     }
 }
 
-impl<S: Splittable + 'static> Future for LazyConfigAcceptor<S>
+impl<S> Future for LazyConfigAcceptor<S>
 where
-    S::ReadHalf: AsyncRead + Unpin,
-    S::WriteHalf: AsyncWrite + Unpin,
+    S: AsyncRead + AsyncWrite + Unpin,
 {
     type Output = Result<StartHandshake<S>, io::Error>;
 
@@ -48,12 +40,11 @@ where
 
 /// A TLS acceptor that has completed the initial handshake and allows access to
 /// the [`ClientHello`] message.
-pub struct StartHandshake<S: Splittable>(futures_rustls::StartHandshake<Pin<Box<AsyncStream<S>>>>);
+pub struct StartHandshake<S>(futures_rustls::StartHandshake<S>);
 
-impl<S: Splittable + 'static> StartHandshake<S>
+impl<S> StartHandshake<S>
 where
-    S::ReadHalf: AsyncRead + Unpin,
-    S::WriteHalf: AsyncWrite + Unpin,
+    S: AsyncRead + AsyncWrite + Unpin,
 {
     /// Get the [`ClientHello`] message from the initial handshake.
     pub fn client_hello(&self) -> ClientHello<'_> {

--- a/compio-tls/src/stream.rs
+++ b/compio-tls/src/stream.rs
@@ -5,33 +5,28 @@ use std::{
     task::{Context, Poll},
 };
 
-use compio_buf::{BufResult, IoBuf, IoBufMut, IoBufMutExt, IoVectoredBuf, SetLenExt};
-use compio_io::{AsyncRead, AsyncWrite, compat::AsyncStream, util::Splittable};
+use futures_util::{AsyncRead, AsyncWrite};
 
 #[derive(Debug)]
 #[allow(clippy::large_enum_variant)]
-enum TlsStreamInner<S: Splittable> {
+enum TlsStreamInner<S> {
     #[cfg(feature = "native-tls")]
-    NativeTls(crate::native::TlsStream<Pin<Box<AsyncStream<S>>>>),
+    NativeTls(crate::native::TlsStream<S>),
     #[cfg(feature = "rustls")]
-    Rustls(futures_rustls::TlsStream<Pin<Box<AsyncStream<S>>>>),
+    Rustls(futures_rustls::TlsStream<S>),
     #[cfg(feature = "py-dynamic-openssl")]
-    PyDynamicOpenSsl(crate::py_ossl::TlsStream<Pin<Box<AsyncStream<S>>>>),
+    PyDynamicOpenSsl(crate::py_ossl::TlsStream<S>),
     #[cfg(not(any(
         feature = "native-tls",
         feature = "rustls",
         feature = "py-dynamic-openssl",
     )))]
-    None(
-        std::convert::Infallible,
-        std::marker::PhantomData<Pin<Box<AsyncStream<S>>>>,
-    ),
+    None(std::convert::Infallible, std::marker::PhantomData<S>),
 }
 
-impl<S: Splittable + 'static> TlsStreamInner<S>
+impl<S> TlsStreamInner<S>
 where
-    S::ReadHalf: AsyncRead + Unpin,
-    S::WriteHalf: AsyncWrite + Unpin,
+    S: AsyncRead + AsyncWrite + Unpin,
 {
     pub fn negotiated_alpn(&self) -> Option<Cow<'_, [u8]>> {
         match self {
@@ -59,12 +54,11 @@ where
 /// data. Bytes read from a `TlsStream` are decrypted from `S` and bytes written
 /// to a `TlsStream` are encrypted when passing through to `S`.
 #[derive(Debug)]
-pub struct TlsStream<S: Splittable>(TlsStreamInner<S>);
+pub struct TlsStream<S>(TlsStreamInner<S>);
 
-impl<S: Splittable + 'static> TlsStream<S>
+impl<S> TlsStream<S>
 where
-    S::ReadHalf: AsyncRead + Unpin,
-    S::WriteHalf: AsyncWrite + Unpin,
+    S: AsyncRead + AsyncWrite + Unpin,
 {
     /// Returns the negotiated ALPN protocol.
     pub fn negotiated_alpn(&self) -> Option<Cow<'_, [u8]>> {
@@ -74,18 +68,16 @@ where
 
 #[cfg(feature = "native-tls")]
 #[doc(hidden)]
-impl<S: Splittable> From<crate::native::TlsStream<Pin<Box<AsyncStream<S>>>>> for TlsStream<S> {
-    fn from(value: crate::native::TlsStream<Pin<Box<AsyncStream<S>>>>) -> Self {
+impl<S> From<crate::native::TlsStream<S>> for TlsStream<S> {
+    fn from(value: crate::native::TlsStream<S>) -> Self {
         Self(TlsStreamInner::NativeTls(value))
     }
 }
 
 #[cfg(feature = "rustls")]
 #[doc(hidden)]
-impl<S: Splittable> From<futures_rustls::client::TlsStream<Pin<Box<AsyncStream<S>>>>>
-    for TlsStream<S>
-{
-    fn from(value: futures_rustls::client::TlsStream<Pin<Box<AsyncStream<S>>>>) -> Self {
+impl<S> From<futures_rustls::client::TlsStream<S>> for TlsStream<S> {
+    fn from(value: futures_rustls::client::TlsStream<S>) -> Self {
         Self(TlsStreamInner::Rustls(futures_rustls::TlsStream::Client(
             value,
         )))
@@ -94,10 +86,8 @@ impl<S: Splittable> From<futures_rustls::client::TlsStream<Pin<Box<AsyncStream<S
 
 #[cfg(feature = "rustls")]
 #[doc(hidden)]
-impl<S: Splittable> From<futures_rustls::server::TlsStream<Pin<Box<AsyncStream<S>>>>>
-    for TlsStream<S>
-{
-    fn from(value: futures_rustls::server::TlsStream<Pin<Box<AsyncStream<S>>>>) -> Self {
+impl<S> From<futures_rustls::server::TlsStream<S>> for TlsStream<S> {
+    fn from(value: futures_rustls::server::TlsStream<S>) -> Self {
         Self(TlsStreamInner::Rustls(futures_rustls::TlsStream::Server(
             value,
         )))
@@ -106,16 +96,15 @@ impl<S: Splittable> From<futures_rustls::server::TlsStream<Pin<Box<AsyncStream<S
 
 #[cfg(feature = "py-dynamic-openssl")]
 #[doc(hidden)]
-impl<S: Splittable> From<crate::py_ossl::TlsStream<Pin<Box<AsyncStream<S>>>>> for TlsStream<S> {
-    fn from(value: crate::py_ossl::TlsStream<Pin<Box<AsyncStream<S>>>>) -> Self {
+impl<S> From<crate::py_ossl::TlsStream<S>> for TlsStream<S> {
+    fn from(value: crate::py_ossl::TlsStream<S>) -> Self {
         Self(TlsStreamInner::PyDynamicOpenSsl(value))
     }
 }
 
-impl<S: Splittable + 'static> futures_util::AsyncRead for TlsStream<S>
+impl<S> AsyncRead for TlsStream<S>
 where
-    S::ReadHalf: AsyncRead + Unpin,
-    S::WriteHalf: AsyncWrite + Unpin,
+    S: AsyncRead + AsyncWrite + Unpin,
 {
     fn poll_read(
         self: Pin<&mut Self>,
@@ -139,39 +128,9 @@ where
     }
 }
 
-pub(crate) async fn read_futures<S: futures_util::AsyncRead + Unpin, B: IoBufMut>(
-    s: &mut S,
-    mut buf: B,
-) -> BufResult<usize, B> {
-    let slice = buf.ensure_init();
-    let res = futures_util::AsyncReadExt::read(s, slice).await;
-    let res = match res {
-        Ok(len) => {
-            unsafe { buf.advance_to(len) };
-            Ok(len)
-        }
-        // TLS streams may return UnexpectedEof when the connection is closed.
-        // https://docs.rs/rustls/latest/rustls/manual/_03_howto/index.html#unexpected-eof
-        Err(e) if e.kind() == io::ErrorKind::UnexpectedEof => Ok(0),
-        _ => res,
-    };
-    BufResult(res, buf)
-}
-
-impl<S: Splittable + 'static> AsyncRead for TlsStream<S>
+impl<S> AsyncWrite for TlsStream<S>
 where
-    S::ReadHalf: AsyncRead + Unpin,
-    S::WriteHalf: AsyncWrite + Unpin,
-{
-    async fn read<B: IoBufMut>(&mut self, buf: B) -> BufResult<usize, B> {
-        read_futures(self, buf).await
-    }
-}
-
-impl<S: Splittable + 'static> futures_util::AsyncWrite for TlsStream<S>
-where
-    S::ReadHalf: AsyncRead + Unpin,
-    S::WriteHalf: AsyncWrite + Unpin,
+    S: AsyncRead + AsyncWrite + Unpin,
 {
     fn poll_write(
         self: Pin<&mut Self>,
@@ -247,31 +206,5 @@ where
             )))]
             TlsStreamInner::None(f, ..) => match *f {},
         }
-    }
-}
-
-impl<S: Splittable + 'static> AsyncWrite for TlsStream<S>
-where
-    S::ReadHalf: AsyncRead + Unpin,
-    S::WriteHalf: AsyncWrite + Unpin,
-{
-    async fn write<T: IoBuf>(&mut self, buf: T) -> BufResult<usize, T> {
-        let slice = buf.as_init();
-        let res = futures_util::AsyncWriteExt::write(self, slice).await;
-        BufResult(res, buf)
-    }
-
-    async fn write_vectored<T: IoVectoredBuf>(&mut self, buf: T) -> BufResult<usize, T> {
-        let slices = buf.iter_slice().map(io::IoSlice::new).collect::<Vec<_>>();
-        let res = futures_util::AsyncWriteExt::write_vectored(self, &slices).await;
-        BufResult(res, buf)
-    }
-
-    async fn flush(&mut self) -> io::Result<()> {
-        futures_util::AsyncWriteExt::flush(self).await
-    }
-
-    async fn shutdown(&mut self) -> io::Result<()> {
-        futures_util::AsyncWriteExt::close(self).await
     }
 }

--- a/compio-tls/tests/echo.rs
+++ b/compio-tls/tests/echo.rs
@@ -1,34 +1,46 @@
-use std::net::SocketAddr;
+use std::{
+    future::poll_fn,
+    net::{Ipv4Addr, SocketAddr, TcpListener, TcpStream},
+};
 
-use compio_io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
-use compio_net::{TcpListener, TcpStream};
-use compio_runtime::JoinHandle;
+use compio_runtime::{JoinHandle, fd::PollFd};
 use compio_tls::{TlsAcceptor, TlsConnector};
+use futures_util::{AsyncReadExt, AsyncWriteExt};
 
 async fn start_server(acceptor: TlsAcceptor) -> (SocketAddr, JoinHandle<()>) {
-    let listener = TcpListener::bind("localhost:0").await.unwrap();
+    let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).unwrap();
+    listener.set_nonblocking(true).unwrap();
     let addr = listener.local_addr().unwrap();
+    let listener = PollFd::new(listener).unwrap();
     let server = compio_runtime::spawn(async move {
-        let (stream, _) = listener.accept().await.unwrap();
+        let (stream, _) = poll_fn(|cx| listener.poll_accept_with(cx, |inner| inner.accept()))
+            .await
+            .unwrap();
+        stream.set_nonblocking(true).unwrap();
+        let stream = PollFd::new(stream).unwrap();
         let mut stream = acceptor.accept(stream).await.unwrap();
-        let (_, res) = stream.read(Vec::with_capacity(12)).await.unwrap();
-        stream.write_all(res).await.unwrap();
+        let mut res = [0; 12];
+        stream.read_exact(&mut res).await.unwrap();
+        stream.write_all(&res).await.unwrap();
         stream.flush().await.unwrap();
-        stream.shutdown().await.unwrap();
-        stream.read(vec![0u8; 1]).await.unwrap();
+        stream.close().await.unwrap();
+        assert_eq!(stream.read(&mut [0]).await.unwrap(), 0);
     });
     (addr, server)
 }
 
 async fn connect(connector: TlsConnector, addr: SocketAddr) {
-    let stream = TcpStream::connect(addr).await.unwrap();
+    let stream = TcpStream::connect(addr).unwrap();
+    stream.set_nonblocking(true).unwrap();
+    let stream = PollFd::new(stream).unwrap();
     let mut stream = connector.connect("localhost", stream).await.unwrap();
 
-    stream.write_all("Hello world!").await.unwrap();
+    stream.write_all(b"Hello world!").await.unwrap();
     stream.flush().await.unwrap();
-    let (_, res) = stream.read_to_end(vec![]).await.unwrap();
+    let mut res = vec![];
+    stream.read_to_end(&mut res).await.unwrap();
     assert_eq!(res, b"Hello world!");
-    stream.shutdown().await.unwrap()
+    stream.close().await.unwrap()
 }
 
 #[cfg(feature = "native-tls")]

--- a/compio-tls/tests/echo.rs
+++ b/compio-tls/tests/echo.rs
@@ -1,11 +1,9 @@
-use std::{
-    future::poll_fn,
-    net::{Ipv4Addr, SocketAddr, TcpListener, TcpStream},
-};
+use std::net::{Ipv4Addr, SocketAddr, TcpListener};
 
 use compio_runtime::{JoinHandle, fd::PollFd};
 use compio_tls::{TlsAcceptor, TlsConnector};
 use futures_util::{AsyncReadExt, AsyncWriteExt};
+use socket2::{Domain, Protocol, Socket, Type};
 
 async fn start_server(acceptor: TlsAcceptor) -> (SocketAddr, JoinHandle<()>) {
     let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).unwrap();
@@ -13,11 +11,7 @@ async fn start_server(acceptor: TlsAcceptor) -> (SocketAddr, JoinHandle<()>) {
     let addr = listener.local_addr().unwrap();
     let listener = PollFd::new(listener).unwrap();
     let server = compio_runtime::spawn(async move {
-        let (stream, _) = poll_fn(|cx| listener.poll_accept_with(cx, |inner| inner.accept()))
-            .await
-            .unwrap();
-        stream.set_nonblocking(true).unwrap();
-        let stream = PollFd::new(stream).unwrap();
+        let (stream, _) = listener.accept().await.unwrap();
         let mut stream = acceptor.accept(stream).await.unwrap();
         let mut res = [0; 12];
         stream.read_exact(&mut res).await.unwrap();
@@ -30,9 +24,9 @@ async fn start_server(acceptor: TlsAcceptor) -> (SocketAddr, JoinHandle<()>) {
 }
 
 async fn connect(connector: TlsConnector, addr: SocketAddr) {
-    let stream = TcpStream::connect(addr).unwrap();
-    stream.set_nonblocking(true).unwrap();
+    let stream = Socket::new(Domain::IPV4, Type::STREAM, Some(Protocol::TCP)).unwrap();
     let stream = PollFd::new(stream).unwrap();
+    stream.connect(&addr.into()).await.unwrap();
     let mut stream = connector.connect("localhost", stream).await.unwrap();
 
     stream.write_all(b"Hello world!").await.unwrap();

--- a/compio-ws/Cargo.toml
+++ b/compio-ws/Cargo.toml
@@ -16,7 +16,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 [dependencies]
 compio-buf = { workspace = true }
 compio-driver = { workspace = true }
-compio-net = { workspace = true, optional = true }
+compio-net = { workspace = true }
 compio-runtime = { workspace = true }
 compio-tls = { workspace = true, default-features = false }
 compio-log = { workspace = true }
@@ -35,7 +35,6 @@ socket2 = { workspace = true }
 [dev-dependencies]
 compio-driver = { workspace = true, features = ["polling"] }
 compio-macros = { workspace = true }
-compio-net = { workspace = true }
 
 futures-channel = { workspace = true }
 rustls-pemfile = "2.0"
@@ -43,7 +42,7 @@ tracing-subscriber = { workspace = true, features = ["env-filter"] }
 
 [features]
 default = []
-connect = ["dep:compio-net"]
+connect = []
 native-tls = ["connect", "compio-tls/native-tls", "tungstenite/native-tls"]
 native-tls-vendored = ["native-tls", "compio-tls/native-tls-vendored"]
 rustls = ["connect", "compio-tls/rustls", "tungstenite/__rustls-tls"]

--- a/compio-ws/Cargo.toml
+++ b/compio-ws/Cargo.toml
@@ -15,8 +15,9 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
 compio-buf = { workspace = true }
-compio-io = { workspace = true, features = ["compat"] }
+compio-driver = { workspace = true }
 compio-net = { workspace = true, optional = true }
+compio-runtime = { workspace = true }
 compio-tls = { workspace = true, default-features = false }
 compio-log = { workspace = true }
 
@@ -29,10 +30,11 @@ webpki-roots = { workspace = true, optional = true }
 
 futures-util = { workspace = true, features = ["sink"] }
 pin-project-lite = { workspace = true }
+socket2 = { workspace = true }
 
 [dev-dependencies]
+compio-driver = { workspace = true, features = ["polling"] }
 compio-macros = { workspace = true }
-compio-runtime = { workspace = true }
 compio-net = { workspace = true }
 
 futures-channel = { workspace = true }

--- a/compio-ws/Cargo.toml
+++ b/compio-ws/Cargo.toml
@@ -33,7 +33,6 @@ pin-project-lite = { workspace = true }
 socket2 = { workspace = true }
 
 [dev-dependencies]
-compio-driver = { workspace = true, features = ["polling"] }
 compio-macros = { workspace = true }
 
 futures-channel = { workspace = true }

--- a/compio-ws/README.md
+++ b/compio-ws/README.md
@@ -29,8 +29,6 @@ This crate provides WebSocket client and server support for compio applications,
 
 ## Usage
 
-### For application
-
 Use `compio` directly with `ws-connect` feature enabled:
 
 ```bash
@@ -53,12 +51,4 @@ let (mut ws_stream, _) = connect_async("wss://echo.websocket.org").await?;
 // Send and receive messages
 ws_stream.send(Message::text("Hello WebSocket!")).await?;
 let msg = ws_stream.next().await.unwrap()?;
-```
-
-### For library
-
-If you are writing libraries that want to support completion-based async WebSocket, you can depend on this crate directly:
-
-```bash
-cargo add compio-ws
 ```

--- a/compio-ws/README.md
+++ b/compio-ws/README.md
@@ -62,5 +62,3 @@ If you are writing libraries that want to support completion-based async WebSock
 ```bash
 cargo add compio-ws
 ```
-
-`compio-ws` is runtime agnostic only when `connect` feature is disabled.

--- a/compio-ws/examples/echo_server_tls.rs
+++ b/compio-ws/examples/echo_server_tls.rs
@@ -98,7 +98,7 @@ async fn handle_client_tls(
 ) -> Result<(), Box<dyn std::error::Error>> {
     // Perform TLS handshake
     println!("Performing TLS handshake...");
-    let tls_stream = acceptor.accept(stream).await?;
+    let tls_stream = acceptor.accept(stream.into_poll_fd()?).await?;
     println!("TLS handshake completed");
 
     // Perform WebSocket handshake

--- a/compio-ws/examples/ws_split.rs
+++ b/compio-ws/examples/ws_split.rs
@@ -4,6 +4,7 @@ use futures_util::{
     SinkExt, StreamExt,
     stream::{SplitSink, SplitStream},
 };
+use socket2::Socket;
 use tungstenite::Message;
 
 const N: usize = 16384;
@@ -29,7 +30,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
-async fn run_client() -> WebSocketStream<TcpStream> {
+async fn run_client() -> WebSocketStream<Socket> {
     let stream = TcpStream::connect("127.0.0.1:8081").await.unwrap();
     let (mut ws, _) = client_async("ws://127.0.0.1:8081", stream).await.unwrap();
     println!("Connected");
@@ -57,8 +58,8 @@ async fn run_client() -> WebSocketStream<TcpStream> {
 }
 
 async fn server_recv_task(
-    mut ws: SplitStream<WebSocketStream<TcpStream>>,
-) -> SplitStream<WebSocketStream<TcpStream>> {
+    mut ws: SplitStream<WebSocketStream<Socket>>,
+) -> SplitStream<WebSocketStream<Socket>> {
     let mut n = 0;
     loop {
         ws.next().await.unwrap().unwrap();
@@ -73,8 +74,8 @@ async fn server_recv_task(
 }
 
 async fn server_send_task(
-    mut ws: SplitSink<WebSocketStream<TcpStream>, Message>,
-) -> SplitSink<WebSocketStream<TcpStream>, Message> {
+    mut ws: SplitSink<WebSocketStream<Socket>, Message>,
+) -> SplitSink<WebSocketStream<Socket>, Message> {
     let data = vec![0; MSG_LEN];
     for _ in 0..N {
         ws.send(Message::Binary(data.clone().into())).await.unwrap();

--- a/compio-ws/src/lib.rs
+++ b/compio-ws/src/lib.rs
@@ -21,12 +21,14 @@
 )]
 
 use std::{
+    io::{Read, Write},
     pin::Pin,
     task::{Context, Poll, ready},
 };
 
 use compio_buf::IntoInner;
-use compio_io::{AsyncRead, AsyncWrite, compat::AsyncStream, util::Splittable};
+use compio_driver::AsFd;
+use compio_runtime::fd::PollFd;
 use compio_tls::{MaybeTlsStream, TlsStream};
 use futures_util::{Sink, SinkExt, Stream, StreamExt, stream::FusedStream};
 use pin_project_lite::pin_project;
@@ -43,6 +45,8 @@ mod tls;
 pub use tls::*;
 pub use tungstenite;
 
+type MaybePollStream<S> = MaybeTlsStream<PollFd<S>>;
+
 /// Configuration for compio-ws.
 ///
 /// ## API Interface
@@ -57,29 +61,16 @@ pub struct Config {
     /// WebSocket configuration from tungstenite.
     websocket: Option<WebSocketConfig>,
 
-    /// Base buffer size
-    buffer_size_base: usize,
-
-    /// Maximum buffer size
-    buffer_size_limit: usize,
-
     /// Disable Nagle's algorithm. This only affects
     /// [`connect_async_with_config()`] and [`connect_async_tls_with_config()`].
     disable_nagle: bool,
 }
 
 impl Config {
-    // 128 KiB, see <https://github.com/compio-rs/compio/pull/532>.
-    const DEFAULT_BUF_SIZE: usize = 128 * 1024;
-    // 64 MiB, the same as [`SyncStream`].
-    const DEFAULT_MAX_BUFFER: usize = 64 * 1024 * 1024;
-
     /// Creates a new `Config` with default settings.
     pub fn new() -> Self {
         Self {
             websocket: None,
-            buffer_size_base: Self::DEFAULT_BUF_SIZE,
-            buffer_size_limit: Self::DEFAULT_MAX_BUFFER,
             disable_nagle: false,
         }
     }
@@ -87,41 +78,6 @@ impl Config {
     /// Get the WebSocket configuration.
     pub fn websocket_config(&self) -> Option<&WebSocketConfig> {
         self.websocket.as_ref()
-    }
-
-    /// Get the base buffer size.
-    pub fn buffer_size_base(&self) -> usize {
-        self.buffer_size_base
-    }
-
-    /// Get the maximum buffer size.
-    pub fn buffer_size_limit(&self) -> usize {
-        self.buffer_size_limit
-    }
-
-    /// Set custom base buffer size.
-    ///
-    /// Default to 128 KiB.
-    pub fn with_buffer_size_base(mut self, size: usize) -> Self {
-        self.buffer_size_base = size;
-        self
-    }
-
-    /// Set custom maximum buffer size.
-    ///
-    /// Default to 64 MiB.
-    pub fn with_buffer_size_limit(mut self, size: usize) -> Self {
-        self.buffer_size_limit = size;
-        self
-    }
-
-    /// Set custom buffer sizes.
-    ///
-    /// Default to 128 KiB for base and 64 MiB for limit.
-    pub fn with_buffer_sizes(mut self, base: usize, limit: usize) -> Self {
-        self.buffer_size_base = base;
-        self.buffer_size_limit = limit;
-        self
     }
 
     /// Disable Nagle's algorithm, i.e. `set_nodelay(true)`.
@@ -163,45 +119,38 @@ mod private {
 
     pub trait Sealed<S>
     where
-        S: Splittable,
+        S: AsFd,
     {
     }
 
-    impl<S: Splittable> Sealed<S> for S {}
-    impl<S: Splittable> Sealed<S> for AsyncStream<S> {}
-    impl<S: Splittable> Sealed<S> for MaybeTlsStream<S> {}
-    impl<S: Splittable> Sealed<S> for TlsStream<S> {}
+    impl<S: AsFd> Sealed<S> for PollFd<S> {}
+    impl<S: AsFd> Sealed<S> for MaybePollStream<S> {}
+    impl<S: AsFd> Sealed<S> for TlsStream<PollFd<S>> {}
 }
 
-/// Create [`MaybeTlsStream`] with capacity and buffer size limit.
+/// Convert a stream into a [`MaybeTlsStream`].
 pub trait IntoMaybeTlsStream<S>: private::Sealed<S>
 where
-    S: Splittable,
+    S: AsFd,
 {
-    /// Create [`MaybeTlsStream`] with capacity and buffer size limit.
-    fn into_maybe_tls_stream(self, capacity: usize, max_buffer_size: usize) -> MaybeTlsStream<S>;
+    /// Convert this stream into a [`MaybeTlsStream`].
+    fn into_maybe_tls_stream(self) -> MaybePollStream<S>;
 }
 
-impl<S: Splittable> IntoMaybeTlsStream<S> for S {
-    fn into_maybe_tls_stream(self, capacity: usize, max_buffer_size: usize) -> MaybeTlsStream<S> {
-        MaybeTlsStream::new_plain_compat(AsyncStream::with_limits(capacity, max_buffer_size, self))
+impl<S: AsFd> IntoMaybeTlsStream<S> for PollFd<S> {
+    fn into_maybe_tls_stream(self) -> MaybePollStream<S> {
+        MaybeTlsStream::new_plain(self)
     }
 }
 
-impl<S: Splittable> IntoMaybeTlsStream<S> for AsyncStream<S> {
-    fn into_maybe_tls_stream(self, _: usize, _: usize) -> MaybeTlsStream<S> {
-        MaybeTlsStream::new_plain_compat(self)
-    }
-}
-
-impl<S: Splittable> IntoMaybeTlsStream<S> for MaybeTlsStream<S> {
-    fn into_maybe_tls_stream(self, _: usize, _: usize) -> MaybeTlsStream<S> {
+impl<S: AsFd> IntoMaybeTlsStream<S> for MaybePollStream<S> {
+    fn into_maybe_tls_stream(self) -> MaybePollStream<S> {
         self
     }
 }
 
-impl<S: Splittable> IntoMaybeTlsStream<S> for TlsStream<S> {
-    fn into_maybe_tls_stream(self, _: usize, _: usize) -> MaybeTlsStream<S> {
+impl<S: AsFd> IntoMaybeTlsStream<S> for TlsStream<PollFd<S>> {
+    fn into_maybe_tls_stream(self) -> MaybePollStream<S> {
         MaybeTlsStream::new_tls(self)
     }
 }
@@ -209,25 +158,24 @@ impl<S: Splittable> IntoMaybeTlsStream<S> for TlsStream<S> {
 pin_project! {
     /// A WebSocket stream that works with compio.
     #[derive(Debug)]
-    pub struct WebSocketStream<S: Splittable> {
+    pub struct WebSocketStream<S: AsFd> {
         #[pin]
-        inner: async_tungstenite::WebSocketStream<MaybeTlsStream<S>>,
+        inner: async_tungstenite::WebSocketStream<MaybePollStream<S>>,
         next_item: Option<Option<Result<Message, WsError>>>,
     }
 }
 
-impl<S: Splittable + 'static> WebSocketStream<S>
+impl<S: AsFd + 'static> WebSocketStream<S>
 where
-    S::ReadHalf: AsyncRead + Unpin,
-    S::WriteHalf: AsyncWrite + Unpin,
+    for<'a> &'a S: Read + Write,
 {
     /// Get a reference to the underlying stream.
-    pub fn get_ref(&self) -> &MaybeTlsStream<S> {
+    pub fn get_ref(&self) -> &MaybePollStream<S> {
         self.inner.get_ref()
     }
 
     /// Get a mutable reference to the underlying stream.
-    pub fn get_mut(&mut self) -> &mut MaybeTlsStream<S> {
+    pub fn get_mut(&mut self) -> &mut MaybePollStream<S> {
         self.inner.get_mut()
     }
 
@@ -246,7 +194,7 @@ where
 
         Self::from_inner(
             async_tungstenite::WebSocketStream::from_raw_socket(
-                stream.into_maybe_tls_stream(config.buffer_size_base, config.buffer_size_limit),
+                stream.into_maybe_tls_stream(),
                 role,
                 config.websocket,
             )
@@ -270,7 +218,7 @@ where
 
         Self::from_inner(
             async_tungstenite::WebSocketStream::from_partially_read(
-                stream.into_maybe_tls_stream(config.buffer_size_base, config.buffer_size_limit),
+                stream.into_maybe_tls_stream(),
                 part,
                 role,
                 config.websocket,
@@ -279,7 +227,7 @@ where
         )
     }
 
-    fn from_inner(inner: async_tungstenite::WebSocketStream<MaybeTlsStream<S>>) -> Self {
+    fn from_inner(inner: async_tungstenite::WebSocketStream<MaybePollStream<S>>) -> Self {
         WebSocketStream {
             inner,
             next_item: None,
@@ -309,18 +257,17 @@ where
     }
 }
 
-impl<S: Splittable> IntoInner for WebSocketStream<S> {
-    type Inner = MaybeTlsStream<S>;
+impl<S: AsFd> IntoInner for WebSocketStream<S> {
+    type Inner = MaybePollStream<S>;
 
     fn into_inner(self) -> Self::Inner {
         self.inner.into_inner()
     }
 }
 
-impl<S: Splittable + 'static> Sink<Message> for WebSocketStream<S>
+impl<S: AsFd + 'static> Sink<Message> for WebSocketStream<S>
 where
-    S::ReadHalf: AsyncRead + Unpin,
-    S::WriteHalf: AsyncWrite + Unpin,
+    for<'a> &'a S: Read + Write,
 {
     type Error = WsError;
 
@@ -346,10 +293,9 @@ where
     }
 }
 
-impl<S: Splittable + 'static> Stream for WebSocketStream<S>
+impl<S: AsFd + 'static> Stream for WebSocketStream<S>
 where
-    S::ReadHalf: AsyncRead + Unpin,
-    S::WriteHalf: AsyncWrite + Unpin,
+    for<'a> &'a S: Read + Write,
 {
     type Item = Result<Message, WsError>;
 
@@ -371,10 +317,9 @@ where
     }
 }
 
-impl<S: Splittable + 'static> FusedStream for WebSocketStream<S>
+impl<S: AsFd + 'static> FusedStream for WebSocketStream<S>
 where
-    S::ReadHalf: AsyncRead + Unpin,
-    S::WriteHalf: AsyncWrite + Unpin,
+    for<'a> &'a S: Read + Write,
 {
     fn is_terminated(&self) -> bool {
         self.inner.is_terminated()
@@ -393,9 +338,8 @@ where
 /// the server half of accepting a client's websocket connection.
 pub async fn accept_async<S, T>(stream: T) -> Result<WebSocketStream<S>, WsError>
 where
-    S: Splittable + 'static,
-    <S as Splittable>::ReadHalf: AsyncRead + Unpin,
-    <S as Splittable>::WriteHalf: AsyncWrite + Unpin,
+    S: AsFd + 'static,
+    for<'a> &'a S: Read + Write,
     T: IntoMaybeTlsStream<S>,
 {
     accept_hdr_async(stream, NoCallback).await
@@ -407,9 +351,8 @@ pub async fn accept_async_with_config<S, T>(
     config: impl Into<Config>,
 ) -> Result<WebSocketStream<S>, WsError>
 where
-    S: Splittable + 'static,
-    <S as Splittable>::ReadHalf: AsyncRead + Unpin,
-    <S as Splittable>::WriteHalf: AsyncWrite + Unpin,
+    S: AsFd + 'static,
+    for<'a> &'a S: Read + Write,
     T: IntoMaybeTlsStream<S>,
 {
     accept_hdr_with_config_async(stream, NoCallback, config).await
@@ -425,11 +368,10 @@ pub async fn accept_hdr_async<S, T, C>(
     callback: C,
 ) -> Result<WebSocketStream<S>, WsError>
 where
-    S: Splittable + 'static,
+    S: AsFd + 'static,
+    for<'a> &'a S: Read + Write,
     T: IntoMaybeTlsStream<S>,
     C: Callback + Unpin,
-    <S as Splittable>::ReadHalf: AsyncRead + Unpin,
-    <S as Splittable>::WriteHalf: AsyncWrite + Unpin,
 {
     accept_hdr_with_config_async(stream, callback, None).await
 }
@@ -441,15 +383,14 @@ pub async fn accept_hdr_with_config_async<S, T, C>(
     config: impl Into<Config>,
 ) -> Result<WebSocketStream<S>, WsError>
 where
-    S: Splittable + 'static,
+    S: AsFd + 'static,
+    for<'a> &'a S: Read + Write,
     T: IntoMaybeTlsStream<S>,
     C: Callback + Unpin,
-    <S as Splittable>::ReadHalf: AsyncRead + Unpin,
-    <S as Splittable>::WriteHalf: AsyncWrite + Unpin,
 {
     let config = config.into();
     let inner = async_tungstenite::accept_hdr_async_with_config(
-        stream.into_maybe_tls_stream(config.buffer_size_base, config.buffer_size_limit),
+        stream.into_maybe_tls_stream(),
         callback,
         config.websocket,
     )
@@ -476,9 +417,8 @@ pub async fn client_async<R, S, T>(
 ) -> Result<(WebSocketStream<S>, tungstenite::handshake::client::Response), WsError>
 where
     R: IntoClientRequest + Unpin,
-    S: Splittable + 'static,
-    <S as Splittable>::ReadHalf: AsyncRead + Unpin,
-    <S as Splittable>::WriteHalf: AsyncWrite + Unpin,
+    S: AsFd + 'static,
+    for<'a> &'a S: Read + Write,
     T: IntoMaybeTlsStream<S>,
 {
     client_async_with_config(request, stream, None).await
@@ -492,15 +432,14 @@ pub async fn client_async_with_config<R, S, T>(
 ) -> Result<(WebSocketStream<S>, tungstenite::handshake::client::Response), WsError>
 where
     R: IntoClientRequest + Unpin,
-    S: Splittable + 'static,
-    <S as Splittable>::ReadHalf: AsyncRead + Unpin,
-    <S as Splittable>::WriteHalf: AsyncWrite + Unpin,
+    S: AsFd + 'static,
+    for<'a> &'a S: Read + Write,
     T: IntoMaybeTlsStream<S>,
 {
     let config = config.into();
     let (inner, response) = async_tungstenite::client_async_with_config(
         request,
-        stream.into_maybe_tls_stream(config.buffer_size_base, config.buffer_size_limit),
+        stream.into_maybe_tls_stream(),
         config.websocket,
     )
     .await?;

--- a/compio-ws/src/lib.rs
+++ b/compio-ws/src/lib.rs
@@ -21,16 +21,19 @@
 )]
 
 use std::{
+    io,
     pin::Pin,
     task::{Context, Poll, ready},
 };
 
 use compio_buf::IntoInner;
 use compio_driver::AsFd;
+use compio_net::{TcpStream, UnixStream};
 use compio_runtime::fd::PollFd;
 use compio_tls::{MaybeTlsStream, TlsStream};
 use futures_util::{Sink, SinkExt, Stream, StreamExt, stream::FusedStream};
 use pin_project_lite::pin_project;
+use socket2::Socket;
 use tungstenite::{
     Error as WsError, Message,
     client::IntoClientRequest,
@@ -125,6 +128,8 @@ mod private {
     impl<S: AsFd> Sealed<S> for PollFd<S> {}
     impl<S: AsFd> Sealed<S> for MaybePollStream<S> {}
     impl<S: AsFd> Sealed<S> for TlsStream<PollFd<S>> {}
+    impl Sealed<Socket> for TcpStream {}
+    impl Sealed<Socket> for UnixStream {}
 }
 
 /// Convert a stream into a [`MaybeTlsStream`].
@@ -133,24 +138,36 @@ where
     S: AsFd,
 {
     /// Convert this stream into a [`MaybeTlsStream`].
-    fn into_maybe_tls_stream(self) -> MaybePollStream<S>;
+    fn into_maybe_tls_stream(self) -> io::Result<MaybePollStream<S>>;
 }
 
 impl<S: AsFd> IntoMaybeTlsStream<S> for PollFd<S> {
-    fn into_maybe_tls_stream(self) -> MaybePollStream<S> {
-        MaybeTlsStream::new_plain(self)
+    fn into_maybe_tls_stream(self) -> io::Result<MaybePollStream<S>> {
+        Ok(MaybeTlsStream::new_plain(self))
     }
 }
 
 impl<S: AsFd> IntoMaybeTlsStream<S> for MaybePollStream<S> {
-    fn into_maybe_tls_stream(self) -> MaybePollStream<S> {
-        self
+    fn into_maybe_tls_stream(self) -> io::Result<MaybePollStream<S>> {
+        Ok(self)
     }
 }
 
 impl<S: AsFd> IntoMaybeTlsStream<S> for TlsStream<PollFd<S>> {
-    fn into_maybe_tls_stream(self) -> MaybePollStream<S> {
-        MaybeTlsStream::new_tls(self)
+    fn into_maybe_tls_stream(self) -> io::Result<MaybePollStream<S>> {
+        Ok(MaybeTlsStream::new_tls(self))
+    }
+}
+
+impl IntoMaybeTlsStream<Socket> for TcpStream {
+    fn into_maybe_tls_stream(self) -> io::Result<MaybePollStream<Socket>> {
+        Ok(MaybeTlsStream::new_plain(self.into_poll_fd()?))
+    }
+}
+
+impl IntoMaybeTlsStream<Socket> for UnixStream {
+    fn into_maybe_tls_stream(self) -> io::Result<MaybePollStream<Socket>> {
+        Ok(MaybeTlsStream::new_plain(self.into_poll_fd()?))
     }
 }
 
@@ -185,17 +202,17 @@ impl<S: AsFd + 'static> WebSocketStream<S> {
         stream: T,
         role: Role,
         config: impl Into<Config>,
-    ) -> Self {
+    ) -> io::Result<Self> {
         let config = config.into();
 
-        Self::from_inner(
+        Ok(Self::from_inner(
             async_tungstenite::WebSocketStream::from_raw_socket(
-                stream.into_maybe_tls_stream(),
+                stream.into_maybe_tls_stream()?,
                 role,
                 config.websocket,
             )
             .await,
-        )
+        ))
     }
 
     /// Convert a raw socket into a [`WebSocketStream`] without performing a
@@ -209,18 +226,18 @@ impl<S: AsFd + 'static> WebSocketStream<S> {
         part: Vec<u8>,
         role: Role,
         config: impl Into<Config>,
-    ) -> Self {
+    ) -> io::Result<Self> {
         let config = config.into();
 
-        Self::from_inner(
+        Ok(Self::from_inner(
             async_tungstenite::WebSocketStream::from_partially_read(
-                stream.into_maybe_tls_stream(),
+                stream.into_maybe_tls_stream()?,
                 part,
                 role,
                 config.websocket,
             )
             .await,
-        )
+        ))
     }
 
     fn from_inner(inner: async_tungstenite::WebSocketStream<MaybePollStream<S>>) -> Self {
@@ -373,7 +390,7 @@ where
 {
     let config = config.into();
     let inner = async_tungstenite::accept_hdr_async_with_config(
-        stream.into_maybe_tls_stream(),
+        stream.into_maybe_tls_stream()?,
         callback,
         config.websocket,
     )
@@ -420,7 +437,7 @@ where
     let config = config.into();
     let (inner, response) = async_tungstenite::client_async_with_config(
         request,
-        stream.into_maybe_tls_stream(),
+        stream.into_maybe_tls_stream()?,
         config.websocket,
     )
     .await?;

--- a/compio-ws/src/lib.rs
+++ b/compio-ws/src/lib.rs
@@ -21,7 +21,6 @@
 )]
 
 use std::{
-    io::{Read, Write},
     pin::Pin,
     task::{Context, Poll, ready},
 };
@@ -165,10 +164,7 @@ pin_project! {
     }
 }
 
-impl<S: AsFd + 'static> WebSocketStream<S>
-where
-    for<'a> &'a S: Read + Write,
-{
+impl<S: AsFd + 'static> WebSocketStream<S> {
     /// Get a reference to the underlying stream.
     pub fn get_ref(&self) -> &MaybePollStream<S> {
         self.inner.get_ref()
@@ -265,10 +261,7 @@ impl<S: AsFd> IntoInner for WebSocketStream<S> {
     }
 }
 
-impl<S: AsFd + 'static> Sink<Message> for WebSocketStream<S>
-where
-    for<'a> &'a S: Read + Write,
-{
+impl<S: AsFd + 'static> Sink<Message> for WebSocketStream<S> {
     type Error = WsError;
 
     fn poll_ready(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), WsError>> {
@@ -293,10 +286,7 @@ where
     }
 }
 
-impl<S: AsFd + 'static> Stream for WebSocketStream<S>
-where
-    for<'a> &'a S: Read + Write,
-{
+impl<S: AsFd + 'static> Stream for WebSocketStream<S> {
     type Item = Result<Message, WsError>;
 
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
@@ -317,10 +307,7 @@ where
     }
 }
 
-impl<S: AsFd + 'static> FusedStream for WebSocketStream<S>
-where
-    for<'a> &'a S: Read + Write,
-{
+impl<S: AsFd + 'static> FusedStream for WebSocketStream<S> {
     fn is_terminated(&self) -> bool {
         self.inner.is_terminated()
     }
@@ -339,7 +326,6 @@ where
 pub async fn accept_async<S, T>(stream: T) -> Result<WebSocketStream<S>, WsError>
 where
     S: AsFd + 'static,
-    for<'a> &'a S: Read + Write,
     T: IntoMaybeTlsStream<S>,
 {
     accept_hdr_async(stream, NoCallback).await
@@ -352,7 +338,6 @@ pub async fn accept_async_with_config<S, T>(
 ) -> Result<WebSocketStream<S>, WsError>
 where
     S: AsFd + 'static,
-    for<'a> &'a S: Read + Write,
     T: IntoMaybeTlsStream<S>,
 {
     accept_hdr_with_config_async(stream, NoCallback, config).await
@@ -369,7 +354,6 @@ pub async fn accept_hdr_async<S, T, C>(
 ) -> Result<WebSocketStream<S>, WsError>
 where
     S: AsFd + 'static,
-    for<'a> &'a S: Read + Write,
     T: IntoMaybeTlsStream<S>,
     C: Callback + Unpin,
 {
@@ -384,7 +368,6 @@ pub async fn accept_hdr_with_config_async<S, T, C>(
 ) -> Result<WebSocketStream<S>, WsError>
 where
     S: AsFd + 'static,
-    for<'a> &'a S: Read + Write,
     T: IntoMaybeTlsStream<S>,
     C: Callback + Unpin,
 {
@@ -418,7 +401,6 @@ pub async fn client_async<R, S, T>(
 where
     R: IntoClientRequest + Unpin,
     S: AsFd + 'static,
-    for<'a> &'a S: Read + Write,
     T: IntoMaybeTlsStream<S>,
 {
     client_async_with_config(request, stream, None).await
@@ -433,7 +415,6 @@ pub async fn client_async_with_config<R, S, T>(
 where
     R: IntoClientRequest + Unpin,
     S: AsFd + 'static,
-    for<'a> &'a S: Read + Write,
     T: IntoMaybeTlsStream<S>,
 {
     let config = config.into();

--- a/compio-ws/src/tls.rs
+++ b/compio-ws/src/tls.rs
@@ -1,8 +1,12 @@
 //! TLS support for WebSocket connections (native-tls and rustls).
 
-use compio_io::{AsyncRead, AsyncWrite, compat::AsyncStream, util::Splittable};
+use std::io::{Read, Write};
+
+use compio_driver::AsFd;
 use compio_net::TcpStream;
+use compio_runtime::fd::PollFd;
 use compio_tls::{MaybeTlsStream, TlsConnector};
+use socket2::Socket;
 use tungstenite::{
     Error,
     client::{IntoClientRequest, uri_mode},
@@ -112,21 +116,17 @@ mod encryption {
 }
 
 async fn wrap_stream<S>(
-    socket: S,
+    socket: PollFd<S>,
     domain: &str,
     connector: Option<TlsConnector>,
     mode: Mode,
-    cap: usize,
-    max_buffer_size: usize,
-) -> Result<MaybeTlsStream<S>, Error>
+) -> Result<MaybeTlsStream<PollFd<S>>, Error>
 where
-    S: Splittable + 'static,
-    S::ReadHalf: AsyncRead + Unpin,
-    S::WriteHalf: AsyncWrite + Unpin,
+    S: AsFd + 'static,
+    for<'a> &'a S: Read + Write,
 {
-    let socket = AsyncStream::with_limits(cap, max_buffer_size, socket);
     match mode {
-        Mode::Plain => Ok(MaybeTlsStream::new_plain_compat(socket)),
+        Mode::Plain => Ok(MaybeTlsStream::new_plain(socket)),
         Mode::Tls => {
             let stream = {
                 let connector = if let Some(connector) = connector {
@@ -164,10 +164,7 @@ where
                     }
                 };
 
-                connector
-                    .connect_compat(domain, socket)
-                    .await
-                    .map_err(Error::Io)?
+                connector.connect(domain, socket).await.map_err(Error::Io)?
             };
             Ok(MaybeTlsStream::new_tls(stream))
         }
@@ -178,13 +175,12 @@ where
 /// upgrading the stream to TLS if required.
 pub async fn client_async_tls<R, S>(
     request: R,
-    stream: S,
+    stream: PollFd<S>,
 ) -> Result<(WebSocketStream<S>, Response), Error>
 where
     R: IntoClientRequest,
-    S: Splittable + 'static,
-    S::ReadHalf: AsyncRead + Unpin,
-    S::WriteHalf: AsyncWrite + Unpin,
+    S: AsFd + 'static,
+    for<'a> &'a S: Read + Write,
 {
     client_async_tls_with_config(request, stream, None, None).await
 }
@@ -193,15 +189,14 @@ where
 /// configuration, and an optional connector.
 pub async fn client_async_tls_with_config<R, S>(
     request: R,
-    stream: S,
+    stream: PollFd<S>,
     connector: Option<TlsConnector>,
     config: impl Into<Config>,
 ) -> Result<(WebSocketStream<S>, Response), Error>
 where
     R: IntoClientRequest,
-    S: Splittable + 'static,
-    S::ReadHalf: AsyncRead + Unpin,
-    S::WriteHalf: AsyncWrite + Unpin,
+    S: AsFd + 'static,
+    for<'a> &'a S: Read + Write,
 {
     let request: Request = request.into_client_request()?;
 
@@ -211,20 +206,12 @@ where
 
     let config = config.into();
 
-    let stream = wrap_stream(
-        stream,
-        domain,
-        connector,
-        mode,
-        config.buffer_size_base,
-        config.buffer_size_limit,
-    )
-    .await?;
+    let stream = wrap_stream(stream, domain, connector, mode).await?;
     client_async_with_config(request, stream, config).await
 }
 
 /// Connect to a given URL.
-pub async fn connect_async<R>(request: R) -> Result<(WebSocketStream<TcpStream>, Response), Error>
+pub async fn connect_async<R>(request: R) -> Result<(WebSocketStream<Socket>, Response), Error>
 where
     R: IntoClientRequest,
 {
@@ -235,7 +222,7 @@ where
 pub async fn connect_async_with_config<R>(
     request: R,
     config: impl Into<Config>,
-) -> Result<(WebSocketStream<TcpStream>, Response), Error>
+) -> Result<(WebSocketStream<Socket>, Response), Error>
 where
     R: IntoClientRequest,
 {
@@ -248,7 +235,7 @@ pub async fn connect_async_tls_with_config<R>(
     request: R,
     config: impl Into<Config>,
     connector: Option<TlsConnector>,
-) -> Result<(WebSocketStream<TcpStream>, Response), Error>
+) -> Result<(WebSocketStream<Socket>, Response), Error>
 where
     R: IntoClientRequest,
 {
@@ -266,6 +253,7 @@ where
         .await
         .map_err(Error::Io)?;
     socket.set_nodelay(config.disable_nagle)?;
+    let socket = socket.into_poll_fd()?;
     client_async_tls_with_config(request, socket, connector, config).await
 }
 

--- a/compio-ws/src/tls.rs
+++ b/compio-ws/src/tls.rs
@@ -1,7 +1,5 @@
 //! TLS support for WebSocket connections (native-tls and rustls).
 
-use std::io::{Read, Write};
-
 use compio_driver::AsFd;
 use compio_net::TcpStream;
 use compio_runtime::fd::PollFd;
@@ -123,7 +121,6 @@ async fn wrap_stream<S>(
 ) -> Result<MaybeTlsStream<PollFd<S>>, Error>
 where
     S: AsFd + 'static,
-    for<'a> &'a S: Read + Write,
 {
     match mode {
         Mode::Plain => Ok(MaybeTlsStream::new_plain(socket)),
@@ -180,7 +177,6 @@ pub async fn client_async_tls<R, S>(
 where
     R: IntoClientRequest,
     S: AsFd + 'static,
-    for<'a> &'a S: Read + Write,
 {
     client_async_tls_with_config(request, stream, None, None).await
 }
@@ -196,7 +192,6 @@ pub async fn client_async_tls_with_config<R, S>(
 where
     R: IntoClientRequest,
     S: AsFd + 'static,
-    for<'a> &'a S: Read + Write,
 {
     let request: Request = request.into_client_request()?;
 

--- a/compio/Cargo.toml
+++ b/compio/Cargo.toml
@@ -214,7 +214,6 @@ read_buf = [
     "compio-buf/read_buf",
     "compio-io?/read_buf",
     "compio-runtime?/read_buf",
-    "compio-tls?/read_buf",
     "compio-fs?/read_buf",
 ]
 try_trait_v2 = ["compio-buf/try_trait_v2"]


### PR DESCRIPTION
* Add `connect`, `accept`, and reimplement `read` & `write` in `PollFd`.
* Only accept futures IO traits in `compio-tls`.
* Use `PollFd` in `compio-ws`.

Now we can remove the `Pin<Box<AsyncStream>>`.