### PR TITLE
feat(rt): multi stream submission factory

### DIFF
--- a/compio-runtime/src/future/stream.rs
+++ b/compio-runtime/src/future/stream.rs
@@ -1,5 +1,6 @@
 use std::{
     cell::RefCell,
+    io,
     marker::PhantomData,
     pin::Pin,
     rc::Rc,
@@ -201,7 +202,7 @@ impl<T: OpCode, B: HandleBufferRef + 'static> SubmitMultiManaged<T, B> {
 impl<T: OpCode + TakeBuffer<Buffer = B> + 'static, B: HandleBufferRef> Stream
     for SubmitMultiManaged<T, B>
 {
-    type Item = std::io::Result<Option<B>>;
+    type Item = io::Result<Option<B>>;
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         if let Some(inner) = self.inner.as_mut() {
@@ -319,34 +320,60 @@ impl HandleBufferRef for RecvMsgMultiResult {
     }
 }
 
-/// A wrapper around [`SubmitMultiManaged`] that submits the operation
-/// automatically till the stream is finished.
-pub struct SubmitMultiStream<F, T: OpCode, B = BufferRef>
-where
-    B: HandleBufferRef + 'static,
-{
-    create_op: F,
-    op: Option<SubmitMultiManaged<T, B>>,
+/// Creates managed multishot submissions for [`SubmitMultiStream`].
+///
+/// [`SubmitMultiStream`] calls [`create`](Self::create) again when the previous
+/// submission ends before EOF.
+///
+/// By default, this trait is implemented for closures
+/// `FnMut() -> std::io::Result<SubmitMultiManaged<T, B>>`.
+pub trait SubmitMultiFactory {
+    /// The [`OpCode`] type.
+    type Op: OpCode + TakeBuffer<Buffer = Self::Buffer> + 'static;
+
+    /// The buffer returned by the OpCode.
+    ///
+    /// This can be [`BufferRef`], [`RecvFromMultiResult`] or
+    /// [`RecvMsgMultiResult`].
+    type Buffer: HandleBufferRef + 'static;
+
+    /// Creates a new managed multishot submission.
+    fn create(&mut self) -> io::Result<SubmitMultiManaged<Self::Op, Self::Buffer>>;
 }
 
-impl<F, T: OpCode, B: HandleBufferRef + 'static> SubmitMultiStream<F, T, B> {
-    /// Create a new [`SubmitMultiStream`] with a closure that creates the
-    /// operation.
-    pub fn new(create_op: F) -> Self {
-        Self {
-            create_op,
-            op: None,
-        }
+impl<F, T, B> SubmitMultiFactory for F
+where
+    F: FnMut() -> io::Result<SubmitMultiManaged<T, B>>,
+    T: OpCode + TakeBuffer<Buffer = B> + 'static,
+    B: HandleBufferRef + 'static,
+{
+    type Buffer = B;
+    type Op = T;
+
+    fn create(&mut self) -> io::Result<SubmitMultiManaged<Self::Op, Self::Buffer>> {
+        (self)()
     }
 }
 
-impl<
-    F: (Fn() -> std::io::Result<SubmitMultiManaged<T, B>>) + Unpin,
-    T: OpCode + TakeBuffer<Buffer = B> + 'static,
-    B: HandleBufferRef,
-> Stream for SubmitMultiStream<F, T, B>
+/// A wrapper around [`SubmitMultiManaged`] that submits operations
+/// automatically until the stream is finished.
+pub struct SubmitMultiStream<F: SubmitMultiFactory> {
+    factory: F,
+    op: Option<SubmitMultiManaged<F::Op, F::Buffer>>,
+}
+
+impl<F: SubmitMultiFactory> SubmitMultiStream<F> {
+    /// Creates a new [`SubmitMultiStream`] with `factory`.
+    pub fn new(factory: F) -> Self {
+        Self { factory, op: None }
+    }
+}
+
+impl<F> Stream for SubmitMultiStream<F>
+where
+    F: SubmitMultiFactory + Unpin,
 {
-    type Item = std::io::Result<B>;
+    type Item = io::Result<F::Buffer>;
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         loop {
@@ -366,7 +393,7 @@ impl<
                 None if cx.get_cancel().is_some_and(CancelToken::is_cancelled) => {
                     break Poll::Ready(None);
                 }
-                None => match (self.create_op)() {
+                None => match self.factory.create() {
                     Ok(op) => self.op = Some(op),
                     Err(e) => break Poll::Ready(Some(Err(e))),
                 },

--- a/compio-runtime/tests/submit_multi_stream.rs
+++ b/compio-runtime/tests/submit_multi_stream.rs
@@ -1,0 +1,53 @@
+use std::{
+    io,
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+use compio_driver::{BufferRef, op::ReadMulti};
+use compio_runtime::{SubmitMultiFactory, SubmitMultiManaged, SubmitMultiStream};
+use futures_util::{Stream, task::noop_waker_ref};
+
+type Op = ReadMulti<std::fs::File>;
+
+struct CustomFactory;
+
+impl SubmitMultiFactory for CustomFactory {
+    type Buffer = BufferRef;
+    type Op = Op;
+
+    fn create(&mut self) -> io::Result<SubmitMultiManaged<Self::Op, Self::Buffer>> {
+        Err(io::Error::other("custom factory error"))
+    }
+}
+
+fn poll_error<S>(stream: Pin<&mut S>) -> io::Error
+where
+    S: Stream<Item = io::Result<BufferRef>>,
+{
+    let mut cx = Context::from_waker(noop_waker_ref());
+    match stream.poll_next(&mut cx) {
+        Poll::Ready(Some(Err(error))) => error,
+        _ => panic!("factory error was not returned"),
+    }
+}
+
+#[test]
+fn accepts_custom_factory() {
+    let mut stream = Box::pin(SubmitMultiStream::new(CustomFactory));
+
+    let error = poll_error(stream.as_mut());
+
+    assert_eq!(error.to_string(), "custom factory error");
+}
+
+#[test]
+fn accepts_closure_factory() {
+    let factory =
+        || -> io::Result<SubmitMultiManaged<Op>> { Err(io::Error::other("closure factory error")) };
+    let mut stream = Box::pin(SubmitMultiStream::new(factory));
+
+    let error = poll_error(stream.as_mut());
+
+    assert_eq!(error.to_string(), "closure factory error");
+}


### PR DESCRIPTION
Extend op code factory accepted by `SubmitMultiStream` into a generic trait so that users can provide their own. Currently a `SubmitMultiStream` taking a capturing closure cannot be named, results in an unnecessary `dyn Stream` to be needed if the stream ever need to be stored or passed around.