### PR TITLE
fix(driver,iour): remove the CQE drain that freed multishot keys twice

### DIFF
--- a/compio-driver/src/sys/driver/iour/mod.rs
+++ b/compio-driver/src/sys/driver/iour/mod.rs
@@ -496,21 +496,8 @@ impl AsRawFd for Driver {
 
 impl Drop for Driver {
     fn drop(&mut self) {
-        // Drain completed CQEs first to avoid double-free.
-        let mut cqueue = self.inner.completion();
-        cqueue.sync();
-        for entry in cqueue {
-            match entry.user_data() {
-                Self::CANCEL | Self::NOTIFY => {}
-                key => {
-                    self.in_flight.remove(&(key as usize));
-                    drop(unsafe { ErasedKey::from_raw(key as _) });
-                }
-            }
-        }
-
-        // Close the io_uring ring *before* freeing the remaining in-flight
-        // keys. Closing the ring fd makes the kernel wait for in-flight ops to
+        // Close the io_uring ring *before* freeing the in-flight keys.
+        // Closing the ring fd makes the kernel wait for in-flight ops to
         // finish or be cancelled, so it will no longer read from or write to
         // the buffers owned by those keys. Without this, the kernel could
         // touch a freed (and potentially recycled) heap allocation, which
@@ -519,7 +506,10 @@ impl Drop for Driver {
         // `corrupted double-linked list` during thread shutdown.
         unsafe { ManuallyDrop::drop(&mut self.inner) };
 
-        // Free remaining in-flight keys. Safe now that the kernel is done.
+        // `in_flight` holds one reference per submitted op: `push_raw_with_key`
+        // leaks it, and `poll_entries` takes it back when it hands the op to
+        // its future. Whatever is left here is ours to free, and the kernel is
+        // done with it.
         for user_data in self.in_flight.drain() {
             drop(unsafe { ErasedKey::from_raw(user_data) });
         }

--- a/compio-driver/tests/op.rs
+++ b/compio-driver/tests/op.rs
@@ -460,3 +460,42 @@ fn drop_with_inflight_ops() {
         assert!(socket.try_unwrap().is_ok(), "in-flight op leaked on drop");
     }
 }
+
+/// A multishot op stays registered across completions, so the completion queue
+/// can hold several CQEs with the same key when the Proactor is dropped.
+/// Dropping the driver must still release the op once, no matter how many of
+/// those CQEs are queued.
+#[cfg(io_uring)]
+#[test]
+fn drop_with_pending_multishot_cqes() {
+    let mut driver = Proactor::new().unwrap();
+    if driver.driver_type().is_polling() {
+        return; // the polling driver has no completion queue
+    }
+
+    let server = TcpListener::bind("127.0.0.1:0").unwrap();
+    let addr = server.local_addr().unwrap();
+    // Connect before submitting, so both accepts succeed inside the submit
+    // below instead of waiting on the kernel to notice the connections.
+    let _clients = [
+        TcpStream::connect(addr).unwrap(),
+        TcpStream::connect(addr).unwrap(),
+    ];
+    let server = SharedFd::new(socket2::Socket::from(server));
+
+    let PushEntry::Pending(_key) = driver.push(AcceptMulti::new(server.clone())) else {
+        panic!("a multishot accept is never ready on push")
+    };
+    // Submit without reaping. Both accepts post a CQE carrying `more`, and
+    // nothing consumes them.
+    driver.flush();
+
+    drop(driver);
+
+    // `_key` still holds the op, so the driver released its own reference and
+    // only that one.
+    assert!(
+        server.try_unwrap().is_err(),
+        "the driver released a multishot key more than once"
+    );
+}


### PR DESCRIPTION
Fixes https://github.com/compio-rs/compio/pull/1019#discussion_r3889862897