### PR TITLE
feat(term): init crate

### DIFF
--- a/.github/scripts/auto-label.cjs
+++ b/.github/scripts/auto-label.cjs
@@ -9,6 +9,7 @@ const TYPE_LABELS = {
 };
 
 const SCOPE_LABELS = {
+  actor: "package: actor",
   buf: "package: buf",
   dispatch: "package: dispatcher",
   dispatcher: "package: dispatcher",
@@ -31,6 +32,7 @@ const SCOPE_LABELS = {
   rt: "package: runtime",
   runtime: "package: runtime",
   signal: "package: signal",
+  term: "package: term",
   tls: "package: tls",
   uring: "driver: io-uring",
   websocket: "package: ws",

--- a/.github/scripts/auto-label.test.cjs
+++ b/.github/scripts/auto-label.test.cjs
@@ -36,6 +36,13 @@ test("supports multiple workspace crates in scope", () => {
   );
 });
 
+test("maps actor and terminal workspace crates", () => {
+  assert.deepEqual(
+    collectConventionalLabels("feat(compio-actor,compio-term): add crates"),
+    ["enhancement", "package: actor", "package: term"],
+  );
+});
+
 test("matches issue keywords when title is not conventional", () => {
   assert.deepEqual(
     collectIssueKeywordLabels("RFC: Feature request for better perf in runtime"),

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ members = [
     "compio-runtime",
     "compio-executor",
     "compio-signal",
+    "compio-term",
     "compio-tls",
     "compio-ws",
     "compio-compat",
@@ -38,6 +39,7 @@ compio-fs = { path = "./compio-fs", version = "0.12.0" }
 compio-io = { path = "./compio-io", version = "0.10.1" }
 compio-net = { path = "./compio-net", version = "0.12.2" }
 compio-signal = { path = "./compio-signal", version = "0.10.0" }
+compio-term = { path = "./compio-term", version = "0.1.0" }
 compio-dispatcher = { path = "./compio-dispatcher", version = "0.11.0" }
 compio-log = { path = "./compio-log", version = "0.2.0" }
 compio-tls = { path = "./compio-tls", version = "0.10.0", default-features = false }
@@ -54,8 +56,10 @@ compio-send-wrapper = "0.7.1"
 console-subscriber = "0.5.0"
 criterion = "0.8.0"
 crossbeam-queue = "0.3.8"
+crossterm = { version = "0.29.0", default-features = false }
 flume = { version = "0.12.0", default-features = false }
 futures-channel = "0.3.29"
+futures-core = "0.3.31"
 futures-executor = "0.3.30"
 futures-rustls = { version = "0.26.0", default-features = false }
 futures-util = "0.3.29"

--- a/compio-term/Cargo.toml
+++ b/compio-term/Cargo.toml
@@ -1,0 +1,45 @@
+[package]
+name = "compio-term"
+version = "0.1.0"
+description = "Completion-based terminal support for Compio"
+readme = "README.md"
+edition = { workspace = true }
+license = { workspace = true }
+repository = { workspace = true }
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
+targets = ["x86_64-unknown-linux-gnu", "x86_64-pc-windows-msvc", "aarch64-apple-darwin"]
+
+[dependencies]
+compio-buf = { workspace = true }
+compio-driver = { workspace = true }
+compio-fs = { workspace = true }
+compio-io = { workspace = true }
+compio-log = { workspace = true }
+compio-runtime = { workspace = true }
+compio-signal = { workspace = true }
+
+crossterm = { workspace = true, features = ["bracketed-paste", "events", "windows"] }
+futures-core = { workspace = true }
+
+[target.'cfg(unix)'.dependencies]
+rustix = { workspace = true, features = ["fs", "process", "termios"] }
+compio-runtime = { workspace = true, features = ["time"] }
+
+[target.'cfg(windows)'.dependencies]
+windows-sys = { workspace = true, features = [
+  "Win32_Foundation",
+  "Win32_System_Console",
+  "Win32_System_IO",
+  "Win32_UI_Input_KeyboardAndMouse",
+  "Win32_UI_WindowsAndMessaging",
+] }
+
+[dev-dependencies]
+compio-macros = { workspace = true }
+futures-util = { workspace = true }
+
+[target.'cfg(target_os = "linux")'.dev-dependencies]
+compio-driver = { workspace = true, features = ["io-uring"] }

--- a/compio-term/Cargo.toml
+++ b/compio-term/Cargo.toml
@@ -40,6 +40,3 @@ windows-sys = { workspace = true, features = [
 [dev-dependencies]
 compio-macros = { workspace = true }
 futures-util = { workspace = true }
-
-[target.'cfg(target_os = "linux")'.dev-dependencies]
-compio-driver = { workspace = true, features = ["io-uring"] }

--- a/compio-term/README.md
+++ b/compio-term/README.md
@@ -1,0 +1,31 @@
+<div align="center">
+    <a href='https://compio.rs'>
+        <img height="150" src="https://github.com/compio-rs/compio-logo/raw/refs/heads/master/generated/colored-with-text.svg">
+    </a>
+</div>
+
+---
+
+# compio-term
+
+[![MIT licensed](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/compio-rs/compio/blob/master/LICENSE)
+[![crates.io](https://img.shields.io/crates/v/compio-term)](https://crates.io/crates/compio-term)
+[![docs.rs](https://img.shields.io/badge/docs.rs-compio--term-latest)](https://docs.rs/compio-term)
+[![Check](https://github.com/compio-rs/compio/actions/workflows/ci_check.yml/badge.svg)](https://github.com/compio-rs/compio/actions/workflows/ci_check.yml)
+[![Test](https://github.com/compio-rs/compio/actions/workflows/ci_test.yml/badge.svg)](https://github.com/compio-rs/compio/actions/workflows/ci_test.yml)
+
+`compio-term` provides completion-based terminal input and output for Compio based on [crossterm](https://github.com/crossterm-rs/crossterm).
+
+The crate provides an async event stream based on compio and an asynchronous command queue to write commands to any `AsyncWrite`. Crossterm's `cursor`, `style`, `terminal`, and `tty` modules are re-exported from the crate root.
+
+## Backends
+
+| Platform                  | Event mechanism                                                    |
+| ------------------------- | ------------------------------------------------------------------ |
+| Linux and Android         | Managed multishot reads, including native io_uring multishot reads |
+| Apple                     | Managed reads for terminal stdin and timer polling for `/dev/tty`  |
+| BSD, illumos, and Solaris | Managed reads over the platform polling backend                    |
+| Other Unix                | Timer polling with nonblocking rustix reads                        |
+| Windows                   | Compio event waits and `ReadConsoleInputW`                          |
+
+Mouse, focus, bracketed-paste, and enhanced keyboard events require the related Crossterm command to be enabled by the caller.

--- a/compio-term/examples/events.rs
+++ b/compio-term/examples/events.rs
@@ -3,7 +3,7 @@ use std::io;
 use compio_io::AsyncWrite;
 use compio_runtime::Runtime;
 use compio_term::{
-    CommandQueue, QueueableCommand, RawMode,
+    CommandQueue, Queueable, RawMode,
     event::{Event, EventStream, KeyCode, KeyEventKind, KeyModifiers},
     style::Print,
 };
@@ -11,12 +11,12 @@ use futures_util::StreamExt;
 
 #[compio_macros::main]
 async fn main() -> io::Result<()> {
-    let mut output = CommandQueue::stdout();
-    terminal_line(
-        &mut output,
-        &format!("Compio driver: {:?}", Runtime::current().driver_type()),
-    )
-    .await?;
+    let mut stdout = compio_fs::stdout();
+    let mut output = stdout.queue(Print(format!(
+        "Compio driver: {:?}\r\n",
+        Runtime::current().driver_type()
+    )))?;
+    output.flush().await?;
 
     let raw_mode = RawMode::enable()?;
     let mut events = EventStream::new()?;
@@ -52,6 +52,6 @@ fn should_quit(event: &Event) -> bool {
 }
 
 async fn terminal_line<W: AsyncWrite>(output: &mut CommandQueue<W>, line: &str) -> io::Result<()> {
-    output.queue(Print(line))?.queue(Print("\r\n"))?;
+    output.queue_many(&[Print(line), Print("\r\n")])?;
     output.flush().await
 }

--- a/compio-term/examples/events.rs
+++ b/compio-term/examples/events.rs
@@ -1,0 +1,57 @@
+use std::io;
+
+use compio_io::AsyncWrite;
+use compio_runtime::Runtime;
+use compio_term::{
+    CommandQueue, QueueableCommand, RawMode,
+    event::{Event, EventStream, KeyCode, KeyEventKind, KeyModifiers},
+    style::Print,
+};
+use futures_util::StreamExt;
+
+#[compio_macros::main]
+async fn main() -> io::Result<()> {
+    let mut output = CommandQueue::stdout();
+    terminal_line(
+        &mut output,
+        &format!("Compio driver: {:?}", Runtime::current().driver_type()),
+    )
+    .await?;
+
+    let raw_mode = RawMode::enable()?;
+    let mut events = EventStream::new()?;
+    terminal_line(
+        &mut output,
+        "reading terminal events; press q or Ctrl-C to stop",
+    )
+    .await?;
+
+    while let Some(event) = events.next().await {
+        let event = event?;
+        terminal_line(&mut output, &format!("{event:?}")).await?;
+        if should_quit(&event) {
+            break;
+        }
+    }
+
+    drop(events);
+    drop(raw_mode);
+    terminal_line(&mut output, "terminal restored").await?;
+    Ok(())
+}
+
+fn should_quit(event: &Event) -> bool {
+    let Event::Key(key) = event else {
+        return false;
+    };
+    if key.kind != KeyEventKind::Press {
+        return false;
+    }
+    key.code == KeyCode::Char('q')
+        || key.code == KeyCode::Char('c') && key.modifiers.contains(KeyModifiers::CONTROL)
+}
+
+async fn terminal_line<W: AsyncWrite>(output: &mut CommandQueue<W>, line: &str) -> io::Result<()> {
+    output.queue(Print(line))?.queue(Print("\r\n"))?;
+    output.flush().await
+}

--- a/compio-term/src/command.rs
+++ b/compio-term/src/command.rs
@@ -1,0 +1,293 @@
+use std::{fmt, io, mem};
+
+use compio_buf::{BufResult, IntoInner, IoBufExt};
+use compio_io::AsyncWrite;
+
+use crate::Command;
+
+/// Adds terminal commands to an asynchronous command queue.
+///
+/// Queuing only renders the command into the queue's memory buffer. Call
+/// [`CommandQueue::flush`] to write the complete batch to its asynchronous
+/// writer.
+pub trait QueueableCommand {
+    /// Adds a command to the queue without writing to the underlying writer.
+    ///
+    /// If the command cannot render its ANSI representation, this method
+    /// removes any bytes that the failed command added. Commands that were
+    /// already queued remain intact.
+    fn queue(&mut self, command: impl Command) -> io::Result<&mut Self>;
+}
+
+/// A buffered queue of terminal commands for a Compio asynchronous writer.
+///
+/// Commands are encoded with [`Command::write_ansi`] and written in one ordered
+/// batch when [`flush`](Self::flush) is awaited. The writer can be Compio's
+/// standard output handle or any other type that implements
+/// [`compio_io::AsyncWrite`].
+///
+/// Call [`flush`](Self::flush) before this value is dropped. Dropping it
+/// discards commands that are still queued.
+///
+/// # Example
+///
+/// ```no_run
+/// use std::io;
+///
+/// use compio_term::{CommandQueue, QueueableCommand, cursor::MoveTo, style::Print};
+///
+/// #[compio_macros::main]
+/// async fn main() -> io::Result<()> {
+///     let mut output = CommandQueue::stdout();
+///     output.queue(MoveTo(0, 0))?.queue(Print("ready\r\n"))?;
+///     output.flush().await
+/// }
+/// ```
+#[derive(Debug)]
+#[must_use = "queued commands are discarded unless flush is awaited"]
+pub struct CommandQueue<W> {
+    writer: W,
+    buffer: Vec<u8>,
+    written: usize,
+}
+
+impl<W> CommandQueue<W> {
+    /// Creates an empty command queue for `writer`.
+    pub fn new(writer: W) -> Self {
+        Self {
+            writer,
+            buffer: Vec::new(),
+            written: 0,
+        }
+    }
+
+    /// Creates an empty command queue with space for at least `capacity` bytes.
+    pub fn with_capacity(capacity: usize, writer: W) -> Self {
+        Self {
+            writer,
+            buffer: Vec::with_capacity(capacity),
+            written: 0,
+        }
+    }
+
+    /// Returns the number of command bytes that have not been written.
+    pub fn buffered_len(&self) -> usize {
+        self.buffer.len() - self.written
+    }
+
+    /// Returns `true` when no command bytes are waiting to be written.
+    pub fn is_empty(&self) -> bool {
+        self.buffered_len() == 0
+    }
+}
+
+impl CommandQueue<compio_fs::Stdout> {
+    /// Creates an empty command queue that writes to standard output.
+    pub fn stdout() -> Self {
+        Self::new(compio_fs::stdout())
+    }
+}
+
+impl<W: AsyncWrite> CommandQueue<W> {
+    /// Writes all queued commands and flushes the underlying writer.
+    ///
+    /// A partial write is resumed at the first unwritten byte if this method is
+    /// called again after a write error. Commands queued after that error stay
+    /// after the remaining bytes from the failed batch.
+    pub async fn flush(&mut self) -> io::Result<()> {
+        while self.written < self.buffer.len() {
+            let buffer = mem::take(&mut self.buffer).slice(self.written..);
+            let BufResult(result, buffer) = self.writer.write(buffer).await;
+            self.buffer = buffer.into_inner();
+
+            match result {
+                Ok(0) => {
+                    return Err(io::Error::new(
+                        io::ErrorKind::WriteZero,
+                        "failed to write queued terminal commands",
+                    ));
+                }
+                Ok(written) => {
+                    let remaining = self.buffer.len() - self.written;
+                    if written > remaining {
+                        return Err(io::Error::new(
+                            io::ErrorKind::InvalidData,
+                            "asynchronous writer reported too many written bytes",
+                        ));
+                    }
+                    self.written += written;
+                }
+                Err(error) if error.kind() == io::ErrorKind::Interrupted => {}
+                Err(error) => return Err(error),
+            }
+        }
+
+        self.buffer.clear();
+        self.written = 0;
+        self.writer.flush().await
+    }
+}
+
+impl<W> QueueableCommand for CommandQueue<W> {
+    fn queue(&mut self, command: impl Command) -> io::Result<&mut Self> {
+        let original_len = self.buffer.len();
+        if command
+            .write_ansi(&mut AnsiBuffer(&mut self.buffer))
+            .is_err()
+        {
+            self.buffer.truncate(original_len);
+            return Err(io::Error::other(
+                "terminal command failed to render its ANSI representation",
+            ));
+        }
+        Ok(self)
+    }
+}
+
+struct AnsiBuffer<'a>(&'a mut Vec<u8>);
+
+impl fmt::Write for AnsiBuffer<'_> {
+    fn write_str(&mut self, value: &str) -> fmt::Result {
+        self.0.extend_from_slice(value.as_bytes());
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{cell::RefCell, fmt, io, rc::Rc};
+
+    use compio_buf::{BufResult, IoBuf, IoBufExt};
+    use compio_io::AsyncWrite;
+    use futures_util::FutureExt;
+
+    use super::{CommandQueue, QueueableCommand};
+    use crate::{Command, cursor::MoveTo, style::Print};
+
+    #[test]
+    fn queues_commands_until_flush_in_order() {
+        let writer = TestWriter::new(2, None);
+        let state = writer.state();
+        let mut queue = CommandQueue::new(writer);
+        let expected = b"\x1b[5;4Hready";
+
+        queue
+            .queue(MoveTo(3, 4))
+            .unwrap()
+            .queue(Print("ready"))
+            .unwrap();
+
+        assert_eq!(queue.buffered_len(), expected.len());
+        assert!(state.borrow().output.is_empty());
+        flush(&mut queue).unwrap();
+        assert_eq!(&state.borrow().output, expected);
+        assert!(queue.is_empty());
+    }
+
+    #[test]
+    fn failed_command_does_not_leave_partial_bytes() {
+        let writer = TestWriter::new(usize::MAX, None);
+        let state = writer.state();
+        let mut queue = CommandQueue::new(writer);
+
+        queue.queue(Print("before")).unwrap();
+        let error = queue
+            .queue(FailingCommand)
+            .err()
+            .expect("failing command must return an error");
+        queue.queue(Print("after")).unwrap();
+        flush(&mut queue).unwrap();
+
+        assert_eq!(error.kind(), io::ErrorKind::Other);
+        assert_eq!(&state.borrow().output, b"beforeafter");
+    }
+
+    #[test]
+    fn retry_resumes_after_a_partial_write() {
+        let writer = TestWriter::new(2, Some(2));
+        let state = writer.state();
+        let mut queue = CommandQueue::new(writer);
+        queue.queue(Print("abcdef")).unwrap();
+
+        let error = flush(&mut queue).unwrap_err();
+        assert_eq!(error.kind(), io::ErrorKind::Other);
+        assert_eq!(&state.borrow().output, b"ab");
+
+        queue.queue(Print("gh")).unwrap();
+        flush(&mut queue).unwrap();
+        assert_eq!(&state.borrow().output, b"abcdefgh");
+    }
+
+    fn flush(queue: &mut CommandQueue<TestWriter>) -> io::Result<()> {
+        queue
+            .flush()
+            .now_or_never()
+            .expect("test writer must not yield")
+    }
+
+    struct FailingCommand;
+
+    impl Command for FailingCommand {
+        fn write_ansi(&self, writer: &mut impl fmt::Write) -> fmt::Result {
+            fmt::Write::write_str(writer, "partial")?;
+            Err(fmt::Error)
+        }
+
+        #[cfg(windows)]
+        fn execute_winapi(&self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    #[derive(Clone)]
+    struct TestWriter {
+        state: Rc<RefCell<WriterState>>,
+    }
+
+    impl TestWriter {
+        fn new(chunk_size: usize, fail_at: Option<usize>) -> Self {
+            Self {
+                state: Rc::new(RefCell::new(WriterState {
+                    output: Vec::new(),
+                    chunk_size,
+                    writes: 0,
+                    fail_at,
+                })),
+            }
+        }
+
+        fn state(&self) -> Rc<RefCell<WriterState>> {
+            Rc::clone(&self.state)
+        }
+    }
+
+    struct WriterState {
+        output: Vec<u8>,
+        chunk_size: usize,
+        writes: usize,
+        fail_at: Option<usize>,
+    }
+
+    impl AsyncWrite for TestWriter {
+        async fn write<T: IoBuf>(&mut self, buffer: T) -> BufResult<usize, T> {
+            let mut state = self.state.borrow_mut();
+            state.writes += 1;
+            if state.fail_at == Some(state.writes) {
+                state.fail_at = None;
+                return BufResult(Err(io::Error::other("injected write failure")), buffer);
+            }
+
+            let written = state.chunk_size.min(buffer.buf_len());
+            state.output.extend_from_slice(&buffer.as_init()[..written]);
+            BufResult(Ok(written), buffer)
+        }
+
+        async fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+
+        async fn shutdown(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+}

--- a/compio-term/src/command/mod.rs
+++ b/compio-term/src/command/mod.rs
@@ -2,28 +2,69 @@ use std::{fmt, io, mem};
 
 use compio_buf::{BufResult, IntoInner, IoBufExt};
 use compio_io::AsyncWrite;
+use crossterm::Command;
 
-use crate::Command;
+mod multi;
 
-/// Adds terminal commands to an asynchronous command queue.
-///
-/// Queuing only renders the command into the queue's memory buffer. Call
-/// [`CommandQueue::flush`] to write the complete batch to its asynchronous
-/// writer.
-pub trait QueueableCommand {
-    /// Adds a command to the queue without writing to the underlying writer.
+pub use multi::Commands;
+
+/// Starts an asynchronous command queue for a writer.
+pub trait Queueable: AsyncWrite {
+    /// Creates a queue that borrows this writer and adds `command` to it.
+    ///
+    /// No bytes are written until [`CommandQueue::flush`] is awaited.
+    fn queue(&mut self, command: impl Command) -> io::Result<CommandQueue<&mut Self>>;
+
+    /// Adds an ordered batch of commands without writing to the underlying
+    /// writer.
+    ///
+    /// If any command cannot render its ANSI representation, this method
+    /// removes every byte added by this call. Commands that were already queued
+    /// remain intact.
+    fn queue_many(&mut self, command: impl Commands) -> io::Result<CommandQueue<&mut Self>>;
+}
+
+impl<W> CommandQueue<W> {
+    /// Adds a command without writing to the underlying writer.
     ///
     /// If the command cannot render its ANSI representation, this method
     /// removes any bytes that the failed command added. Commands that were
     /// already queued remain intact.
-    fn queue(&mut self, command: impl Command) -> io::Result<&mut Self>;
+    pub fn queue(&mut self, command: impl Command) -> io::Result<&mut Self> {
+        self.append(|writer| command.write_ansi(writer))
+    }
+
+    /// Adds an ordered batch of commands without writing to the underlying
+    /// writer.
+    ///
+    /// If any command cannot render its ANSI representation, this method
+    /// removes every byte added by this call. Commands that were already queued
+    /// remain intact.
+    pub fn queue_many(&mut self, commands: impl Commands) -> io::Result<&mut Self> {
+        self.append(|writer| commands.write_ansi(writer))
+    }
+}
+
+impl<W: AsyncWrite + ?Sized> Queueable for W {
+    fn queue(&mut self, command: impl Command) -> io::Result<CommandQueue<&mut Self>> {
+        let mut queue = CommandQueue::new(self);
+        queue.queue(command)?;
+        Ok(queue)
+    }
+
+    fn queue_many(&mut self, command: impl Commands) -> io::Result<CommandQueue<&mut Self>> {
+        let mut queue = CommandQueue::new(self);
+        queue.queue_many(command)?;
+        Ok(queue)
+    }
 }
 
 /// A buffered queue of terminal commands for a Compio asynchronous writer.
 ///
-/// Commands are encoded with [`Command::write_ansi`] and written in one ordered
-/// batch when [`flush`](Self::flush) is awaited. The writer can be Compio's
-/// standard output handle or any other type that implements
+/// Commands are encoded with
+/// [`Command::write_ansi`](crate::Command::write_ansi) and written in one
+/// ordered batch when [`flush`](Self::flush) is awaited. The writer can be
+/// Compio's standard output handle or any other type that implements
 /// [`compio_io::AsyncWrite`].
 ///
 /// Call [`flush`](Self::flush) before this value is dropped. Dropping it
@@ -34,12 +75,13 @@ pub trait QueueableCommand {
 /// ```no_run
 /// use std::io;
 ///
-/// use compio_term::{CommandQueue, QueueableCommand, cursor::MoveTo, style::Print};
+/// use compio_term::{Queueable, cursor::MoveTo, style::Print};
 ///
 /// #[compio_macros::main]
 /// async fn main() -> io::Result<()> {
-///     let mut output = CommandQueue::stdout();
-///     output.queue(MoveTo(0, 0))?.queue(Print("ready\r\n"))?;
+///     let mut stdout = compio_fs::stdout();
+///     let mut output = stdout.queue(MoveTo(0, 0))?;
+///     output.queue_many((Print("ready"), Print("\r\n")))?;
 ///     output.flush().await
 /// }
 /// ```
@@ -79,12 +121,33 @@ impl<W> CommandQueue<W> {
     pub fn is_empty(&self) -> bool {
         self.buffered_len() == 0
     }
+
+    fn append(
+        &mut self,
+        write: impl FnOnce(&mut AnsiBuffer<'_>) -> fmt::Result,
+    ) -> io::Result<&mut Self> {
+        let original_len = self.buffer.len();
+        if write(&mut AnsiBuffer(&mut self.buffer)).is_err() {
+            self.buffer.truncate(original_len);
+            return Err(io::Error::other(
+                "terminal command failed to render its ANSI representation",
+            ));
+        }
+        Ok(self)
+    }
 }
 
 impl CommandQueue<compio_fs::Stdout> {
     /// Creates an empty command queue that writes to standard output.
     pub fn stdout() -> Self {
         Self::new(compio_fs::stdout())
+    }
+}
+
+impl CommandQueue<compio_fs::Stderr> {
+    /// Creates an empty command queue that writes to standard error.
+    pub fn stderr() -> Self {
+        Self::new(compio_fs::stderr())
     }
 }
 
@@ -128,22 +191,6 @@ impl<W: AsyncWrite> CommandQueue<W> {
     }
 }
 
-impl<W> QueueableCommand for CommandQueue<W> {
-    fn queue(&mut self, command: impl Command) -> io::Result<&mut Self> {
-        let original_len = self.buffer.len();
-        if command
-            .write_ansi(&mut AnsiBuffer(&mut self.buffer))
-            .is_err()
-        {
-            self.buffer.truncate(original_len);
-            return Err(io::Error::other(
-                "terminal command failed to render its ANSI representation",
-            ));
-        }
-        Ok(self)
-    }
-}
-
 struct AnsiBuffer<'a>(&'a mut Vec<u8>);
 
 impl fmt::Write for AnsiBuffer<'_> {
@@ -161,7 +208,7 @@ mod tests {
     use compio_io::AsyncWrite;
     use futures_util::FutureExt;
 
-    use super::{CommandQueue, QueueableCommand};
+    use super::CommandQueue;
     use crate::{Command, cursor::MoveTo, style::Print};
 
     #[test]

--- a/compio-term/src/command/multi.rs
+++ b/compio-term/src/command/multi.rs
@@ -1,0 +1,76 @@
+use std::fmt;
+
+use crate::Command;
+
+/// An ordered batch of terminal commands.
+///
+/// Implemented for borrowed collections that yield shared [`Command`]
+/// references and for heterogeneous tuples of up to 20 commands.
+pub trait Commands {
+    /// Writes the ANSI representation of every command in order.
+    ///
+    /// This method is normally called through [`CommandQueue::queue_many`].
+    ///
+    /// [`CommandQueue::queue_many`]: crate::CommandQueue::queue_many
+    fn write_ansi(&self, writer: &mut impl fmt::Write) -> fmt::Result;
+}
+
+impl<'a, C, I: ?Sized> Commands for &'a I
+where
+    C: Command + 'a,
+    &'a I: IntoIterator<Item = &'a C>,
+{
+    fn write_ansi(&self, writer: &mut impl fmt::Write) -> fmt::Result {
+        for command in *self {
+            command.write_ansi(writer)?;
+        }
+        Ok(())
+    }
+}
+
+macro_rules! impl_commands_for_tuples {
+    (($head_type:ident, $head:ident) $(, ($tail_type:ident, $tail:ident))*) => {
+        impl<$head_type: Command $(, $tail_type: Command)*> Commands
+            for ($head_type, $($tail_type,)*)
+        {
+            fn write_ansi(&self, writer: &mut impl fmt::Write) -> fmt::Result {
+                let ($head, $($tail,)*) = self;
+                $head.write_ansi(writer)?;
+                $($tail.write_ansi(writer)?;)*
+                Ok(())
+            }
+        }
+
+        impl_commands_for_tuples!($(($tail_type, $tail)),*);
+    };
+    () => {
+        impl Commands for () {
+            fn write_ansi(&self, _: &mut impl fmt::Write) -> fmt::Result {
+                Ok(())
+            }
+        }
+    };
+}
+
+impl_commands_for_tuples!(
+    (C0, c0),
+    (C1, c1),
+    (C2, c2),
+    (C3, c3),
+    (C4, c4),
+    (C5, c5),
+    (C6, c6),
+    (C7, c7),
+    (C8, c8),
+    (C9, c9),
+    (C10, c10),
+    (C11, c11),
+    (C12, c12),
+    (C13, c13),
+    (C14, c14),
+    (C15, c15),
+    (C16, c16),
+    (C17, c17),
+    (C18, c18),
+    (C19, c19)
+);

--- a/compio-term/src/event/mod.rs
+++ b/compio-term/src/event/mod.rs
@@ -1,0 +1,32 @@
+//! Asynchronous terminal events.
+//!
+//! [`EventStream`] uses the active Compio runtime. Linux uses Compio's managed
+//! multishot read operation. Other Unix systems use the Compio polling driver
+//! when stdin is a terminal. If stdin is redirected, they use Compio timers
+//! with nonblocking rustix reads from `/dev/tty`. Windows uses a Compio event
+//! wait and `ReadConsoleInputW`. No backend starts a helper thread.
+//!
+//! Event values and event-control commands are re-exported from Crossterm. Code
+//! that already matches on [`Event`], [`KeyCode`], or [`MouseEvent`] can use
+//! the same values with this stream.
+//!
+//! Terminal input is normally line buffered. Enable raw mode before reading
+//! individual key events. Mouse, focus, bracketed-paste, and enhanced keyboard
+//! events also require their corresponding Crossterm command to be enabled.
+
+mod stream;
+mod sys;
+
+pub use crossterm::event::{
+    DisableBracketedPaste, DisableFocusChange, DisableMouseCapture, EnableBracketedPaste,
+    EnableFocusChange, EnableMouseCapture, Event, KeyCode, KeyEvent, KeyEventKind, KeyEventState,
+    KeyModifiers, KeyboardEnhancementFlags, MediaKeyCode, ModifierKeyCode, MouseButton, MouseEvent,
+    MouseEventKind, PopKeyboardEnhancementFlags, PushKeyboardEnhancementFlags,
+};
+pub use stream::EventStream;
+
+#[derive(Debug)]
+pub(super) enum InternalEvent {
+    Event(Event),
+    Ignored,
+}

--- a/compio-term/src/event/stream.rs
+++ b/compio-term/src/event/stream.rs
@@ -2,7 +2,7 @@ use std::{
     io,
     pin::Pin,
     sync::atomic::{AtomicBool, Ordering},
-    task::{Context, Poll},
+    task::{Context, Poll, ready},
 };
 
 use futures_core::Stream;
@@ -49,14 +49,13 @@ impl Stream for EventStream {
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         loop {
-            match Pin::new(&mut self.source).poll_next(cx) {
-                Poll::Ready(Some(Ok(InternalEvent::Event(event)))) => {
+            match ready!(Pin::new(&mut self.source).poll_next(cx)) {
+                Some(Ok(InternalEvent::Event(event))) => {
                     return Poll::Ready(Some(Ok(event)));
                 }
-                Poll::Ready(Some(Ok(InternalEvent::Ignored))) => {}
-                Poll::Ready(Some(Err(error))) => return Poll::Ready(Some(Err(error))),
-                Poll::Ready(None) => return Poll::Ready(None),
-                Poll::Pending => return Poll::Pending,
+                Some(Ok(InternalEvent::Ignored)) => {}
+                Some(Err(error)) => return Poll::Ready(Some(Err(error))),
+                None => return Poll::Ready(None),
             }
         }
     }

--- a/compio-term/src/event/stream.rs
+++ b/compio-term/src/event/stream.rs
@@ -1,0 +1,85 @@
+use std::{
+    io,
+    pin::Pin,
+    sync::atomic::{AtomicBool, Ordering},
+    task::{Context, Poll},
+};
+
+use futures_core::Stream;
+
+use super::{Event, InternalEvent, sys::EventSource};
+
+static ACTIVE_READER: AtomicBool = AtomicBool::new(false);
+
+/// A local asynchronous stream of terminal events.
+///
+/// The stream must be created while a Compio runtime is active. It does not
+/// enable raw mode or any optional terminal event modes. Use Crossterm's
+/// terminal and event commands to configure those modes before polling.
+///
+/// Terminal input is a process-wide resource. Only one `EventStream` can be
+/// active at a time. A second call to [`EventStream::new`] returns
+/// [`io::ErrorKind::AlreadyExists`]. Dropping the stream cancels its pending
+/// Compio operation and permits a new stream.
+#[must_use = "streams do nothing unless polled"]
+pub struct EventStream {
+    source: EventSource,
+    _lease: ReaderLease,
+}
+
+impl EventStream {
+    /// Creates an event stream for the process terminal.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when there is no active Compio runtime, another event
+    /// stream is active, or the process terminal cannot be opened.
+    pub fn new() -> io::Result<Self> {
+        let lease = ReaderLease::acquire()?;
+        let source = EventSource::new()?;
+        Ok(Self {
+            source,
+            _lease: lease,
+        })
+    }
+}
+
+impl Stream for EventStream {
+    type Item = io::Result<Event>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        loop {
+            match Pin::new(&mut self.source).poll_next(cx) {
+                Poll::Ready(Some(Ok(InternalEvent::Event(event)))) => {
+                    return Poll::Ready(Some(Ok(event)));
+                }
+                Poll::Ready(Some(Ok(InternalEvent::Ignored))) => {}
+                Poll::Ready(Some(Err(error))) => return Poll::Ready(Some(Err(error))),
+                Poll::Ready(None) => return Poll::Ready(None),
+                Poll::Pending => return Poll::Pending,
+            }
+        }
+    }
+}
+
+struct ReaderLease;
+
+impl ReaderLease {
+    fn acquire() -> io::Result<Self> {
+        ACTIVE_READER
+            .compare_exchange(false, true, Ordering::Acquire, Ordering::Relaxed)
+            .map_err(|_| {
+                io::Error::new(
+                    io::ErrorKind::AlreadyExists,
+                    "a terminal event stream is already active",
+                )
+            })?;
+        Ok(Self)
+    }
+}
+
+impl Drop for ReaderLease {
+    fn drop(&mut self) {
+        ACTIVE_READER.store(false, Ordering::Release);
+    }
+}

--- a/compio-term/src/event/sys/mod.rs
+++ b/compio-term/src/event/sys/mod.rs
@@ -1,0 +1,13 @@
+cfg_select! {
+    windows => {
+        mod windows;
+        pub(super) use windows::EventSource;
+    }
+    unix => {
+        mod unix;
+        pub(super) use unix::EventSource;
+    }
+    _ => {
+        compile_error!("compio-term supports Unix and Windows targets");
+    }
+}

--- a/compio-term/src/event/sys/unix/input/fusion.rs
+++ b/compio-term/src/event/sys/unix/input/fusion.rs
@@ -1,0 +1,46 @@
+use std::{
+    fs::File,
+    io,
+    task::{Context, Poll},
+};
+
+use compio_driver::SharedFd;
+use compio_runtime::Runtime;
+
+use super::{
+    super::{TermType, parse::Parser},
+    ReadState,
+    multishot::Input as MultishotInput,
+    poll::Input as PollInput,
+};
+
+pub(crate) enum Input {
+    Multishot(MultishotInput),
+    Poll(PollInput),
+}
+
+impl Input {
+    pub(crate) fn new(
+        terminal: SharedFd<File>,
+        runtime: Runtime,
+        term_type: TermType,
+    ) -> io::Result<Self> {
+        match term_type {
+            TermType::Stdin => {
+                MultishotInput::new(terminal, runtime, term_type).map(Self::Multishot)
+            }
+            TermType::Tty => PollInput::new(terminal, runtime, term_type).map(Self::Poll),
+        }
+    }
+
+    pub(crate) fn poll_read(
+        &mut self,
+        cx: &mut Context<'_>,
+        parser: &mut Parser,
+    ) -> Poll<io::Result<ReadState>> {
+        match self {
+            Self::Multishot(input) => input.poll_read(cx, parser),
+            Self::Poll(input) => input.poll_read(cx, parser),
+        }
+    }
+}

--- a/compio-term/src/event/sys/unix/input/mod.rs
+++ b/compio-term/src/event/sys/unix/input/mod.rs
@@ -1,0 +1,32 @@
+cfg_select! {
+    // Darwin kqueue rejects /dev/tty, so use timer polling for that path.
+    target_vendor = "apple" => {
+        mod poll;
+        mod multishot;
+        mod fusion;
+        pub(super) use fusion::Input;
+    }
+    any(
+        target_os = "linux",
+        target_os = "android",
+        target_os = "freebsd",
+        target_os = "netbsd",
+        target_os = "openbsd",
+        target_os = "dragonfly",
+        target_os = "illumos",
+        target_os = "solaris",
+    ) => {
+        mod multishot;
+        pub(super) use multishot::Input;
+    }
+    _ => {
+        // Read with a timer where terminal readiness has not been proved.
+        mod poll;
+        pub(super) use poll::Input;
+    }
+}
+
+pub(super) enum ReadState {
+    Data,
+    Closed,
+}

--- a/compio-term/src/event/sys/unix/input/multishot.rs
+++ b/compio-term/src/event/sys/unix/input/multishot.rs
@@ -1,0 +1,63 @@
+use std::{
+    fs::File,
+    io,
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+use compio_driver::{BufferRef, SharedFd, op::ReadMulti};
+use compio_runtime::{Runtime, SubmitMultiFactory, SubmitMultiManaged, SubmitMultiStream};
+use futures_core::Stream;
+
+use super::{
+    super::{TermType, parse::Parser},
+    ReadState,
+};
+
+type ReadOp = ReadMulti<SharedFd<File>>;
+type ReadStream = SubmitMultiStream<ReadFactory>;
+
+struct ReadFactory {
+    terminal: SharedFd<File>,
+    runtime: Runtime,
+}
+
+impl SubmitMultiFactory for ReadFactory {
+    type Buffer = BufferRef;
+    type Op = ReadOp;
+
+    fn create(&mut self) -> io::Result<SubmitMultiManaged<Self::Op, Self::Buffer>> {
+        let pool = self.runtime.buffer_pool()?;
+        let op = ReadMulti::new(self.terminal.clone(), &pool, 0)?;
+        Ok(self.runtime.submit_multi(op).into_managed(pool))
+    }
+}
+
+pub(crate) struct Input {
+    stream: ReadStream,
+}
+
+impl Input {
+    pub(crate) fn new(terminal: SharedFd<File>, runtime: Runtime, _: TermType) -> io::Result<Self> {
+        runtime.buffer_pool()?;
+        let factory = ReadFactory { terminal, runtime };
+        let stream = SubmitMultiStream::new(factory);
+        Ok(Self { stream })
+    }
+
+    pub(crate) fn poll_read(
+        &mut self,
+        cx: &mut Context<'_>,
+        parser: &mut Parser,
+    ) -> Poll<io::Result<ReadState>> {
+        match Pin::new(&mut self.stream).poll_next(cx) {
+            Poll::Ready(Some(Ok(buffer))) => {
+                parser.advance(&buffer);
+                Poll::Ready(Ok(ReadState::Data))
+            }
+            Poll::Ready(Some(Err(error))) => Poll::Ready(Err(error)),
+            Poll::Ready(None) => Poll::Ready(Ok(ReadState::Closed)),
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}

--- a/compio-term/src/event/sys/unix/input/poll.rs
+++ b/compio-term/src/event/sys/unix/input/poll.rs
@@ -1,0 +1,72 @@
+use std::{
+    fs::File,
+    future::Future,
+    io,
+    pin::Pin,
+    task::{Context, Poll},
+    time::Duration,
+};
+
+use compio_driver::SharedFd;
+use compio_runtime::{
+    Runtime,
+    time::{Sleep, sleep},
+};
+use rustix::io::{Errno, read};
+
+use super::{
+    super::{TermType, parse::Parser},
+    ReadState,
+};
+
+const READ_INTERVAL: Duration = Duration::from_millis(8);
+const BUFFER_SIZE: usize = 68;
+
+pub(crate) struct Input {
+    terminal: SharedFd<File>,
+    buffer: [u8; BUFFER_SIZE],
+    timer: Option<Sleep>,
+}
+
+impl Input {
+    pub(crate) fn new(terminal: SharedFd<File>, _: Runtime, _: TermType) -> io::Result<Self> {
+        Ok(Self {
+            terminal,
+            buffer: [0; BUFFER_SIZE],
+            timer: None,
+        })
+    }
+
+    pub(crate) fn poll_read(
+        &mut self,
+        cx: &mut Context<'_>,
+        parser: &mut Parser,
+    ) -> Poll<io::Result<ReadState>> {
+        if let Some(timer) = &mut self.timer {
+            if Pin::new(timer).poll(cx).is_pending() {
+                return Poll::Pending;
+            }
+            self.timer = None;
+        }
+
+        loop {
+            match read(&self.terminal, &mut self.buffer) {
+                Ok(0) => return Poll::Ready(Ok(ReadState::Closed)),
+                Ok(len) => {
+                    parser.advance(&self.buffer[..len]);
+                    return Poll::Ready(Ok(ReadState::Data));
+                }
+                Err(Errno::INTR) => {}
+                Err(Errno::AGAIN) => {
+                    let mut timer = sleep(READ_INTERVAL);
+                    if Pin::new(&mut timer).poll(cx).is_ready() {
+                        continue;
+                    }
+                    self.timer = Some(timer);
+                    return Poll::Pending;
+                }
+                Err(error) => return Poll::Ready(Err(error.into())),
+            }
+        }
+    }
+}

--- a/compio-term/src/event/sys/unix/mod.rs
+++ b/compio-term/src/event/sys/unix/mod.rs
@@ -1,0 +1,184 @@
+use std::{
+    fs::{File, OpenOptions},
+    future::Future,
+    io::{self, IsTerminal},
+    os::unix::fs::OpenOptionsExt,
+    pin::Pin,
+    task::{Context, Poll},
+    time::Duration,
+};
+
+use compio_driver::SharedFd;
+use compio_runtime::{
+    Runtime,
+    time::{Sleep, sleep},
+};
+use futures_core::Stream;
+use rustix::{
+    fs::{OFlags, fcntl_getfl, fcntl_setfl},
+    process::Signal,
+    termios::{LocalModes, tcgetattr, tcgetwinsize},
+};
+
+use self::{
+    input::{Input, ReadState},
+    parse::Parser,
+};
+use crate::event::{Event, InternalEvent};
+
+mod input;
+mod parse;
+
+const ESCAPE_TIMEOUT: Duration = Duration::from_millis(20);
+#[derive(Clone, Copy)]
+enum TermType {
+    Tty,
+    Stdin,
+}
+
+impl TermType {
+    const fn path(self) -> &'static str {
+        match self {
+            Self::Tty => "/dev/tty",
+            Self::Stdin => "/dev/stdin",
+        }
+    }
+}
+
+type ResizeListener = Pin<Box<dyn Future<Output = io::Result<()>>>>;
+
+pub(crate) struct EventSource {
+    input: Input,
+    terminal: SharedFd<File>,
+    parser: Parser,
+    escape_timer: Option<Sleep>,
+    resize: ResizeListener,
+    input_closed: bool,
+}
+
+impl EventSource {
+    pub(crate) fn new() -> io::Result<Self> {
+        let runtime = Runtime::try_current().ok_or_else(|| {
+            io::Error::other("EventStream must be created inside a Compio runtime")
+        })?;
+
+        let term_type = if io::stdin().is_terminal() {
+            TermType::Stdin
+        } else {
+            TermType::Tty
+        };
+        let mut options = OpenOptions::new();
+        options
+            .read(true)
+            .custom_flags(OFlags::NONBLOCK.bits() as i32);
+        let terminal = SharedFd::new(options.open(term_type.path())?);
+        let termios = tcgetattr(&terminal)?;
+
+        // liburing issue #1185 found that setting O_NONBLOCK at open time was
+        // not sufficient for tty multishot reads. Repeat it with F_SETFL.
+        let flags = fcntl_getfl(&terminal)?;
+        fcntl_setfl(&terminal, flags | OFlags::NONBLOCK)?;
+
+        let input = Input::new(terminal.clone(), runtime, term_type)?;
+
+        Ok(Self {
+            input,
+            terminal,
+            parser: Parser::new(!termios.local_modes.contains(LocalModes::ICANON)),
+            escape_timer: None,
+            resize: resize_listener(),
+            input_closed: false,
+        })
+    }
+
+    fn update_escape_timer(&mut self, cx: &mut Context<'_>) {
+        if !self.parser.has_ambiguous_escape() {
+            self.escape_timer = None;
+            return;
+        }
+        if self.escape_timer.is_none() {
+            let mut timer = sleep(ESCAPE_TIMEOUT);
+            let _ = Pin::new(&mut timer).poll(cx);
+            self.escape_timer = Some(timer);
+        }
+    }
+
+    fn poll_escape_timer(&mut self, cx: &mut Context<'_>) {
+        let expired = self
+            .escape_timer
+            .as_mut()
+            .is_some_and(|timer| Pin::new(timer).poll(cx).is_ready());
+        if expired {
+            self.escape_timer = None;
+            self.parser.resolve_escape();
+        }
+    }
+
+    fn poll_resize(&mut self, cx: &mut Context<'_>) -> Poll<Option<io::Result<InternalEvent>>> {
+        let Poll::Ready(result) = self.resize.as_mut().poll(cx) else {
+            return Poll::Pending;
+        };
+
+        self.resize = resize_listener();
+        let _ = self.resize.as_mut().poll(cx);
+        if let Err(error) = result {
+            return Poll::Ready(Some(Err(error)));
+        }
+        let size = match tcgetwinsize(&self.terminal) {
+            Ok(size) => size,
+            Err(error) => return Poll::Ready(Some(Err(error.into()))),
+        };
+        Poll::Ready(Some(Ok(InternalEvent::Event(Event::Resize(
+            size.ws_col,
+            size.ws_row,
+        )))))
+    }
+}
+
+impl Stream for EventSource {
+    type Item = io::Result<InternalEvent>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        loop {
+            let this = self.as_mut().get_mut();
+            if let Some(event) = this.parser.next() {
+                return Poll::Ready(Some(Ok(event)));
+            }
+
+            this.poll_escape_timer(cx);
+            if let Some(event) = this.parser.next() {
+                return Poll::Ready(Some(Ok(event)));
+            }
+
+            if !this.input_closed {
+                match this.input.poll_read(cx, &mut this.parser) {
+                    Poll::Ready(Ok(ReadState::Data)) => {
+                        this.update_escape_timer(cx);
+                        continue;
+                    }
+                    Poll::Ready(Ok(ReadState::Closed)) => {
+                        this.input_closed = true;
+                        this.parser.resolve_escape();
+                        continue;
+                    }
+                    Poll::Ready(Err(error)) => return Poll::Ready(Some(Err(error))),
+                    Poll::Pending => {}
+                }
+            }
+
+            if let Poll::Ready(event) = this.poll_resize(cx) {
+                return Poll::Ready(event);
+            }
+            if this.input_closed {
+                return Poll::Ready(None);
+            }
+
+            this.update_escape_timer(cx);
+            return Poll::Pending;
+        }
+    }
+}
+
+fn resize_listener() -> ResizeListener {
+    Box::pin(compio_signal::unix::signal(Signal::WINCH.as_raw()))
+}

--- a/compio-term/src/event/sys/unix/parse.rs
+++ b/compio-term/src/event/sys/unix/parse.rs
@@ -1,0 +1,618 @@
+// Portions of this parser are adapted from Crossterm 0.29.0.
+// Copyright (c) 2019 Timon. Licensed under the MIT license.
+
+use std::{collections::VecDeque, str::FromStr};
+
+use crate::event::{
+    Event, InternalEvent, KeyCode, KeyEvent, KeyEventKind, KeyEventState, KeyModifiers,
+    MediaKeyCode, ModifierKeyCode, MouseButton, MouseEvent, MouseEventKind,
+};
+
+const PASTE_START: &[u8] = b"\x1b[200~";
+const PASTE_END: &[u8] = b"\x1b[201~";
+
+pub(super) struct Parser {
+    buffer: Vec<u8>,
+    events: VecDeque<InternalEvent>,
+    raw_mode: bool,
+}
+
+impl Parser {
+    pub(super) fn new(raw_mode: bool) -> Self {
+        Self {
+            buffer: Vec::with_capacity(256),
+            events: VecDeque::with_capacity(128),
+            raw_mode,
+        }
+    }
+
+    pub(super) fn advance(&mut self, bytes: &[u8]) {
+        for &byte in bytes {
+            self.buffer.push(byte);
+            match parse_event(&self.buffer, true, self.raw_mode) {
+                Ok(Some(event)) => {
+                    self.events.push_back(event);
+                    self.buffer.clear();
+                }
+                Ok(None) => {}
+                Err(()) => self.buffer.clear(),
+            }
+        }
+    }
+
+    pub(super) fn resolve_escape(&mut self) {
+        match parse_event(&self.buffer, false, self.raw_mode) {
+            Ok(Some(event)) => {
+                self.events.push_back(event);
+                self.buffer.clear();
+            }
+            Ok(None) => {}
+            Err(()) => self.buffer.clear(),
+        }
+    }
+
+    pub(super) fn has_ambiguous_escape(&self) -> bool {
+        self.buffer == b"\x1b"
+    }
+}
+
+impl Iterator for Parser {
+    type Item = InternalEvent;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.events.pop_front()
+    }
+}
+
+fn parse_event(
+    buffer: &[u8],
+    input_available: bool,
+    raw_mode: bool,
+) -> Result<Option<InternalEvent>, ()> {
+    let Some(&first) = buffer.first() else {
+        return Ok(None);
+    };
+
+    match first {
+        b'\x1b' if buffer.len() == 1 => {
+            if input_available {
+                Ok(None)
+            } else {
+                Ok(Some(key(KeyCode::Esc, KeyModifiers::NONE)))
+            }
+        }
+        b'\x1b' => match buffer[1] {
+            b'[' => parse_csi(buffer, raw_mode),
+            b'O' => parse_ss3(buffer),
+            b'\x1b' => Ok(Some(key(KeyCode::Esc, KeyModifiers::NONE))),
+            _ => parse_event(&buffer[1..], input_available, raw_mode).map(|event| {
+                event.map(|event| match event {
+                    InternalEvent::Event(Event::Key(mut key)) => {
+                        key.modifiers |= KeyModifiers::ALT;
+                        InternalEvent::Event(Event::Key(key))
+                    }
+                    event => event,
+                })
+            }),
+        },
+        b'\r' => Ok(Some(key(KeyCode::Enter, KeyModifiers::NONE))),
+        b'\n' if !raw_mode => Ok(Some(key(KeyCode::Enter, KeyModifiers::NONE))),
+        b'\t' => Ok(Some(key(KeyCode::Tab, KeyModifiers::NONE))),
+        b'\x7f' => Ok(Some(key(KeyCode::Backspace, KeyModifiers::NONE))),
+        b'\0' => Ok(Some(key(KeyCode::Char(' '), KeyModifiers::CONTROL))),
+        byte @ b'\x01'..=b'\x1a' => Ok(Some(key(
+            KeyCode::Char(char::from(byte - 1 + b'a')),
+            KeyModifiers::CONTROL,
+        ))),
+        byte @ b'\x1c'..=b'\x1f' => Ok(Some(key(
+            KeyCode::Char(char::from(byte - b'\x1c' + b'4')),
+            KeyModifiers::CONTROL,
+        ))),
+        _ => parse_utf8(buffer).map(|character| {
+            character.map(|character| {
+                let modifiers = if character.is_uppercase() {
+                    KeyModifiers::SHIFT
+                } else {
+                    KeyModifiers::NONE
+                };
+                key(KeyCode::Char(character), modifiers)
+            })
+        }),
+    }
+}
+
+fn parse_ss3(buffer: &[u8]) -> Result<Option<InternalEvent>, ()> {
+    let Some(&byte) = buffer.get(2) else {
+        return Ok(None);
+    };
+    let code = match byte {
+        b'A' => KeyCode::Up,
+        b'B' => KeyCode::Down,
+        b'C' => KeyCode::Right,
+        b'D' => KeyCode::Left,
+        b'F' => KeyCode::End,
+        b'H' => KeyCode::Home,
+        b'P'..=b'S' => KeyCode::F(1 + byte - b'P'),
+        _ => return Err(()),
+    };
+    Ok(Some(key(code, KeyModifiers::NONE)))
+}
+
+fn parse_csi(buffer: &[u8], raw_mode: bool) -> Result<Option<InternalEvent>, ()> {
+    if buffer.starts_with(PASTE_START) {
+        return parse_paste(buffer);
+    }
+    if buffer.starts_with(b"\x1b[M") {
+        return parse_normal_mouse(buffer);
+    }
+    if buffer.len() == 2 {
+        return Ok(None);
+    }
+
+    let final_byte = *buffer.last().ok_or(())?;
+    if !(0x40..=0x7e).contains(&final_byte) {
+        return Ok(None);
+    }
+
+    let body = &buffer[2..buffer.len() - 1];
+    let event = match (body, final_byte) {
+        (b"", b'A') => key(KeyCode::Up, KeyModifiers::NONE),
+        (b"", b'B') => key(KeyCode::Down, KeyModifiers::NONE),
+        (b"", b'C') => key(KeyCode::Right, KeyModifiers::NONE),
+        (b"", b'D') => key(KeyCode::Left, KeyModifiers::NONE),
+        (b"", b'F') => key(KeyCode::End, KeyModifiers::NONE),
+        (b"", b'H') => key(KeyCode::Home, KeyModifiers::NONE),
+        (b"", b'I') => InternalEvent::Event(Event::FocusGained),
+        (b"", b'O') => InternalEvent::Event(Event::FocusLost),
+        (b"", b'P') => key(KeyCode::F(1), KeyModifiers::NONE),
+        (b"", b'Q') => key(KeyCode::F(2), KeyModifiers::NONE),
+        (b"", b'S') => key(KeyCode::F(4), KeyModifiers::NONE),
+        (b"", b'Z') => key(KeyCode::BackTab, KeyModifiers::SHIFT),
+        (body, b'R') if body.contains(&b';') => InternalEvent::Ignored,
+        (body, b'A' | b'B' | b'C' | b'D' | b'F' | b'H' | b'P' | b'Q' | b'R' | b'S') => {
+            parse_modified_key(body, final_byte)?
+        }
+        (body, b'M' | b'm') if body.starts_with(b"<") => parse_sgr_mouse(body, final_byte)?,
+        (body, b'M') if body.contains(&b';') => parse_rxvt_mouse(body)?,
+        (body, b'~') => parse_special_key(body)?,
+        (body, b'u') if body.starts_with(b"?") => InternalEvent::Ignored,
+        (body, b'u') => parse_kitty_key(body, raw_mode)?,
+        (body, b'c') if body.starts_with(b"?") => InternalEvent::Ignored,
+        _ => return Err(()),
+    };
+    Ok(Some(event))
+}
+
+fn parse_modified_key(body: &[u8], final_byte: u8) -> Result<InternalEvent, ()> {
+    let text = std::str::from_utf8(body).map_err(|_| ())?;
+    let mut parameters = text.split(';');
+    let _ = parameters.next();
+    let (modifiers, kind, state) = parameters
+        .next()
+        .map(parse_modifier_parameter)
+        .transpose()?
+        .map(|(mask, kind)| {
+            (
+                parse_modifiers(mask),
+                parse_kind(kind),
+                parse_modifier_state(mask),
+            )
+        })
+        .unwrap_or((KeyModifiers::NONE, KeyEventKind::Press, KeyEventState::NONE));
+    let code = match final_byte {
+        b'A' => KeyCode::Up,
+        b'B' => KeyCode::Down,
+        b'C' => KeyCode::Right,
+        b'D' => KeyCode::Left,
+        b'F' => KeyCode::End,
+        b'H' => KeyCode::Home,
+        b'P' => KeyCode::F(1),
+        b'Q' => KeyCode::F(2),
+        b'R' => KeyCode::F(3),
+        b'S' => KeyCode::F(4),
+        _ => return Err(()),
+    };
+    Ok(InternalEvent::Event(Event::Key(
+        KeyEvent::new_with_kind_and_state(code, modifiers, kind, state),
+    )))
+}
+
+fn parse_special_key(body: &[u8]) -> Result<InternalEvent, ()> {
+    let text = std::str::from_utf8(body).map_err(|_| ())?;
+    let mut parameters = text.split(';');
+    let first = next_parsed::<u8>(&mut parameters)?;
+    let (modifiers, kind, state) = parameters
+        .next()
+        .map(parse_modifier_parameter)
+        .transpose()?
+        .map(|(mask, kind)| {
+            (
+                parse_modifiers(mask),
+                parse_kind(kind),
+                parse_modifier_state(mask),
+            )
+        })
+        .unwrap_or((KeyModifiers::NONE, KeyEventKind::Press, KeyEventState::NONE));
+    let code = match first {
+        1 | 7 => KeyCode::Home,
+        2 => KeyCode::Insert,
+        3 => KeyCode::Delete,
+        4 | 8 => KeyCode::End,
+        5 => KeyCode::PageUp,
+        6 => KeyCode::PageDown,
+        value @ 11..=15 => KeyCode::F(value - 10),
+        value @ 17..=21 => KeyCode::F(value - 11),
+        value @ 23..=26 => KeyCode::F(value - 12),
+        value @ 28..=29 => KeyCode::F(value - 15),
+        value @ 31..=34 => KeyCode::F(value - 17),
+        _ => return Err(()),
+    };
+    Ok(InternalEvent::Event(Event::Key(
+        KeyEvent::new_with_kind_and_state(code, modifiers, kind, state),
+    )))
+}
+
+fn parse_kitty_key(body: &[u8], raw_mode: bool) -> Result<InternalEvent, ()> {
+    let text = std::str::from_utf8(body).map_err(|_| ())?;
+    let mut parameters = text.split(';');
+    let mut codepoints = parameters.next().ok_or(())?.split(':');
+    let codepoint = next_parsed::<u32>(&mut codepoints)?;
+    let (mask, kind) = parameters
+        .next()
+        .map(parse_modifier_parameter)
+        .transpose()?
+        .unwrap_or((1, 1));
+    let mut modifiers = parse_modifiers(mask);
+    let mut state = parse_modifier_state(mask);
+    let mut code = if let Some((code, code_state)) = functional_key(codepoint) {
+        state |= code_state;
+        code
+    } else {
+        let character = char::from_u32(codepoint).ok_or(())?;
+        match character {
+            '\x1b' => KeyCode::Esc,
+            '\r' => KeyCode::Enter,
+            '\n' if !raw_mode => KeyCode::Enter,
+            '\t' if modifiers.contains(KeyModifiers::SHIFT) => KeyCode::BackTab,
+            '\t' => KeyCode::Tab,
+            '\x7f' => KeyCode::Backspace,
+            character => KeyCode::Char(character),
+        }
+    };
+
+    if let KeyCode::Modifier(modifier) = code {
+        let modifier = match modifier {
+            ModifierKeyCode::LeftAlt | ModifierKeyCode::RightAlt => KeyModifiers::ALT,
+            ModifierKeyCode::LeftControl | ModifierKeyCode::RightControl => KeyModifiers::CONTROL,
+            ModifierKeyCode::LeftShift | ModifierKeyCode::RightShift => KeyModifiers::SHIFT,
+            ModifierKeyCode::LeftSuper | ModifierKeyCode::RightSuper => KeyModifiers::SUPER,
+            ModifierKeyCode::LeftHyper | ModifierKeyCode::RightHyper => KeyModifiers::HYPER,
+            ModifierKeyCode::LeftMeta | ModifierKeyCode::RightMeta => KeyModifiers::META,
+            _ => KeyModifiers::NONE,
+        };
+        modifiers |= modifier;
+    }
+
+    if modifiers.contains(KeyModifiers::SHIFT)
+        && let Some(character) = codepoints
+            .next()
+            .and_then(|value| value.parse::<u32>().ok())
+            .and_then(char::from_u32)
+    {
+        code = KeyCode::Char(character);
+        modifiers.remove(KeyModifiers::SHIFT);
+    }
+
+    Ok(InternalEvent::Event(Event::Key(
+        KeyEvent::new_with_kind_and_state(code, modifiers, parse_kind(kind), state),
+    )))
+}
+
+fn functional_key(codepoint: u32) -> Option<(KeyCode, KeyEventState)> {
+    let keypad = match codepoint {
+        57399..=57408 => KeyCode::Char(char::from(b'0' + (codepoint - 57399) as u8)),
+        57409 => KeyCode::Char('.'),
+        57410 => KeyCode::Char('/'),
+        57411 => KeyCode::Char('*'),
+        57412 => KeyCode::Char('-'),
+        57413 => KeyCode::Char('+'),
+        57414 => KeyCode::Enter,
+        57415 => KeyCode::Char('='),
+        57416 => KeyCode::Char(','),
+        57417 => KeyCode::Left,
+        57418 => KeyCode::Right,
+        57419 => KeyCode::Up,
+        57420 => KeyCode::Down,
+        57421 => KeyCode::PageUp,
+        57422 => KeyCode::PageDown,
+        57423 => KeyCode::Home,
+        57424 => KeyCode::End,
+        57425 => KeyCode::Insert,
+        57426 => KeyCode::Delete,
+        57427 => KeyCode::KeypadBegin,
+        _ => return non_keypad_functional_key(codepoint),
+    };
+    Some((keypad, KeyEventState::KEYPAD))
+}
+
+fn non_keypad_functional_key(codepoint: u32) -> Option<(KeyCode, KeyEventState)> {
+    let code = match codepoint {
+        57358 => KeyCode::CapsLock,
+        57359 => KeyCode::ScrollLock,
+        57360 => KeyCode::NumLock,
+        57361 => KeyCode::PrintScreen,
+        57362 => KeyCode::Pause,
+        57363 => KeyCode::Menu,
+        57376..=57398 => KeyCode::F((codepoint - 57363) as u8),
+        57428 => KeyCode::Media(MediaKeyCode::Play),
+        57429 => KeyCode::Media(MediaKeyCode::Pause),
+        57430 => KeyCode::Media(MediaKeyCode::PlayPause),
+        57431 => KeyCode::Media(MediaKeyCode::Reverse),
+        57432 => KeyCode::Media(MediaKeyCode::Stop),
+        57433 => KeyCode::Media(MediaKeyCode::FastForward),
+        57434 => KeyCode::Media(MediaKeyCode::Rewind),
+        57435 => KeyCode::Media(MediaKeyCode::TrackNext),
+        57436 => KeyCode::Media(MediaKeyCode::TrackPrevious),
+        57437 => KeyCode::Media(MediaKeyCode::Record),
+        57438 => KeyCode::Media(MediaKeyCode::LowerVolume),
+        57439 => KeyCode::Media(MediaKeyCode::RaiseVolume),
+        57440 => KeyCode::Media(MediaKeyCode::MuteVolume),
+        57441 => KeyCode::Modifier(ModifierKeyCode::LeftShift),
+        57442 => KeyCode::Modifier(ModifierKeyCode::LeftControl),
+        57443 => KeyCode::Modifier(ModifierKeyCode::LeftAlt),
+        57444 => KeyCode::Modifier(ModifierKeyCode::LeftSuper),
+        57445 => KeyCode::Modifier(ModifierKeyCode::LeftHyper),
+        57446 => KeyCode::Modifier(ModifierKeyCode::LeftMeta),
+        57447 => KeyCode::Modifier(ModifierKeyCode::RightShift),
+        57448 => KeyCode::Modifier(ModifierKeyCode::RightControl),
+        57449 => KeyCode::Modifier(ModifierKeyCode::RightAlt),
+        57450 => KeyCode::Modifier(ModifierKeyCode::RightSuper),
+        57451 => KeyCode::Modifier(ModifierKeyCode::RightHyper),
+        57452 => KeyCode::Modifier(ModifierKeyCode::RightMeta),
+        57453 => KeyCode::Modifier(ModifierKeyCode::IsoLevel3Shift),
+        57454 => KeyCode::Modifier(ModifierKeyCode::IsoLevel5Shift),
+        _ => return None,
+    };
+    Some((code, KeyEventState::NONE))
+}
+
+fn parse_rxvt_mouse(body: &[u8]) -> Result<InternalEvent, ()> {
+    let text = std::str::from_utf8(body).map_err(|_| ())?;
+    let mut values = text.split(';');
+    let cb = next_parsed::<u8>(&mut values)?.checked_sub(32).ok_or(())?;
+    let (kind, modifiers) = parse_cb(cb)?;
+    let column = next_parsed::<u16>(&mut values)?.checked_sub(1).ok_or(())?;
+    let row = next_parsed::<u16>(&mut values)?.checked_sub(1).ok_or(())?;
+    Ok(mouse(kind, column, row, modifiers))
+}
+
+fn parse_normal_mouse(buffer: &[u8]) -> Result<Option<InternalEvent>, ()> {
+    if buffer.len() < 6 {
+        return Ok(None);
+    }
+    let cb = buffer[3].checked_sub(32).ok_or(())?;
+    let (kind, modifiers) = parse_cb(cb)?;
+    let column = u16::from(buffer[4].checked_sub(33).ok_or(())?);
+    let row = u16::from(buffer[5].checked_sub(33).ok_or(())?);
+    Ok(Some(mouse(kind, column, row, modifiers)))
+}
+
+fn parse_sgr_mouse(body: &[u8], final_byte: u8) -> Result<InternalEvent, ()> {
+    let text = std::str::from_utf8(body.strip_prefix(b"<").ok_or(())?).map_err(|_| ())?;
+    let mut values = text.split(';');
+    let cb = next_parsed::<u8>(&mut values)?;
+    let (mut kind, modifiers) = parse_cb(cb)?;
+    let column = next_parsed::<u16>(&mut values)?.checked_sub(1).ok_or(())?;
+    let row = next_parsed::<u16>(&mut values)?.checked_sub(1).ok_or(())?;
+    if final_byte == b'm'
+        && let MouseEventKind::Down(button) = kind
+    {
+        kind = MouseEventKind::Up(button);
+    }
+    Ok(mouse(kind, column, row, modifiers))
+}
+
+fn parse_cb(cb: u8) -> Result<(MouseEventKind, KeyModifiers), ()> {
+    let button = (cb & 0b0000_0011) | ((cb & 0b1100_0000) >> 4);
+    let dragging = cb & 0b0010_0000 != 0;
+    let kind = match (button, dragging) {
+        (0, false) => MouseEventKind::Down(MouseButton::Left),
+        (1, false) => MouseEventKind::Down(MouseButton::Middle),
+        (2, false) => MouseEventKind::Down(MouseButton::Right),
+        (0, true) => MouseEventKind::Drag(MouseButton::Left),
+        (1, true) => MouseEventKind::Drag(MouseButton::Middle),
+        (2, true) => MouseEventKind::Drag(MouseButton::Right),
+        (3, false) => MouseEventKind::Up(MouseButton::Left),
+        (3..=5, true) => MouseEventKind::Moved,
+        (4, false) => MouseEventKind::ScrollUp,
+        (5, false) => MouseEventKind::ScrollDown,
+        (6, false) => MouseEventKind::ScrollLeft,
+        (7, false) => MouseEventKind::ScrollRight,
+        _ => return Err(()),
+    };
+    let mut modifiers = KeyModifiers::NONE;
+    modifiers.set(KeyModifiers::SHIFT, cb & 0b0000_0100 != 0);
+    modifiers.set(KeyModifiers::ALT, cb & 0b0000_1000 != 0);
+    modifiers.set(KeyModifiers::CONTROL, cb & 0b0001_0000 != 0);
+    Ok((kind, modifiers))
+}
+
+fn parse_paste(buffer: &[u8]) -> Result<Option<InternalEvent>, ()> {
+    if !buffer.ends_with(PASTE_END) {
+        return Ok(None);
+    }
+    let text = String::from_utf8_lossy(&buffer[PASTE_START.len()..buffer.len() - PASTE_END.len()])
+        .into_owned();
+    Ok(Some(InternalEvent::Event(Event::Paste(text))))
+}
+
+fn parse_modifier_parameter(parameter: &str) -> Result<(u8, u8), ()> {
+    let mut values = parameter.split(':');
+    let mask = next_parsed::<u8>(&mut values)?;
+    let kind = values
+        .next()
+        .map(|value| value.parse::<u8>().map_err(|_| ()))
+        .transpose()?
+        .unwrap_or(1);
+    Ok((mask, kind))
+}
+
+fn parse_modifiers(mask: u8) -> KeyModifiers {
+    let bits = mask.saturating_sub(1);
+    let mut modifiers = KeyModifiers::NONE;
+    modifiers.set(KeyModifiers::SHIFT, bits & 1 != 0);
+    modifiers.set(KeyModifiers::ALT, bits & 2 != 0);
+    modifiers.set(KeyModifiers::CONTROL, bits & 4 != 0);
+    modifiers.set(KeyModifiers::SUPER, bits & 8 != 0);
+    modifiers.set(KeyModifiers::HYPER, bits & 16 != 0);
+    modifiers.set(KeyModifiers::META, bits & 32 != 0);
+    modifiers
+}
+
+fn parse_modifier_state(mask: u8) -> KeyEventState {
+    let bits = mask.saturating_sub(1);
+    let mut state = KeyEventState::NONE;
+    state.set(KeyEventState::CAPS_LOCK, bits & 64 != 0);
+    state.set(KeyEventState::NUM_LOCK, bits & 128 != 0);
+    state
+}
+
+fn parse_kind(kind: u8) -> KeyEventKind {
+    match kind {
+        2 => KeyEventKind::Repeat,
+        3 => KeyEventKind::Release,
+        _ => KeyEventKind::Press,
+    }
+}
+
+fn parse_utf8(buffer: &[u8]) -> Result<Option<char>, ()> {
+    match std::str::from_utf8(buffer) {
+        Ok(text) => Ok(text.chars().next()),
+        Err(_) => {
+            let width = match buffer[0] {
+                0x00..=0x7f => 1,
+                0xc2..=0xdf => 2,
+                0xe0..=0xef => 3,
+                0xf0..=0xf4 => 4,
+                _ => return Err(()),
+            };
+            if buffer[1..].iter().any(|byte| byte & 0xc0 != 0x80) {
+                return Err(());
+            }
+            if buffer.len() < width {
+                Ok(None)
+            } else {
+                Err(())
+            }
+        }
+    }
+}
+
+fn next_parsed<'a, T: FromStr>(values: &mut impl Iterator<Item = &'a str>) -> Result<T, ()> {
+    values.next().ok_or(())?.parse().map_err(|_| ())
+}
+
+fn key(code: KeyCode, modifiers: KeyModifiers) -> InternalEvent {
+    InternalEvent::Event(Event::Key(KeyEvent::new(code, modifiers)))
+}
+
+fn mouse(kind: MouseEventKind, column: u16, row: u16, modifiers: KeyModifiers) -> InternalEvent {
+    InternalEvent::Event(Event::Mouse(MouseEvent {
+        kind,
+        column,
+        row,
+        modifiers,
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn events(bytes: &[u8]) -> Vec<Event> {
+        let mut parser = Parser::new(true);
+        parser.advance(bytes);
+        parser.resolve_escape();
+        parser
+            .filter_map(|event| match event {
+                InternalEvent::Event(event) => Some(event),
+                InternalEvent::Ignored => None,
+            })
+            .collect()
+    }
+
+    #[test]
+    fn parses_plain_utf8_and_control_keys() {
+        assert_eq!(
+            events("aé\u{3}".as_bytes()),
+            vec![
+                Event::Key(KeyEvent::new(KeyCode::Char('a'), KeyModifiers::NONE)),
+                Event::Key(KeyEvent::new(KeyCode::Char('é'), KeyModifiers::NONE)),
+                Event::Key(KeyEvent::new(KeyCode::Char('c'), KeyModifiers::CONTROL,)),
+            ]
+        );
+    }
+
+    #[test]
+    fn resolves_escape_and_alt_keys() {
+        assert_eq!(
+            events(b"\x1b"),
+            vec![Event::Key(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE,))]
+        );
+        assert_eq!(
+            events(b"\x1bx"),
+            vec![Event::Key(KeyEvent::new(
+                KeyCode::Char('x'),
+                KeyModifiers::ALT,
+            ))]
+        );
+    }
+
+    #[test]
+    fn parses_navigation_modifiers_and_kind() {
+        assert_eq!(
+            events(b"\x1b[A\x1b[1;6:2C"),
+            vec![
+                Event::Key(KeyEvent::new(KeyCode::Up, KeyModifiers::NONE)),
+                Event::Key(KeyEvent::new_with_kind(
+                    KeyCode::Right,
+                    KeyModifiers::SHIFT | KeyModifiers::CONTROL,
+                    KeyEventKind::Repeat,
+                )),
+            ]
+        );
+    }
+
+    #[test]
+    fn parses_bracketed_paste_as_one_event() {
+        assert_eq!(
+            events(b"\x1b[200~hello\nworld\x1b[201~"),
+            vec![Event::Paste("hello\nworld".into())]
+        );
+    }
+
+    #[test]
+    fn parses_sgr_mouse_coordinates() {
+        assert_eq!(
+            events(b"\x1b[<0;4;3M"),
+            vec![Event::Mouse(MouseEvent {
+                kind: MouseEventKind::Down(MouseButton::Left),
+                column: 3,
+                row: 2,
+                modifiers: KeyModifiers::NONE,
+            })]
+        );
+    }
+
+    #[test]
+    fn parses_kitty_release_event() {
+        assert_eq!(
+            events(b"\x1b[97;5:3u"),
+            vec![Event::Key(KeyEvent::new_with_kind(
+                KeyCode::Char('a'),
+                KeyModifiers::CONTROL,
+                KeyEventKind::Release,
+            ))]
+        );
+    }
+}

--- a/compio-term/src/event/sys/windows/mod.rs
+++ b/compio-term/src/event/sys/windows/mod.rs
@@ -1,0 +1,127 @@
+use std::{
+    future::Future,
+    io,
+    os::windows::io::{AsRawHandle, RawHandle},
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+use compio_buf::BufResult;
+use compio_driver::{OpCode, OpType};
+use compio_runtime::{Runtime, Submit};
+use futures_core::Stream;
+use windows_sys::Win32::System::Console::{
+    GetConsoleMode, GetNumberOfConsoleInputEvents, INPUT_RECORD, ReadConsoleInputW,
+};
+
+use self::parse::Parser;
+use crate::event::InternalEvent;
+
+mod parse;
+
+pub(crate) struct EventSource {
+    handle: RawHandle,
+    read: Option<Submit<ReadInput>>,
+    parser: Parser,
+}
+
+impl EventSource {
+    pub(crate) fn new() -> io::Result<Self> {
+        if Runtime::try_current().is_none() {
+            return Err(io::Error::other(
+                "EventStream must be created inside a Compio runtime",
+            ));
+        }
+
+        let handle = io::stdin().as_raw_handle();
+        let mut mode = 0;
+        if unsafe { GetConsoleMode(handle, &mut mode) } == 0 {
+            return Err(io::Error::last_os_error());
+        }
+
+        Ok(Self {
+            handle,
+            read: None,
+            parser: Parser::default(),
+        })
+    }
+}
+
+impl Stream for EventSource {
+    type Item = io::Result<InternalEvent>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let this = self.as_mut().get_mut();
+        if this.read.is_none() {
+            this.read = Some(compio_runtime::submit(ReadInput::new(this.handle)));
+        }
+
+        let Poll::Ready(BufResult(result, input)) =
+            Pin::new(this.read.as_mut().expect("read future was created")).poll(cx)
+        else {
+            return Poll::Pending;
+        };
+        this.read = None;
+        if let Err(error) = result {
+            return Poll::Ready(Some(Err(error)));
+        }
+        match this.parser.parse(input.record) {
+            Ok(Some(event)) => Poll::Ready(Some(Ok(InternalEvent::Event(event)))),
+            Ok(None) => Poll::Ready(Some(Ok(InternalEvent::Ignored))),
+            Err(error) => Poll::Ready(Some(Err(error))),
+        }
+    }
+}
+
+struct ReadInput {
+    handle: RawHandle,
+    record: INPUT_RECORD,
+}
+
+impl ReadInput {
+    fn new(handle: RawHandle) -> Self {
+        Self {
+            handle,
+            record: INPUT_RECORD::default(),
+        }
+    }
+}
+
+// Compio waits for the console handle before calling `operate`. The operation
+// owns the record storage until it completes.
+unsafe impl OpCode for ReadInput {
+    type Control = ();
+
+    fn op_type(&self, _: &Self::Control) -> OpType {
+        OpType::Event(self.handle as _)
+    }
+
+    unsafe fn operate(
+        &mut self,
+        _: &mut Self::Control,
+        _: *mut windows_sys::Win32::System::IO::OVERLAPPED,
+    ) -> Poll<io::Result<usize>> {
+        let mut available = 0;
+        if unsafe { GetNumberOfConsoleInputEvents(self.handle, &mut available) } == 0 {
+            return Poll::Ready(Err(io::Error::last_os_error()));
+        }
+        if available == 0 {
+            return Poll::Ready(Err(io::Error::new(
+                io::ErrorKind::WouldBlock,
+                "console input was consumed by another reader",
+            )));
+        }
+
+        let mut read = 0;
+        if unsafe { ReadConsoleInputW(self.handle, &mut self.record, 1, &mut read) } == 0 {
+            Poll::Ready(Err(io::Error::last_os_error()))
+        } else if read == 1 {
+            Poll::Ready(Ok(1))
+        } else {
+            Poll::Ready(Err(io::Error::new(
+                io::ErrorKind::UnexpectedEof,
+                "console input returned no event",
+            )))
+        }
+    }
+}

--- a/compio-term/src/event/sys/windows/parse.rs
+++ b/compio-term/src/event/sys/windows/parse.rs
@@ -1,0 +1,334 @@
+// Portions of this parser are adapted from Crossterm 0.29.0.
+// Copyright (c) 2019 Timon. Licensed under the MIT license.
+
+use std::{char, io};
+
+use windows_sys::Win32::{
+    Foundation::{INVALID_HANDLE_VALUE, TRUE},
+    System::Console::{
+        CAPSLOCK_ON, CONSOLE_SCREEN_BUFFER_INFO, DOUBLE_CLICK, FOCUS_EVENT,
+        FROM_LEFT_1ST_BUTTON_PRESSED, FROM_LEFT_2ND_BUTTON_PRESSED, GetConsoleScreenBufferInfo,
+        GetStdHandle, INPUT_RECORD, KEY_EVENT, KEY_EVENT_RECORD, LEFT_ALT_PRESSED,
+        LEFT_CTRL_PRESSED, MOUSE_EVENT, MOUSE_EVENT_RECORD, MOUSE_HWHEELED, MOUSE_MOVED,
+        MOUSE_WHEELED, NUMLOCK_ON, RIGHT_ALT_PRESSED, RIGHT_CTRL_PRESSED, RIGHTMOST_BUTTON_PRESSED,
+        SHIFT_PRESSED, STD_OUTPUT_HANDLE, WINDOW_BUFFER_SIZE_EVENT,
+    },
+    UI::{
+        Input::KeyboardAndMouse::{
+            GetKeyboardLayout, ToUnicodeEx, VK_BACK, VK_CONTROL, VK_DELETE, VK_DOWN, VK_END,
+            VK_ESCAPE, VK_F1, VK_F24, VK_HOME, VK_INSERT, VK_LEFT, VK_MENU, VK_NEXT, VK_NUMPAD0,
+            VK_NUMPAD9, VK_PRIOR, VK_RETURN, VK_RIGHT, VK_SHIFT, VK_TAB, VK_UP,
+        },
+        WindowsAndMessaging::{GetForegroundWindow, GetWindowThreadProcessId},
+    },
+};
+
+use crate::event::{
+    Event, KeyCode, KeyEvent, KeyEventKind, KeyEventState, KeyModifiers, MouseButton, MouseEvent,
+    MouseEventKind,
+};
+
+#[derive(Default)]
+pub(super) struct Parser {
+    surrogate: Option<u16>,
+    buttons: MouseButtons,
+}
+
+impl Parser {
+    pub(super) fn parse(&mut self, record: INPUT_RECORD) -> io::Result<Option<Event>> {
+        let event = match u32::from(record.EventType) {
+            KEY_EVENT => {
+                // The event tag determines the active INPUT_RECORD union field.
+                let record = unsafe { record.Event.KeyEvent };
+                self.parse_key(record)
+            }
+            MOUSE_EVENT => {
+                // The event tag determines the active INPUT_RECORD union field.
+                let record = unsafe { record.Event.MouseEvent };
+                let event = parse_mouse(record, self.buttons)?;
+                self.buttons = MouseButtons::from_state(record.dwButtonState);
+                event.map(Event::Mouse)
+            }
+            WINDOW_BUFFER_SIZE_EVENT => {
+                // The event tag determines the active INPUT_RECORD union field.
+                let size = unsafe { record.Event.WindowBufferSizeEvent }.dwSize;
+                Some(Event::Resize(size.X.max(0) as u16, size.Y.max(0) as u16))
+            }
+            FOCUS_EVENT => {
+                // The event tag determines the active INPUT_RECORD union field.
+                let focus = unsafe { record.Event.FocusEvent };
+                Some(if focus.bSetFocus == TRUE {
+                    Event::FocusGained
+                } else {
+                    Event::FocusLost
+                })
+            }
+            _ => None,
+        };
+        Ok(event)
+    }
+
+    fn parse_key(&mut self, record: KEY_EVENT_RECORD) -> Option<Event> {
+        let event = parse_key(record)?;
+        match event {
+            WindowsKeyEvent::Key(event) => {
+                self.surrogate = None;
+                Some(Event::Key(event))
+            }
+            WindowsKeyEvent::Surrogate(surrogate) => {
+                let first = self.surrogate.replace(surrogate)?;
+                self.surrogate = None;
+                let character = char::decode_utf16([first, surrogate]).next()?.ok()?;
+                Some(Event::Key(KeyEvent::new(
+                    KeyCode::Char(character),
+                    modifiers(record.dwControlKeyState),
+                )))
+            }
+        }
+    }
+}
+
+enum WindowsKeyEvent {
+    Key(KeyEvent),
+    Surrogate(u16),
+}
+
+fn parse_key(record: KEY_EVENT_RECORD) -> Option<WindowsKeyEvent> {
+    let modifiers = modifiers(record.dwControlKeyState);
+    let state = key_state(record.dwControlKeyState);
+    let virtual_key = record.wVirtualKeyCode;
+    // The KEY_EVENT_RECORD layout makes UnicodeChar the active union field for W
+    // APIs.
+    let utf16 = unsafe { record.uChar.UnicodeChar };
+
+    let alt_code = virtual_key == VK_MENU && record.bKeyDown == 0 && utf16 != 0;
+    if alt_code {
+        return unicode_key(utf16, modifiers, state, KeyEventKind::Release);
+    }
+
+    let numpad = (VK_NUMPAD0..=VK_NUMPAD9).contains(&virtual_key);
+    let only_alt = modifiers.contains(KeyModifiers::ALT)
+        && !modifiers.intersects(KeyModifiers::SHIFT | KeyModifiers::CONTROL);
+    if numpad && only_alt {
+        return None;
+    }
+
+    let code = match virtual_key {
+        VK_SHIFT | VK_CONTROL | VK_MENU => return None,
+        VK_BACK => Some(KeyCode::Backspace),
+        VK_ESCAPE => Some(KeyCode::Esc),
+        VK_RETURN => Some(KeyCode::Enter),
+        VK_F1..=VK_F24 => Some(KeyCode::F((virtual_key - VK_F1 + 1) as u8)),
+        VK_LEFT => Some(KeyCode::Left),
+        VK_UP => Some(KeyCode::Up),
+        VK_RIGHT => Some(KeyCode::Right),
+        VK_DOWN => Some(KeyCode::Down),
+        VK_PRIOR => Some(KeyCode::PageUp),
+        VK_NEXT => Some(KeyCode::PageDown),
+        VK_HOME => Some(KeyCode::Home),
+        VK_END => Some(KeyCode::End),
+        VK_DELETE => Some(KeyCode::Delete),
+        VK_INSERT => Some(KeyCode::Insert),
+        VK_TAB if modifiers.contains(KeyModifiers::SHIFT) => Some(KeyCode::BackTab),
+        VK_TAB => Some(KeyCode::Tab),
+        _ if utf16 <= 0x1f => character_for_key(record).map(KeyCode::Char),
+        _ if (0xd800..=0xdfff).contains(&utf16) => {
+            return Some(WindowsKeyEvent::Surrogate(utf16));
+        }
+        _ => char::from_u32(u32::from(utf16)).map(KeyCode::Char),
+    }?;
+    let kind = if record.bKeyDown == 0 {
+        KeyEventKind::Release
+    } else {
+        KeyEventKind::Press
+    };
+    Some(WindowsKeyEvent::Key(KeyEvent::new_with_kind_and_state(
+        code, modifiers, kind, state,
+    )))
+}
+
+fn unicode_key(
+    utf16: u16,
+    modifiers: KeyModifiers,
+    state: KeyEventState,
+    kind: KeyEventKind,
+) -> Option<WindowsKeyEvent> {
+    if (0xd800..=0xdfff).contains(&utf16) {
+        return Some(WindowsKeyEvent::Surrogate(utf16));
+    }
+    let character = char::from_u32(u32::from(utf16))?;
+    Some(WindowsKeyEvent::Key(KeyEvent::new_with_kind_and_state(
+        KeyCode::Char(character),
+        modifiers,
+        kind,
+        state,
+    )))
+}
+
+fn character_for_key(record: KEY_EVENT_RECORD) -> Option<char> {
+    let keyboard_state = [0_u8; 256];
+    let mut utf16 = [0_u16; 16];
+    let layout = unsafe {
+        let window = GetForegroundWindow();
+        let thread = GetWindowThreadProcessId(window, std::ptr::null_mut());
+        GetKeyboardLayout(thread)
+    };
+    let count = unsafe {
+        ToUnicodeEx(
+            u32::from(record.wVirtualKeyCode),
+            u32::from(record.wVirtualScanCode),
+            keyboard_state.as_ptr(),
+            utf16.as_mut_ptr(),
+            utf16.len() as i32,
+            4,
+            layout,
+        )
+    };
+    if count < 1 {
+        return None;
+    }
+    let mut characters = char::decode_utf16(utf16.into_iter().take(count as usize));
+    let mut character = characters.next()?.ok()?;
+    if characters.next().is_some() {
+        return None;
+    }
+
+    let uppercase = (record.dwControlKeyState & SHIFT_PRESSED != 0)
+        ^ (record.dwControlKeyState & CAPSLOCK_ON != 0);
+    if uppercase && character.is_lowercase() {
+        let mut converted = character.to_uppercase();
+        let first = converted.next()?;
+        if converted.next().is_none() {
+            character = first;
+        }
+    } else if !uppercase && character.is_uppercase() {
+        let mut converted = character.to_lowercase();
+        let first = converted.next()?;
+        if converted.next().is_none() {
+            character = first;
+        }
+    }
+    Some(character)
+}
+
+fn modifiers(state: u32) -> KeyModifiers {
+    let mut modifiers = KeyModifiers::NONE;
+    modifiers.set(KeyModifiers::SHIFT, state & SHIFT_PRESSED != 0);
+    modifiers.set(
+        KeyModifiers::CONTROL,
+        state & (LEFT_CTRL_PRESSED | RIGHT_CTRL_PRESSED) != 0,
+    );
+    modifiers.set(
+        KeyModifiers::ALT,
+        state & (LEFT_ALT_PRESSED | RIGHT_ALT_PRESSED) != 0,
+    );
+    modifiers
+}
+
+fn key_state(state: u32) -> KeyEventState {
+    let mut event_state = KeyEventState::NONE;
+    event_state.set(KeyEventState::CAPS_LOCK, state & CAPSLOCK_ON != 0);
+    event_state.set(KeyEventState::NUM_LOCK, state & NUMLOCK_ON != 0);
+    event_state
+}
+
+#[derive(Clone, Copy, Default)]
+struct MouseButtons {
+    left: bool,
+    right: bool,
+    middle: bool,
+}
+
+impl MouseButtons {
+    fn from_state(state: u32) -> Self {
+        Self {
+            left: state & FROM_LEFT_1ST_BUTTON_PRESSED != 0,
+            right: state & RIGHTMOST_BUTTON_PRESSED != 0,
+            middle: state & FROM_LEFT_2ND_BUTTON_PRESSED != 0,
+        }
+    }
+}
+
+fn parse_mouse(
+    record: MOUSE_EVENT_RECORD,
+    pressed: MouseButtons,
+) -> io::Result<Option<MouseEvent>> {
+    let state = record.dwButtonState;
+    let kind = match record.dwEventFlags {
+        0 | DOUBLE_CLICK => {
+            if state & FROM_LEFT_1ST_BUTTON_PRESSED != 0 && !pressed.left {
+                Some(MouseEventKind::Down(MouseButton::Left))
+            } else if state & FROM_LEFT_1ST_BUTTON_PRESSED == 0 && pressed.left {
+                Some(MouseEventKind::Up(MouseButton::Left))
+            } else if state & RIGHTMOST_BUTTON_PRESSED != 0 && !pressed.right {
+                Some(MouseEventKind::Down(MouseButton::Right))
+            } else if state & RIGHTMOST_BUTTON_PRESSED == 0 && pressed.right {
+                Some(MouseEventKind::Up(MouseButton::Right))
+            } else if state & FROM_LEFT_2ND_BUTTON_PRESSED != 0 && !pressed.middle {
+                Some(MouseEventKind::Down(MouseButton::Middle))
+            } else if state & FROM_LEFT_2ND_BUTTON_PRESSED == 0 && pressed.middle {
+                Some(MouseEventKind::Up(MouseButton::Middle))
+            } else {
+                None
+            }
+        }
+        MOUSE_MOVED => {
+            let button = if state & RIGHTMOST_BUTTON_PRESSED != 0 {
+                MouseButton::Right
+            } else if state & FROM_LEFT_2ND_BUTTON_PRESSED != 0 {
+                MouseButton::Middle
+            } else {
+                MouseButton::Left
+            };
+            if state
+                & (FROM_LEFT_1ST_BUTTON_PRESSED
+                    | RIGHTMOST_BUTTON_PRESSED
+                    | FROM_LEFT_2ND_BUTTON_PRESSED)
+                == 0
+            {
+                Some(MouseEventKind::Moved)
+            } else {
+                Some(MouseEventKind::Drag(button))
+            }
+        }
+        MOUSE_WHEELED => match wheel_delta(state).cmp(&0) {
+            std::cmp::Ordering::Less => Some(MouseEventKind::ScrollDown),
+            std::cmp::Ordering::Greater => Some(MouseEventKind::ScrollUp),
+            std::cmp::Ordering::Equal => None,
+        },
+        MOUSE_HWHEELED => match wheel_delta(state).cmp(&0) {
+            std::cmp::Ordering::Less => Some(MouseEventKind::ScrollLeft),
+            std::cmp::Ordering::Greater => Some(MouseEventKind::ScrollRight),
+            std::cmp::Ordering::Equal => None,
+        },
+        _ => None,
+    };
+    let Some(kind) = kind else {
+        return Ok(None);
+    };
+
+    let column = record.dwMousePosition.X.max(0) as u16;
+    let row = relative_row(record.dwMousePosition.Y)?;
+    Ok(Some(MouseEvent {
+        kind,
+        column,
+        row,
+        modifiers: modifiers(record.dwControlKeyState),
+    }))
+}
+
+fn relative_row(row: i16) -> io::Result<u16> {
+    let output = unsafe { GetStdHandle(STD_OUTPUT_HANDLE) };
+    if output.is_null() || output == INVALID_HANDLE_VALUE {
+        return Err(io::Error::last_os_error());
+    }
+    let mut info = CONSOLE_SCREEN_BUFFER_INFO::default();
+    if unsafe { GetConsoleScreenBufferInfo(output, &mut info) } == 0 {
+        return Err(io::Error::last_os_error());
+    }
+    Ok(row.saturating_sub(info.srWindow.Top).max(0) as u16)
+}
+
+fn wheel_delta(state: u32) -> i16 {
+    (state >> 16) as i16
+}

--- a/compio-term/src/lib.rs
+++ b/compio-term/src/lib.rs
@@ -8,7 +8,8 @@
 //!
 //! Crossterm's cursor, style, terminal, and terminal detection modules are
 //! re-exported unchanged. Crossterm's synchronous command execution traits and
-//! macros are replaced by [`CommandQueue`] and [`QueueableCommand`].
+//! macros are replaced by [`CommandQueue`], [`Commands`], and
+//! [`Queueable`].
 //!
 //! [`io::AsyncWrite`]: compio_io::AsyncWrite
 
@@ -22,7 +23,7 @@ use crossterm::terminal::{disable_raw_mode, enable_raw_mode};
 mod command;
 pub mod event;
 
-pub use command::{CommandQueue, QueueableCommand};
+pub use command::{CommandQueue, Commands, Queueable};
 pub use crossterm::{Command, cursor, style, terminal, tty};
 
 /// A guard that keeps the terminal in raw mode until it is dropped.

--- a/compio-term/src/lib.rs
+++ b/compio-term/src/lib.rs
@@ -1,0 +1,47 @@
+//! Completion-based terminal support for the [Compio](https://crates.io/crates/compio)
+//! runtime.
+//!
+//! This crate keeps Crossterm's event data model and command types. It replaces
+//! Crossterm's threaded event reader with a local Compio [`event::EventStream`]
+//! and writes queued commands through Compio [`io::AsyncWrite`] sinks. Event
+//! reading never starts a helper thread.
+//!
+//! Crossterm's cursor, style, terminal, and terminal detection modules are
+//! re-exported unchanged. Crossterm's synchronous command execution traits and
+//! macros are replaced by [`CommandQueue`] and [`QueueableCommand`].
+//!
+//! [`io::AsyncWrite`]: compio_io::AsyncWrite
+
+#![allow(unused_features)]
+#![warn(missing_docs)]
+#![deny(rustdoc::broken_intra_doc_links)]
+use std::io;
+
+use crossterm::terminal::{disable_raw_mode, enable_raw_mode};
+
+mod command;
+pub mod event;
+
+pub use command::{CommandQueue, QueueableCommand};
+pub use crossterm::{Command, cursor, style, terminal, tty};
+
+/// A guard that keeps the terminal in raw mode until it is dropped.
+#[derive(Debug)]
+#[must_use = "raw mode is disabled when the guard is dropped"]
+pub struct RawMode;
+
+impl RawMode {
+    /// Enables terminal raw mode.
+    pub fn enable() -> io::Result<Self> {
+        enable_raw_mode()?;
+        Ok(Self)
+    }
+}
+
+impl Drop for RawMode {
+    fn drop(&mut self) {
+        if let Err(error) = disable_raw_mode() {
+            compio_log::error!("failed to disable terminal raw mode: {error}");
+        }
+    }
+}

--- a/compio/Cargo.toml
+++ b/compio/Cargo.toml
@@ -29,6 +29,7 @@ compio-fs = { workspace = true, optional = true }
 compio-io = { workspace = true, optional = true }
 compio-net = { workspace = true, optional = true }
 compio-signal = { workspace = true, optional = true }
+compio-term = { workspace = true, optional = true }
 compio-dispatcher = { workspace = true, optional = true }
 compio-log = { workspace = true }
 compio-tls = { workspace = true, optional = true }
@@ -88,6 +89,7 @@ runtime = ["dep:compio-runtime"]
 async-fd = ["runtime", "compio-runtime/async-fd"]
 macros = ["dep:compio-macros", "runtime"]
 signal = ["dep:compio-signal", "runtime"]
+term = ["dep:compio-term", "runtime"]
 time = ["compio-runtime/time", "runtime"]
 dispatcher = ["dep:compio-dispatcher", "runtime"]
 tls = ["dep:compio-tls"]
@@ -129,6 +131,7 @@ all = [
     "time",
     "macros",
     "signal",
+    "term",
     "dispatcher",
     "native-tls",
     "rustls",

--- a/compio/src/lib.rs
+++ b/compio/src/lib.rs
@@ -84,6 +84,9 @@ pub use compio_runtime as runtime;
 #[cfg(feature = "signal")]
 #[doc(inline)]
 pub use compio_signal as signal;
+#[cfg(feature = "term")]
+#[doc(inline)]
+pub use compio_term as term;
 #[cfg(feature = "tls")]
 #[doc(inline)]
 pub use compio_tls as tls;


### PR DESCRIPTION
`compio-term` provides completion-based terminal input and output for Compio based on [crossterm](https://github.com/crossterm-rs/crossterm).

The crate provides an async event stream based on compio and an asynchronous command queue to write commands to any `AsyncWrite`. Crossterm's `cursor`, `style`, `terminal`, and `tty` modules are re-exported from the crate root.