### PR TITLE
perf(driver/iour): change in_flight from HashSet to SlotMap

### DIFF
--- a/compio-driver/Cargo.toml
+++ b/compio-driver/Cargo.toml
@@ -60,6 +60,7 @@ once_cell = { workspace = true, optional = true }
 polling = { version = "3.3.0", optional = true }
 rustix = { workspace = true }
 linux-raw-sys = { version = "0.12.1", optional = true }
+slotmap = { workspace = true, optional = true }
 
 # Other platform dependencies
 [target.'cfg(all(unix, not(target_os = "linux")))'.dependencies]
@@ -86,6 +87,7 @@ io-uring = [
     "linux-raw-sys/io_uring",
     "dep:io-uring",
     "dep:once_cell",
+    "dep:slotmap",
 ]
 polling = ["dep:polling"]
 

--- a/compio-driver/src/sys/driver/iour/mod.rs
+++ b/compio-driver/src/sys/driver/iour/mod.rs
@@ -1,6 +1,5 @@
 use std::{
-    collections::HashSet, marker::PhantomData, mem::ManuallyDrop, panic::AssertUnwindSafe,
-    sync::Arc, time::Duration,
+    marker::PhantomData, mem::ManuallyDrop, panic::AssertUnwindSafe, sync::Arc, time::Duration,
 };
 
 use crate::sys::{extra::IourExtra, prelude::*};
@@ -32,6 +31,7 @@ use io_uring::{
     opcode::{AsyncCancel, PollAdd},
     types::{Fd, SubmitArgs, Timespec},
 };
+use slotmap::{DefaultKey, SlotMap};
 
 use crate::{
     AsyncifyPool, DriverType, Entry, ProactorBuilder,
@@ -69,7 +69,7 @@ pub(crate) struct Driver {
     completed_rx: Receiver<Entry>,
     flags: DriverFlags,
     /// Keys leaked via `into_raw()` into io_uring user_data, freed on drop.
-    in_flight: HashSet<usize>,
+    in_flight: SlotMap<DefaultKey, usize>,
     _p: PhantomData<ErasedKey>,
 }
 
@@ -140,7 +140,7 @@ impl Driver {
             completed_rx,
             pool: builder.create_or_get_thread_pool(),
             flags,
-            in_flight: HashSet::new(),
+            in_flight: SlotMap::new(),
             _p: PhantomData,
         })
     }
@@ -303,8 +303,9 @@ impl Driver {
                         }
                         key.wake_by_ref();
                     } else {
-                        self.in_flight.remove(&(key as usize));
-                        create_entry(entry).notify()
+                        let entry = create_entry(entry);
+                        Self::remove_in_flight(&mut self.in_flight, &entry.key);
+                        entry.notify()
                     }
                 }
             }
@@ -345,7 +346,9 @@ impl Driver {
         let user_data = key.as_raw();
         let entry = entry.user_data(user_data as _);
         self.push_raw(entry)?; // if push failed, do not leak the key. Drop it upon return.
-        self.in_flight.insert(user_data);
+
+        let slot = self.in_flight.insert(user_data);
+        key.borrow().extra_mut().as_iour_mut().set_in_flight(slot);
         key.into_raw();
         Ok(())
     }
@@ -486,6 +489,16 @@ impl Driver {
     ) -> Option<BufResult<usize, crate::sys::Extra>> {
         key.borrow().carrier.pop_multishot()
     }
+
+    /// Take an op out of the `in_flight` map. The slot lives in the op's
+    /// extra, and is only set while the op is in flight.
+    fn remove_in_flight(in_flight: &mut SlotMap<DefaultKey, usize>, key: &ErasedKey) {
+        let Some(slot) = key.borrow().extra_mut().as_iour_mut().take_in_flight() else {
+            return;
+        };
+        let removed = in_flight.remove(slot);
+        debug_assert_eq!(removed, Some(key.as_raw()));
+    }
 }
 
 impl AsRawFd for Driver {
@@ -510,7 +523,7 @@ impl Drop for Driver {
         // leaks it, and `poll_entries` takes it back when it hands the op to
         // its future. Whatever is left here is ours to free, and the kernel is
         // done with it.
-        for user_data in self.in_flight.drain() {
+        for (_, user_data) in self.in_flight.drain() {
             drop(unsafe { ErasedKey::from_raw(user_data) });
         }
     }

--- a/compio-driver/src/sys/extra/iour.rs
+++ b/compio-driver/src/sys/extra/iour.rs
@@ -1,4 +1,5 @@
 use io_uring::squeue::Flags;
+use slotmap::DefaultKey;
 
 /// Extra data for RawOp.
 #[derive(Debug)]
@@ -6,6 +7,9 @@ pub(in crate::sys) struct Extra {
     sqe_flags: Flags,
     cqe_flags: u32,
     personality: Option<u16>,
+    /// Slot of this op inside the `in_flight` map of the `io_uring` driver,
+    /// set while the op is in flight.
+    in_flight: Option<DefaultKey>,
 }
 
 pub(in crate::sys) use Extra as IourExtra;
@@ -16,7 +20,17 @@ impl Extra {
             sqe_flags: Flags::empty(),
             cqe_flags: 0,
             personality: None,
+            in_flight: None,
         }
+    }
+
+    pub fn set_in_flight(&mut self, slot: DefaultKey) {
+        debug_assert!(self.in_flight.is_none(), "op is already in flight");
+        self.in_flight = Some(slot);
+    }
+
+    pub fn take_in_flight(&mut self) -> Option<DefaultKey> {
+        self.in_flight.take()
     }
 
     pub fn set_personality(&mut self, personality: u16) {


### PR DESCRIPTION
Park each key in a [SlotMap](https://docs.rs/slotmap/latest/slotmap/struct.SlotMap.html) instead and let the op remember its own slot, so registering and dropping are both O(1) operations.

Comparison of retired user instructions / op:

 | in flight | Vec | slotmap | BTreeSet | HashSet |
  | --- | --- | --- | --- | --- |
  | 1         | +70 | +80     | +218     | +310    |
 | 128       | +79 | +77     | +499     | +302    |
 |  512       | +77 | +73     | +576     | +299    |