### PR TITLE
feat(driver): support forcing io_uring features

### DIFF
--- a/compio-driver/src/features.rs
+++ b/compio-driver/src/features.rs
@@ -1,0 +1,81 @@
+#[cfg(feature = "once_cell_try")]
+use std::sync::OnceLock;
+#[cfg(io_uring)]
+use std::sync::atomic::{AtomicU32, Ordering};
+
+#[cfg(all(io_uring, not(feature = "once_cell_try")))]
+use once_cell::sync::OnceCell as OnceLock;
+
+#[cfg(io_uring)]
+use crate::sys::pal::is_kernel_at_least;
+
+bitflags::bitflags! {
+    /// Advanced io_uring features that can be queried or forced on.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+    pub struct IoUringFeatures: u32 {
+        /// Network recv/send poll-first flag (>= 5.19)
+        const RECVSEND_POLL_FIRST = 1 << 0;
+        /// Multishot accept (>= 5.19)
+        const MULTISHOT_ACCEPT    = 1 << 1;
+        /// Multishot receive with buffer pool (>= 6.0)
+        const MULTISHOT_RECV      = 1 << 2;
+        /// Multishot recvmsg with io_uring_recvmsg_out (>= 6.0)
+        const MULTISHOT_RECVMSG   = 1 << 3;
+        /// Accept poll-first flag (>= 6.10)
+        const ACCEPT_POLL_FIRST   = 1 << 4;
+    }
+}
+
+#[cfg(io_uring)]
+static FORCED_FEATURES: AtomicU32 = AtomicU32::new(0);
+
+/// Force enable specific `io_uring` features.
+///
+/// This is additive: the specified features will be merged with the detected
+/// kernel defaults (`effective = kernel_defaults | forced`).
+/// Useful for enterprise kernels (e.g. RHEL/CentOS Stream 9 on kernel 5.14)
+/// where features like multishot recv/recvmsg are backported.
+///
+/// On platforms without `io_uring`, this is a no-op.
+pub fn force_io_uring_features(features: IoUringFeatures) {
+    #[cfg(io_uring)]
+    FORCED_FEATURES.fetch_or(features.bits(), Ordering::Relaxed);
+    #[cfg(not(io_uring))]
+    let _ = features;
+}
+
+/// Baseline kernel features inferred from `uname` release version.
+#[cfg(io_uring)]
+pub(crate) fn kernel_defaults() -> IoUringFeatures {
+    static DEFAULTS: OnceLock<IoUringFeatures> = OnceLock::new();
+    *DEFAULTS.get_or_init(|| {
+        let mut feats = IoUringFeatures::empty();
+        if is_kernel_at_least((5, 19)) {
+            feats |= IoUringFeatures::RECVSEND_POLL_FIRST | IoUringFeatures::MULTISHOT_ACCEPT;
+        }
+        if is_kernel_at_least((6, 0)) {
+            feats |= IoUringFeatures::MULTISHOT_RECV | IoUringFeatures::MULTISHOT_RECVMSG;
+        }
+        if is_kernel_at_least((6, 10)) {
+            feats |= IoUringFeatures::ACCEPT_POLL_FIRST;
+        }
+        feats
+    })
+}
+
+/// Central feature capability check.
+///
+/// On platforms without `io_uring`, this always returns `false`.
+#[inline(always)]
+pub fn is_feature_supported(feature: IoUringFeatures) -> bool {
+    #[cfg(io_uring)]
+    {
+        let forced = IoUringFeatures::from_bits_truncate(FORCED_FEATURES.load(Ordering::Relaxed));
+        (kernel_defaults() | forced).contains(feature)
+    }
+    #[cfg(not(io_uring))]
+    {
+        let _ = feature;
+        false
+    }
+}

--- a/compio-driver/src/lib.rs
+++ b/compio-driver/src/lib.rs
@@ -49,6 +49,9 @@ pub use cancel::*;
 mod buffer_pool;
 pub use buffer_pool::{BoxAllocator, BufferAllocator, BufferPool, BufferRef};
 
+mod features;
+pub use features::*;
+
 use crate::{
     buffer_pool::{BufferAlloc, BufferPoolRoot},
     key::ErasedKey,

--- a/compio-driver/src/sys/mod.rs
+++ b/compio-driver/src/sys/mod.rs
@@ -1,7 +1,7 @@
 mod buffer_pool;
 mod driver;
 mod extra;
-mod pal;
+pub(crate) mod pal;
 mod sys_slice;
 
 // Publicly visible items

--- a/compio-driver/src/sys/op/managed/iour.rs
+++ b/compio-driver/src/sys/op/managed/iour.rs
@@ -12,9 +12,8 @@ use rustix::net::{RecvFlags, ReturnFlags};
 use socket2::{SockAddr, SockAddrStorage, socklen_t};
 
 use crate::{
-    BufferPool, BufferRef, Extra, IourOpCode as OpCode, OpEntry, PollFirst,
-    op::TakeBuffer,
-    sys::pal::{is_kernel_at_least, set_poll_first},
+    BufferPool, BufferRef, Extra, IoUringFeatures, IourOpCode as OpCode, OpEntry, PollFirst,
+    is_feature_supported, op::TakeBuffer, sys::pal::set_poll_first,
 };
 
 /// Read a file at specified position into specified buffer.
@@ -578,7 +577,7 @@ unsafe impl<S: AsFd> OpCode for RecvMulti<S> {
     type Control = ();
 
     fn create_entry(&mut self, control: &mut Self::Control) -> OpEntry {
-        if is_kernel_at_least((6, 0)) {
+        if is_feature_supported(IoUringFeatures::MULTISHOT_RECV) {
             let fd = self.inner.fd.as_fd().as_raw_fd();
             opcode::RecvMulti::new(Fd(fd), self.inner.buffer_group)
                 .flags(self.inner.flags.bits() as _)
@@ -1015,7 +1014,7 @@ pub struct RecvMsgMulti<S: AsFd> {
 impl<S: AsFd> RecvMsgMulti<S> {
     /// Create [`RecvMsgMulti`].
     pub fn new(fd: S, pool: &BufferPool, control_len: usize, flags: RecvFlags) -> io::Result<Self> {
-        let inner = if is_kernel_at_least((6, 0)) {
+        let inner = if is_feature_supported(IoUringFeatures::MULTISHOT_RECVMSG) {
             RecvMsgMultiInner::Impl(RecvMsgMultiImpl::new(fd, pool, control_len, flags)?)
         } else {
             RecvMsgMultiInner::Fallback(RecvMsgMultiFallback::new(fd, pool, control_len, flags)?)

--- a/compio-driver/src/sys/op/multishot/iour.rs
+++ b/compio-driver/src/sys/op/multishot/iour.rs
@@ -1,6 +1,8 @@
 use io_uring::{opcode, types::Fd};
 
-use crate::{IourOpCode as OpCode, OpEntry, sys::op::*};
+use crate::{
+    IoUringFeatures, IourOpCode as OpCode, OpEntry, is_feature_supported, sys::op::*,
+};
 
 /// Accept multiple connections.
 pub struct AcceptMulti<S> {
@@ -44,7 +46,7 @@ unsafe impl<S: AsFd> OpCode for AcceptMulti<S> {
     }
 
     fn create_entry(&mut self, control: &mut Self::Control) -> OpEntry {
-        if is_kernel_at_least((5, 19)) {
+        if is_feature_supported(IoUringFeatures::MULTISHOT_ACCEPT) {
             opcode::AcceptMulti::new(Fd(self.op.fd.as_fd().as_raw_fd()))
                 .flags(libc::SOCK_CLOEXEC)
                 .build()

--- a/compio-driver/src/sys/pal/iour/mod.rs
+++ b/compio-driver/src/sys/pal/iour/mod.rs
@@ -6,6 +6,8 @@ use linux_raw_sys::io_uring::{IORING_ACCEPT_POLL_FIRST, IORING_RECVSEND_POLL_FIR
 #[cfg(not(feature = "once_cell_try"))]
 use once_cell::sync::OnceCell as OnceLock;
 
+use crate::{IoUringFeatures, is_feature_supported};
+
 pub fn is_op_supported(code: u8) -> bool {
     static PROBE: OnceLock<io_uring::Probe> = OnceLock::new();
 
@@ -57,11 +59,16 @@ pub fn is_kernel_at_least(v: impl Into<KernelVersion>) -> bool {
 }
 
 pub(crate) fn set_poll_first(mut entry: Entry, flag: bool) -> Entry {
-    let (ioprio, version) = match entry.get_opcode() as u8 {
-        io_uring::opcode::Accept::CODE => (IORING_ACCEPT_POLL_FIRST, (6, 10)),
-        _ => (IORING_RECVSEND_POLL_FIRST, (5, 19)),
+    let (ioprio, feat) = match entry.get_opcode() as u8 {
+        io_uring::opcode::Accept::CODE => {
+            (IORING_ACCEPT_POLL_FIRST, IoUringFeatures::ACCEPT_POLL_FIRST)
+        }
+        _ => (
+            IORING_RECVSEND_POLL_FIRST,
+            IoUringFeatures::RECVSEND_POLL_FIRST,
+        ),
     };
-    if flag && is_kernel_at_least(version) {
+    if flag && is_feature_supported(feat) {
         let sqe = &raw mut entry as *mut io_uring_sqe;
         unsafe {
             (*sqe).ioprio |= ioprio as u16;

--- a/compio-net/tests/buffer_pool.rs
+++ b/compio-net/tests/buffer_pool.rs
@@ -1,5 +1,6 @@
 use std::net::Ipv6Addr;
 
+use compio_driver::{IoUringFeatures, force_io_uring_features};
 use compio_io::{
     AsyncReadManaged, AsyncReadMulti, AsyncWriteExt,
     ancillary::{AncillaryBuf, AsyncReadAncillaryManaged, ReturnFlags},
@@ -199,6 +200,7 @@ async fn test_udp_recv_multi() {
 
 #[compio_macros::test]
 async fn test_udp_recv_from_multi() {
+    force_io_uring_features(IoUringFeatures::MULTISHOT_RECVMSG);
     let listener = UdpSocket::bind((Ipv6Addr::LOCALHOST, 0)).await.unwrap();
     let server_addr = listener.local_addr().unwrap();
     let connected = UdpSocket::bind((Ipv6Addr::LOCALHOST, 0)).await.unwrap();
@@ -216,6 +218,7 @@ async fn test_udp_recv_from_multi() {
 
 #[compio_macros::test]
 async fn test_udp_recv_msg_multi() {
+    force_io_uring_features(IoUringFeatures::MULTISHOT_RECVMSG);
     let listener = UdpSocket::bind((Ipv6Addr::LOCALHOST, 0)).await.unwrap();
     let server_addr = listener.local_addr().unwrap();
     let connected = UdpSocket::bind((Ipv6Addr::LOCALHOST, 0)).await.unwrap();
@@ -234,6 +237,7 @@ async fn test_udp_recv_msg_multi() {
 
 #[compio_macros::test(with_proactor(buffer_pool_buffer_len = 256))]
 async fn test_udp_recv_msg_multi_truncated_datagram() {
+    force_io_uring_features(IoUringFeatures::MULTISHOT_RECVMSG);
     let listener = UdpSocket::bind((Ipv6Addr::LOCALHOST, 0)).await.unwrap();
     let server_addr = listener.local_addr().unwrap();
     let connected = UdpSocket::bind((Ipv6Addr::LOCALHOST, 0)).await.unwrap();


### PR DESCRIPTION
feat(driver): support forcing io_uring features via capability bitmap (#1021)

Introduce an additive capability governance architecture via IoUringFeatures bitflags and force_io_uring_features API to address environments where the kernel version check fails to reflect backported features (such as RHEL 9/CentOS Stream 9 on Linux 5.14).

- Add compio_driver::features module as single source of truth for features
- Query effective capability bitmap in multishot accept and recv/recvmsg ops
- Add force_io_uring_features hook in compio-net buffer_pool tests
- Keep driver submission hot path branchless with zero inspection overhead