### PR TITLE
fix(io): correct Vec reserve amount in vectored writes

### DIFF
--- a/compio-io/src/write/mod.rs
+++ b/compio-io/src/write/mod.rs
@@ -92,7 +92,7 @@ impl<#[cfg(feature = "allocator_api")] A: Allocator> AsyncWrite for t_alloc!(Vec
 
     async fn write_vectored<T: IoVectoredBuf>(&mut self, buf: T) -> BufResult<usize, T> {
         let len = buf.iter_slice().map(|b| b.buf_len()).sum();
-        self.reserve(len - self.len());
+        self.reserve(len);
         for buf in buf.iter_slice() {
             self.extend_from_slice(buf);
         }
@@ -267,9 +267,9 @@ impl<#[cfg(feature = "allocator_api")] A: Allocator> AsyncWriteAt for t_alloc!(V
         pos: u64,
     ) -> BufResult<usize, T> {
         let mut pos = pos as usize;
-        let len = buf.iter_slice().map(|b| b.buf_len()).sum();
+        let len: usize = buf.iter_slice().map(|b| b.buf_len()).sum();
         if pos <= self.len() {
-            self.reserve(len - (self.len() - pos));
+            self.reserve(len.saturating_sub(self.len() - pos));
         } else {
             self.reserve(pos - self.len() + len);
             self.resize(pos, 0);
@@ -401,7 +401,7 @@ impl<#[cfg(feature = "allocator_api")] A: Allocator> AsyncWriteZerocopy for t_al
         buf: T,
     ) -> BufResult<usize, Self::VectoredBufferReadyFuture<T>> {
         let len = buf.iter_slice().map(|b| b.buf_len()).sum();
-        self.reserve(len - self.len());
+        self.reserve(len);
         for slice in buf.iter_slice() {
             self.extend_from_slice(slice);
         }

--- a/compio-io/tests/io.rs
+++ b/compio-io/tests/io.rs
@@ -6,7 +6,7 @@ use compio_buf::{
 };
 use compio_io::{
     AsyncBufRead, AsyncRead, AsyncReadAt, AsyncReadAtExt, AsyncReadExt, AsyncWrite, AsyncWriteAt,
-    AsyncWriteAtExt, AsyncWriteExt, BufReader, BufWriter, split,
+    AsyncWriteAtExt, AsyncWriteExt, AsyncWriteZerocopy, BufReader, BufWriter, split,
 };
 use futures_executor::block_on;
 
@@ -163,6 +163,33 @@ fn writev() {
         assert_eq!(len, 6);
         assert_eq!(dst.len(), 6);
         assert_eq!(dst, [1, 1, 4, 5, 1, 4]);
+
+        let mut dst = vec![7u8; 100];
+        let (len, _) = dst
+            .write_vectored([vec![1, 1, 4], vec![5, 1, 4]])
+            .await
+            .unwrap();
+
+        assert_eq!(len, 6);
+        assert_eq!(dst.len(), 106);
+        assert_eq!(&dst[..100], [7; 100]);
+        assert_eq!(&dst[100..], [1, 1, 4, 5, 1, 4]);
+    })
+}
+
+#[test]
+fn writev_zerocopy_vec() {
+    block_on(async {
+        let mut dst = vec![7u8; 100];
+        let BufResult(len, ready) = dst
+            .write_zerocopy_vectored([vec![1, 1, 4], vec![5, 1, 4]])
+            .await;
+
+        assert_eq!(len.unwrap(), 6);
+        assert_eq!(dst.len(), 106);
+        assert_eq!(&dst[..100], [7; 100]);
+        assert_eq!(&dst[100..], [1, 1, 4, 5, 1, 4]);
+        let _bufs = ready.await;
     })
 }
 
@@ -221,6 +248,18 @@ fn writev_at() {
         assert_eq!(len, 6);
         assert_eq!(dst.len(), 8);
         assert_eq!(dst, [0, 0, 1, 1, 4, 5, 1, 4]);
+
+        let mut dst = vec![7u8; 100];
+        let (len, _) = dst
+            .write_vectored_at([vec![1, 1, 4], vec![5, 1, 4]], 50)
+            .await
+            .unwrap();
+
+        assert_eq!(len, 6);
+        assert_eq!(dst.len(), 100);
+        assert_eq!(&dst[..50], [7; 50]);
+        assert_eq!(&dst[50..56], [1, 1, 4, 5, 1, 4]);
+        assert_eq!(&dst[56..], [7; 44]);
     })
 }
 


### PR DESCRIPTION
In the `AsyncWrite`/`AsyncWriteAt`/`AsyncWriteZerocopy` impls for `Vec`, the reserve amount is computed with unchecked subtraction:

- `write_vectored` / `write_zerocopy_vectored`: `self.reserve(len - self.len())`
- `write_vectored_at` (`pos <= self.len()`): `self.reserve(len - (self.len() - pos))`

When the target `Vec` is already longer than the total size of the input buffers, the subtraction underflows.

```rust
let mut dst = vec![7u8; 100];
// panics with "attempt to subtract with overflow"
dst.write_vectored([vec![1, 1, 4], vec![5, 1, 4]]).await.unwrap();
assert_eq!(&dst[..100], [7; 100]);
assert_eq!(&dst[100..], [1, 1, 4, 5, 1, 4]);
```
