### PR TITLE
ci: fix commitlint config

### DIFF
--- a/.github/workflows/ci_commitlint.yml
+++ b/.github/workflows/ci_commitlint.yml
@@ -15,3 +15,5 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: wagoid/commitlint-github-action@v6
+        with:
+          configFile: .commitlintrc.json


### PR DESCRIPTION
https://github.com/wagoid/commitlint-github-action#configfile:

> ### `configFile`
>
> The path to your commitlint config file.
>
> Default: `commitlint.config.mjs`
>
> If the config file doesn't exist, [config-conventional](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional) settings will be loaded as a default fallback.

So our config to use `@commitlint/config-angular` is never applied. This may fix the issue in https://github.com/compio-rs/compio/pull/1037.

Also notice that https://github.com/wagoid/commitlint-github-action is unmaintained.
