### PR TITLE
perf(io): inline compatibility write futures

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,6 +89,7 @@ thin-cell = "0.2.1"
 slotmap = "1.1.1"
 crossfire = "3.1.5"
 rustix = "1.1.4"
+smallbox = "0.8.8"
 
 [profile.bench]
 debug = true

--- a/compio-io/Cargo.toml
+++ b/compio-io/Cargo.toml
@@ -14,6 +14,7 @@ compio-buf = { workspace = true, features = ["arrayvec"] }
 futures-util = { workspace = true, features = ["sink"] }
 paste = { workspace = true }
 pin-project-lite = { workspace = true, optional = true }
+smallbox = { workspace = true, optional = true }
 rustix = { workspace = true, features = ["net"], optional = true }
 synchrony = { workspace = true, features = ["bilock"] }
 
@@ -39,7 +40,7 @@ futures-executor = { workspace = true }
 
 [features]
 default = ["bytes"]
-compat = ["futures-util/io", "dep:pin-project-lite"]
+compat = ["futures-util/io", "dep:pin-project-lite", "dep:smallbox"]
 sync = []
 ancillary = ["dep:libc", "dep:rustix", "dep:windows-sys"]
 bytes = ["compio-buf/bytes"]

--- a/compio-io/src/compat/async_stream.rs
+++ b/compio-io/src/compat/async_stream.rs
@@ -1,5 +1,6 @@
 use std::{
     fmt::Debug,
+    future::Future,
     io,
     marker::PhantomPinned,
     mem::MaybeUninit,
@@ -8,6 +9,7 @@ use std::{
 };
 
 use pin_project_lite::pin_project;
+use smallbox::{SmallBox, smallbox, space::S64};
 
 use super::waker_array::WakerArrayRef;
 use crate::{
@@ -15,6 +17,8 @@ use crate::{
     compat::{SyncStream, SyncStreamReadHalf, SyncStreamWriteHalf},
     util::{DEFAULT_BUF_SIZE, Splittable},
 };
+
+type InlineWriteFuture = SmallBox<dyn Future<Output = io::Result<usize>>, S64>;
 
 pin_project! {
     /// A stream wrapper for [`futures_util::io`] traits.
@@ -136,7 +140,8 @@ pin_project! {
     pub struct AsyncWriteStream<S> {
         #[pin]
         inner: SyncStreamWriteHalf<S>,
-        write_future: Option<PinBoxFuture<io::Result<usize>>>,
+        #[pin]
+        write_future: Option<InlineWriteFuture>,
         shutdown_future: Option<PinBoxFuture<io::Result<()>>>,
         write_waker: Option<Waker>,
         flush_waker: Option<Waker>,
@@ -204,6 +209,23 @@ macro_rules! poll_future {
                 return Poll::Pending;
             }
             Poll::Ready(res) => res,
+        }
+    }};
+}
+
+macro_rules! poll_inline_future {
+    ($f:expr, $cx:expr, $e:expr) => {{
+        let mut future_slot = $f;
+        if future_slot.as_ref().get_ref().is_none() {
+            let future: InlineWriteFuture = smallbox!($e);
+            future_slot.as_mut().set(Some(future));
+        }
+        match future_slot.as_mut().as_pin_mut().unwrap().poll($cx) {
+            Poll::Pending => return Poll::Pending,
+            Poll::Ready(res) => {
+                future_slot.set(None);
+                res
+            }
         }
     }};
 }
@@ -398,7 +420,7 @@ impl<S: AsyncWrite + Unpin + 'static> AsyncWriteStream<S> {
         ]);
         arr.with(|waker| {
             let cx = &mut Context::from_waker(waker);
-            let res = poll_future!(this.write_future, cx, inner.flush_write_buf());
+            let res = poll_inline_future!(this.write_future, cx, inner.flush_write_buf());
             Poll::Ready(res)
         })
     }
@@ -489,10 +511,27 @@ impl<S: Splittable> Splittable for AsyncStream<S> {
 
 #[cfg(test)]
 mod test {
+    use std::{future, hint, io};
+
     use futures_executor::block_on;
     use futures_util::AsyncWriteExt;
+    use smallbox::smallbox;
 
-    use super::AsyncWriteStream;
+    use super::{AsyncWriteStream, InlineWriteFuture};
+
+    #[test]
+    fn write_future_uses_inline_storage_with_heap_fallback() {
+        let inline: InlineWriteFuture = smallbox!(async { Ok::<usize, io::Error>(0) });
+        assert!(!inline.is_heap());
+
+        let oversized: InlineWriteFuture = smallbox!(async {
+            let storage = [0u8; 1_024];
+            future::pending::<()>().await;
+            hint::black_box(storage);
+            Ok::<usize, io::Error>(0)
+        });
+        assert!(oversized.is_heap());
+    }
 
     #[test]
     fn close() {


### PR DESCRIPTION
## Summary

- Store the compatibility adapter's in-flight write future in a pinned `SmallBox`.
- Use 64 words of inline storage with automatic heap fallback.
- Leave read and shutdown futures unchanged.
- Cover both inline storage and an intentionally oversized fallback case.

## Motivation

`AsyncWriteStream::poll_flush_impl` creates `flush_write_buf()` and erases it behind `Pin<Box<dyn Future>>`. That allocates once whenever a new write flush begins.

In an x86-64 completion-based TLS/WebSocket workload, DHAT attributed 304 measured allocations totaling 124,032 bytes to that exact site: 408 bytes per write. A standalone prototype removed the matching DHAT allocation stack across 320 successful local loopback writes while preserving the exact write count and semantic digest. This is allocation evidence, not a latency claim.

The measurement used Compio v0.19.1 / `compio-io` v0.10.1. The same mechanism is implemented here on current `master`.

## Safety and tradeoff

An inline `!Unpin` future must not move between polls. This change pins the `Option<SmallBox<...>>` field, installs a future only before its first poll, retains it in place while pending, and clears it only after `Ready`. `SmallBox` falls back to the heap when the future does not fit.

On x86-64, `S64` adds roughly 512 bytes to the compatibility-stream object; in return, it avoids a 408-byte allocation on every affected write. Other future sizes and architectures retain correctness through the heap fallback.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p compio-io --features compat`
- `cargo clippy -p compio-io --features compat --all-targets -- -D warnings`
- Normal inline and deliberate 1 KiB oversized fallback tests
- Production-shaped local-loopback DHAT evidence, with no latency claim
